### PR TITLE
Fjerner visning av NaN hvis vi ikke har størrelse på pakka

### DIFF
--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -36,7 +36,8 @@
   <ion-list>
     <ion-list-header>
       <ion-label>Kartpakke</ion-label>
-      <ion-label>Størrelse</ion-label>
+      <ion-label>Str</ion-label>
+      <ion-label>Dato</ion-label>
       <ion-label></ion-label>
     </ion-list-header>
     <ion-item (click)="presentActionSheet(item)" *ngFor="let item of downloadedMaps$ | async">
@@ -44,6 +45,7 @@
       <ion-label *ngIf="isDownloading(item)">
         ({{getPercentage(item) +'%' }})</ion-label>
       <ion-label *ngIf="!isDownloading(item)">{{ humanReadableByteSize(item.size) }}</ion-label>
+      <ion-label></ion-label>
       <ion-icon slot="end" *ngIf="!!item.downloadComplete" name="checkmark"></ion-icon>
     </ion-item>
   </ion-list>

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -26,6 +26,9 @@ export class OfflineMapPage implements OnInit {
   }
 
   humanReadableByteSize(bytes: number): string {
+    if (isNaN(bytes)) {
+      return '';
+    }
     return this.helperService.humanReadableByteSize(bytes);
   }
 


### PR DESCRIPTION
Dette er en liten fiks av tabellen med oversikt over kartpakker på tlf.
Har også lagt inn kolonne for dato/versjon, selv om vi ikke har det ennå