### PR TITLE
Support one-finger zooming on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7402,6 +7402,12 @@
         }
       }
     },
+    "cordova-plugin-safariviewcontroller": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-safariviewcontroller/-/cordova-plugin-safariviewcontroller-2.0.0.tgz",
+      "integrity": "sha512-pYYM4hcS9YsS47N97HA5dIG7JAVrsCLaD/RLG/0rBfFuGVWQmu776TazPjrvZs3chZDYQTLPZGkx4othrig0AQ==",
+      "dev": true
+    },
     "cordova-plugin-screen-orientation": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-screen-orientation/-/cordova-plugin-screen-orientation-3.0.2.tgz",
@@ -12373,6 +12379,19 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
       "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+    },
+    "leaflet-doubletapdrag": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/leaflet-doubletapdrag/-/leaflet-doubletapdrag-0.1.1.tgz",
+      "integrity": "sha512-2n6D0igBx89RHNXLmhQGfslwMYc8UWOAlkExU3IeGL85Ckqmhj5XCZvr4sr42IGtH9bSqRLP4nHaaj2MjLrldA=="
+    },
+    "leaflet-doubletapdragzoom": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet-doubletapdragzoom/-/leaflet-doubletapdragzoom-0.2.0.tgz",
+      "integrity": "sha512-GHW8+CfMr6usn7G0j/fI9PkqOZHXiONzc/3rx6jkTi0TmI9Uc6dsy8BmUUsnhaWQdnWE4fkMuC3jwfYG9yTT4g==",
+      "requires": {
+        "leaflet-doubletapdrag": "^0.1.0"
+      }
     },
     "leaflet-edgebuffer": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "ionic-appauth": "^0.7.4",
     "json-stringify-safe": "^5.0.1",
     "leaflet": "^1.7.1",
+    "leaflet-doubletapdrag": "^0.1.1",
+    "leaflet-doubletapdragzoom": "^0.2.0",
     "leaflet-edgebuffer": "^1.0.6",
     "leaflet.markercluster": "^1.4.1",
     "leaflet.utm": "1.0.0",

--- a/src/app/core/helpers/leaflet/user-marker/user-marker.ts
+++ b/src/app/core/helpers/leaflet/user-marker/user-marker.ts
@@ -35,7 +35,24 @@ export class UserMarker {
     };
     this.userMarker = L.marker(latLng, { icon: this.userMarkerIcon });
     this.userMarker.addTo(this.map);
-    this.setAccuracy(position);
+
+    this.accuracyMarker = L.circle(
+      latLng,
+      position.coords.accuracy,
+      this.accuracyCircleStyle
+    );
+    this.accuracyMarker.addTo(this.map);
+
+    // NOTE: Leaflet doesn't handle rescaling the CircleMarker while the zoom
+    // is triggering repaints. This results in the accuracy circle drifting
+    // around the map in strange ways. Until this is resolved, simply hide the
+    // circle during the zoom operations.
+    //
+    // For more info: https://github.com/Leaflet/Leaflet/issues/5321
+    this.map.on('doubletapdragstart', () => this.onMapZoomStart());
+    this.map.on('doubletapdragend', () => this.onMapZoomEnd());
+
+    this.setAccuracy(latLng, position.coords.accuracy);
   }
 
   getPosition(): Geoposition {
@@ -49,7 +66,7 @@ export class UserMarker {
       lng: position.coords.longitude
     };
     this.userMarker.setLatLng(latLng);
-    this.setAccuracy(position);
+    this.setAccuracy(latLng, position.coords.accuracy);
     // if (position.coords.heading !== null) {
     //     this.setHeading(position.coords.heading);
     // }
@@ -65,21 +82,16 @@ export class UserMarker {
     element.style.display = 'block';
   }
 
-  private setAccuracy(position: Geoposition) {
-    const latLng = {
-      lat: position.coords.latitude,
-      lng: position.coords.longitude
-    };
-    if (!this.accuracyMarker) {
-      this.accuracyMarker = L.circle(
-        latLng,
-        position.coords.accuracy,
-        this.accuracyCircleStyle
-      );
-      this.accuracyMarker.addTo(this.map);
-    } else {
-      this.accuracyMarker.setRadius(position.coords.accuracy);
-      this.accuracyMarker.setLatLng(latLng);
-    }
+  private setAccuracy(latLng: L.LatLngExpression, accuracy: number) {
+    this.accuracyMarker.setRadius(accuracy);
+    this.accuracyMarker.setLatLng(latLng);
+  }
+
+  private onMapZoomStart() {
+    this.accuracyMarker.removeFrom(this.map);
+  }
+
+  private onMapZoomEnd() {
+    this.accuracyMarker.addTo(this.map);
   }
 }

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -9,6 +9,8 @@ import {
   EventEmitter
 } from '@angular/core';
 import * as L from 'leaflet';
+import 'leaflet-doubletapdrag';
+import 'leaflet-doubletapdragzoom';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
 import { timer, Subject, from, BehaviorSubject } from 'rxjs';
 import { UserSetting } from '../../../../core/models/user-settings.model';
@@ -104,7 +106,12 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     });
   }
 
-  options: L.MapOptions;
+  options: L.MapOptions & {
+    doubleTapDragZoom?: L.MapOptions['doubleClickZoom'],
+    doubleTapDragZoomOptions?: {
+      reverse: boolean,
+    }
+  };
 
   async ngOnInit() {
     this.options = {
@@ -121,7 +128,11 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
         new L.LatLng(90.0, -180.0),
         new L.LatLng(-90, 180.0)
       ),
-      maxBoundsViscosity: 1.0
+      maxBoundsViscosity: 1.0,
+      doubleTapDragZoom: 'center',
+      doubleTapDragZoomOptions: {
+        reverse: true,
+      },
     };
     this.isActive = new BehaviorSubject(this.autoActivate);
     try {


### PR DESCRIPTION
When running on a mobile device, users don't always have two fingers
available for doing fine motor movements, like pinch-zooming. For this
reason, mapping applications typically support the standardized zoom
gesture of double-tap-and-dragging to zoom in or out.

This change adds this functionality to the RegObs app -- it is
especially helpful for gloved users, as doing two-finger operations can
be difficult.