### PR TITLE
Fix selects, change default map, remove start trip on desktop

### DIFF
--- a/src/app/components/img-swiper/img-swiper.component.scss
+++ b/src/app/components/img-swiper/img-swiper.component.scss
@@ -53,7 +53,6 @@
       width: 80vw;
       height: 80vw;
       display: inline-flex;
-      margin-right: 5px;
 
       &:last-child {
         margin-right: 0px;

--- a/src/app/core/services/breakpoint.service.ts
+++ b/src/app/core/services/breakpoint.service.ts
@@ -9,7 +9,7 @@ export class BreakpointService {
   private isDesktop = new BehaviorSubject(false);
 
   onResize(size: number): void {
-    if (size < 700) {
+    if (size < 900) {
       this.isDesktop.next(false);
     } else {
       this.isDesktop.next(true);

--- a/src/app/core/services/user-setting/user-settings.default.ts
+++ b/src/app/core/services/user-setting/user-settings.default.ts
@@ -23,7 +23,7 @@ export const DEFAULT_USER_SETTINGS: (langKey: LangKey) => UserSetting = (
   tilesCacheSizev2: settings.map.tiles.cacheSize,
   showObservations: true,
   emailReceipt: true,
-  topoMap: TopoMap.default,
+  topoMap: TopoMap.mixArcGisOnline,
   showGeoSelectInfo: true,
   useRetinaMap: false,
   consentForSendingAnalytics: true,

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.ts
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.ts
@@ -15,6 +15,8 @@ import {
 } from '@ionic-native/email-composer/ngx';
 import { TranslateService } from '@ngx-translate/core';
 import { settings } from '../../../../../settings';
+import { Platform } from '@ionic/angular';
+import { isAndroidOrIos } from '../../../../core/helpers/ionic/platform-helper';
 const stringify = require('json-stringify-safe');
 
 @Component({
@@ -30,7 +32,8 @@ export class FailedRegistrationComponent implements OnInit {
     private registrationService: RegistrationService,
     private emailComposer: EmailComposer,
     private translateService: TranslateService,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private platform: Platform
   ) {}
 
   ngOnInit() {}
@@ -44,27 +47,32 @@ export class FailedRegistrationComponent implements OnInit {
   }
 
   async sendEmail() {
-    const translations = await this.translateService
-      .get(['REGISTRATION.EMAIL.SUBJECT', 'REGISTRATION.EMAIL.BODY'])
-      .toPromise();
-    const pictures = this.registrationService
-      .getAllPictures(this.registration.request)
-      .filter(
-        (p) => p.PictureImageBase64 && !p.PictureImageBase64.startsWith('data')
-      )
-      .map((p) => p.PictureImageBase64);
-    const base64string = btoa(stringify(this.registration));
-    const attachments = ['base64:registration.json//' + base64string].concat(
-      pictures
-    );
-    const email: EmailComposerOptions = {
-      to: settings.errorEmailAddress,
-      attachments,
-      subject: translations['REGISTRATION.EMAIL.SUBJECT'],
-      body: translations['REGISTRATION.EMAIL.BODY'],
-      isHtml: true
-    };
-    this.emailComposer.open(email);
+    if (isAndroidOrIos(this.platform)) {
+      const translations = await this.translateService
+        .get(['REGISTRATION.EMAIL.SUBJECT', 'REGISTRATION.EMAIL.BODY'])
+        .toPromise();
+      const pictures = this.registrationService
+        .getAllPictures(this.registration.request)
+        .filter(
+          (p) =>
+            p.PictureImageBase64 && !p.PictureImageBase64.startsWith('data')
+        )
+        .map((p) => p.PictureImageBase64);
+      const base64string = btoa(stringify(this.registration));
+      const attachments = ['base64:registration.json//' + base64string].concat(
+        pictures
+      );
+      const email: EmailComposerOptions = {
+        to: settings.errorEmailAddress,
+        attachments,
+        subject: translations['REGISTRATION.EMAIL.SUBJECT'],
+        body: translations['REGISTRATION.EMAIL.BODY'],
+        isHtml: true
+      };
+      this.emailComposer.open(email);
+    } else {
+      window.location.href = 'mailto:regobs@nve.no';
+    }
   }
 
   // private async getEmailAddress() {

--- a/src/app/modules/registration/pages/danger-obs/add-or-edit-danger-obs-modal/add-or-edit-danger-obs-modal.page.ts
+++ b/src/app/modules/registration/pages/danger-obs/add-or-edit-danger-obs-modal/add-or-edit-danger-obs-modal.page.ts
@@ -127,8 +127,8 @@ export class AddOrEditDangerObsModalPage implements OnInit {
     return this.dangerSignTid !== undefined
       ? this.dangerSignTid
       : this.geoHazard !== GeoHazard.Snow
-        ? this.geoHazard * 10
-        : 0;
+      ? this.geoHazard * 10
+      : 0;
   }
 
   ok() {
@@ -172,23 +172,23 @@ export class AddOrEditDangerObsModalPage implements OnInit {
 
   getAreaArray() {
     switch (this.geoHazard) {
-    case GeoHazard.Ice: {
-      return [
-        'REGISTRATION.DANGER_OBS.RIGHT_HERE',
-        'REGISTRATION.DANGER_OBS.ON_THIS_SIDE_OF_THE_WATER',
-        'REGISTRATION.DANGER_OBS.ON_THIS_WATER',
-        'REGISTRATION.DANGER_OBS.MANY_WATER_NEARBY'
-      ];
-    }
-    default:
-      return [
-        'REGISTRATION.DANGER_OBS.ON_THIS_PLACE',
-        'REGISTRATION.DANGER_OBS.ON_THIS_MOUNTAIN_SIDE',
-        'REGISTRATION.DANGER_OBS.GENERAL_ON_MOUNTAIN',
-        'REGISTRATION.DANGER_OBS.IN_THE_VALLEY_OR_FJORD',
-        'REGISTRATION.DANGER_OBS.FOR_MUNICIPAL',
-        'REGISTRATION.DANGER_OBS.FOR_REGION'
-      ];
+      case GeoHazard.Ice: {
+        return [
+          'REGISTRATION.DANGER_OBS.RIGHT_HERE',
+          'REGISTRATION.DANGER_OBS.ON_THIS_SIDE_OF_THE_WATER',
+          'REGISTRATION.DANGER_OBS.ON_THIS_WATER',
+          'REGISTRATION.DANGER_OBS.MANY_WATER_NEARBY'
+        ];
+      }
+      default:
+        return [
+          'REGISTRATION.DANGER_OBS.ON_THIS_PLACE',
+          'REGISTRATION.DANGER_OBS.ON_THIS_MOUNTAIN_SIDE',
+          'REGISTRATION.DANGER_OBS.GENERAL_ON_MOUNTAIN',
+          'REGISTRATION.DANGER_OBS.IN_THE_VALLEY_OR_FJORD',
+          'REGISTRATION.DANGER_OBS.FOR_MUNICIPAL',
+          'REGISTRATION.DANGER_OBS.FOR_REGION'
+        ];
     }
   }
 }

--- a/src/app/modules/shared/components/add-menu/add-menu.component.html
+++ b/src/app/modules/shared/components/add-menu/add-menu.component.html
@@ -28,7 +28,7 @@
     <div class="backdrop" click="closeMenu()"></div>
   </ion-fab-list>
 </ion-fab>
-<ng-template #startTrip>
+<ng-template #startTrip *ngIf="isIosOrAndroid">
   <ion-item (click)="startOrStopTrip(false)">
     <ion-icon slot="start" src="/assets/icon/man.svg"></ion-icon>
     <ion-label>{{'TRIP.START_TRIP' | translate }}</ion-label>

--- a/src/app/modules/shared/components/add-menu/add-menu.component.ts
+++ b/src/app/modules/shared/components/add-menu/add-menu.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { IonFab, NavController } from '@ionic/angular';
+import { IonFab, NavController, Platform } from '@ionic/angular';
 import { Observable, from, combineLatest, of } from 'rxjs';
 import moment from 'moment';
 import { DateHelperService } from '../../services/date-helper/date-helper.service';
@@ -13,6 +13,7 @@ import { RegistrationService } from '../../../registration/services/registration
 import { map, tap, switchMap } from 'rxjs/operators';
 import { setObservableTimeout } from '../../../../core/helpers/observable-helper';
 import { LoggingService } from '../../services/logging/logging.service';
+import { isAndroidOrIos } from 'src/app/core/helpers/ionic/platform-helper';
 
 const DEBUG_TAG = 'AddMenuComponent';
 
@@ -32,6 +33,7 @@ export class AddMenuComponent implements OnInit {
   }>;
   tripStarted$: Observable<boolean>;
   showSpace$: Observable<boolean>;
+  isIosOrAndroid: boolean;
 
   constructor(
     private registrationService: RegistrationService,
@@ -40,10 +42,12 @@ export class AddMenuComponent implements OnInit {
     private tripLoggerService: TripLoggerService,
     private userSettingService: UserSettingService,
     private geoHelperService: GeoHelperService,
-    private loggingService: LoggingService
+    private loggingService: LoggingService,
+    private platform: Platform
   ) {}
 
   ngOnInit(): void {
+    this.isIosOrAndroid = isAndroidOrIos(this.platform);
     this.geoHazardInfo$ = this.userSettingService.userSetting$.pipe(
       map((us) => ({
         geoHazards: us.currentGeoHazard,

--- a/src/app/modules/shared/components/header/header.component.html
+++ b/src/app/modules/shared/components/header/header.component.html
@@ -6,7 +6,8 @@
     <ion-buttons slot="end" *ngIf="showMenuButton">
       <ion-menu-toggle autoHide="false">
         <ion-button (click)="toggleMenu()">
-          <ion-icon name="menu" slot="icon-only"></ion-icon>
+          <svg-icon *ngIf="splitPaneClosed || !isDesktop" src="/assets/icon/menuanimation.svg"></svg-icon>
+          <svg-icon *ngIf="!splitPaneClosed && isDesktop" [ngClass]="'transition'" src="/assets/icon/menuarrow.svg"></svg-icon>
         </ion-button>
       </ion-menu-toggle>
       <ion-menu-button *ngIf="false" color="light" mode="ios"></ion-menu-button>

--- a/src/app/modules/shared/components/header/header.component.scss
+++ b/src/app/modules/shared/components/header/header.component.scss
@@ -1,5 +1,4 @@
-
 .stop-trip {
-    --ion-color-success: var(--ion-color-success-tint);
-    font-size: 16px;
+  --ion-color-success: var(--ion-color-success-tint);
+  font-size: 16px;
 }

--- a/src/app/modules/shared/components/input/select/select.component.html
+++ b/src/app/modules/shared/components/input/select/select.component.html
@@ -10,7 +10,7 @@
 </ng-container>
 
 <ng-template #popover>
-  <ion-select (ionChange)="onChange($event)" [disabled]="disabled" cancelText="{{'DIALOGS.CANCEL' | translate}}" interface="popover" [placeholder]="title | translate">
+  <ion-select *ngIf="options && options.length" (ionChange)="onChange($event)" [disabled]="disabled" cancelText="{{'DIALOGS.CANCEL' | translate}}" interface="popover" [(ngModel)]="selectedValue">
     <ion-select-option *ngFor="let option of options" [value]="option.id">
       {{option.text | translate }}
     </ion-select-option>

--- a/src/app/modules/shared/components/input/select/select.component.ts
+++ b/src/app/modules/shared/components/input/select/select.component.ts
@@ -121,7 +121,7 @@ export class SelectComponent implements OnInit {
     this.selectedValueChange.emit(id);
   }
 
-  onChange(event) {
+  onChange(event): void {
     this.selectedValue = event.target.value;
     this.selectedValueChange.emit(this.selectedValue);
   }

--- a/src/app/modules/side-menu/components/side-menu.component.html
+++ b/src/app/modules/side-menu/components/side-menu.component.html
@@ -1,4 +1,4 @@
-<ion-list lines="full" class="ion-no-margin" *ngIf="userSettings">
+<ion-list [ngClass]="{'scrollDesktop': !isIosOrAndroid }" lines="full" class="ion-no-margin" *ngIf="userSettings">
   <ion-list-header color="varsom-blue" class="ion-no-margin">
     <ion-label class="list-header-label">
       {{'MENU.USER_SETTINGS' | translate}}

--- a/src/app/modules/side-menu/components/side-menu.component.html
+++ b/src/app/modules/side-menu/components/side-menu.component.html
@@ -1,4 +1,4 @@
-<ion-list [ngClass]="{'scrollDesktop': !isIosOrAndroid }" lines="full" class="ion-no-margin" *ngIf="userSettings">
+<ion-list [ngClass]="{'scrollDesktop': !isIosOrAndroid, 'mobilePadding': isMobileWeb }" lines="full" class="ion-no-margin" *ngIf="userSettings">
   <ion-list-header color="varsom-blue" class="ion-no-margin">
     <ion-label class="list-header-label">
       {{'MENU.USER_SETTINGS' | translate}}

--- a/src/app/modules/side-menu/components/side-menu.component.scss
+++ b/src/app/modules/side-menu/components/side-menu.component.scss
@@ -47,3 +47,7 @@ ion-list {
   max-height: 100vh;
   overflow: auto;
 }
+
+.mobilePadding {
+  padding-bottom: 6em;
+}

--- a/src/app/modules/side-menu/components/side-menu.component.scss
+++ b/src/app/modules/side-menu/components/side-menu.component.scss
@@ -49,5 +49,5 @@ ion-list {
 }
 
 .mobilePadding {
-  padding-bottom: 6em;
+  padding-bottom: 8em;
 }

--- a/src/app/modules/side-menu/components/side-menu.component.scss
+++ b/src/app/modules/side-menu/components/side-menu.component.scss
@@ -43,9 +43,7 @@ ion-list {
   margin-bottom: 0px;
 }
 
-@media only screen and (min-width: 1000px) {
-  ion-list {
-    max-height: 100vh;
-    overflow: auto;
-  }
+.scrollDesktop {
+  max-height: 100vh;
+  overflow: auto;
 }

--- a/src/app/modules/side-menu/components/side-menu.component.ts
+++ b/src/app/modules/side-menu/components/side-menu.component.ts
@@ -30,6 +30,7 @@ export class SideMenuComponent implements OnInit, OnDestroy {
   LangKey = LangKey;
   popupType: SelectInterface;
   isIosOrAndroid: boolean;
+  isMobileWeb: boolean;
 
   private lastUpdateSubscription: Subscription;
   private userSettingSubscription: Subscription;
@@ -49,6 +50,7 @@ export class SideMenuComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     this.popupType = isAndroidOrIos(this.platform) ? 'action-sheet' : 'popover';
     this.isIosOrAndroid = isAndroidOrIos(this.platform);
+    this.isMobileWeb = this.platform.is('mobileweb');
     this.lastUpdateSubscription = this.observationService
       .getLastUpdatedForCurrentGeoHazardAsObservable()
       .subscribe((val) => {

--- a/src/app/pages/user-settings/user-settings.page.html
+++ b/src/app/pages/user-settings/user-settings.page.html
@@ -14,7 +14,7 @@
       <ion-label position="stacked" color="medium" class="ion-text-uppercase">{{ "SETTINGS.LANGUAGE" | translate }}
       </ion-label>
       <ion-select cancelText="{{'DIALOGS.CANCEL' | translate}}" [(ngModel)]="userSettings.language"
-        interface="action-sheet" (ngModelChange)="updateSettings()">
+        [interface]="(isDesktop || computer) ? 'popover' : 'action-sheet'" (ngModelChange)="updateSettings()">
         <ion-select-option [value]="lang.langKey" *ngFor="let lang of supportedLanguages">
           {{ lang.name }}
         </ion-select-option>

--- a/src/app/pages/user-settings/user-settings.page.ts
+++ b/src/app/pages/user-settings/user-settings.page.ts
@@ -4,7 +4,8 @@ import { UserSetting } from '../../core/models/user-settings.model';
 import {
   NavController,
   AlertController,
-  LoadingController
+  LoadingController,
+  Platform
 } from '@ionic/angular';
 import { LangKey } from '../../core/models/langKey';
 import { KdvService } from '../../core/services/kdv/kdv.service';
@@ -48,6 +49,7 @@ export class UserSettingsPage implements OnInit, OnDestroy {
     langKey: LangKey[lang.lang]
   }));
   isDesktop: boolean;
+  computer: boolean;
 
   get appModeOptions() {
     const options: SelectOption[] = [
@@ -75,10 +77,14 @@ export class UserSettingsPage implements OnInit, OnDestroy {
     private loadingController: LoadingController,
     private appResetService: AppResetService,
     private navController: NavController,
-    private breakpointService: BreakpointService
+    private breakpointService: BreakpointService,
+    private platform: Platform
   ) {}
 
   async ngOnInit() {
+    if (this.platform.is('desktop')) {
+      this.computer = true;
+    }
     this.breakpointService.isDesktopView().subscribe((isDesktop) => {
       this.isDesktop = isDesktop;
     });

--- a/src/assets/icon/menuanimation.svg
+++ b/src/assets/icon/menuanimation.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 25H120V35H0V25ZM0 55H120V65H0V55ZM120 85H0V95H120V85Z" fill="white"/>
+</svg>

--- a/src/assets/icon/menuarrow.svg
+++ b/src/assets/icon/menuarrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.59 7.41L7 6L13 12L7 18L5.59 16.59L10.17 12L5.59 7.41ZM11.59 7.41L13 6L19 12L13 18L11.59 16.59L16.17 12L11.59 7.41Z" fill="white"/>
+</svg>

--- a/src/global.scss
+++ b/src/global.scss
@@ -604,3 +604,29 @@ ion-select-popover ion-list ion-item ion-radio {
 ion-split-pane {
   --side-max-width: 400px;
 }
+
+.slide-in {
+  animation: slide-in 0.3s forwards;
+}
+
+.slide-out {
+  animation: slide-out 0.3s forwards;
+}
+
+@keyframes slide-in {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(0%);
+  }
+}
+
+@keyframes slide-out {
+  0% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}


### PR DESCRIPTION
This change includes several customizations for the desktop version of the app and some updates to the app.
WEB
- RO-1175: Fix dropdown under 'skredproblem'
- RO-1173: Add arrow icon and slide in animation for split pane on side menu
- RO-1166: If observation fails the send email button tries to open the computers mail client and the edit button redirects back to the observation
- RO-1174: Remove start trip option for desktop
- RO-1176: Select component did not display properly due to a missing ngModel binding to the selected value. 
- Change language dropdown to be popover on desktop

APP (Changes that are for both the mobile app and web version)
- RO-1180: Default map is now ESRI World Topo + Kartverket instead of just kartverket
- Change highlighted tab color for more contrast and increased visibility.  
