### PR TITLE
RO-1218: Forsøk på fiks av "Tiles slutter å laste etter en stund (offlinekart)"

### DIFF
--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -107,6 +107,7 @@ export class MapComponent implements OnInit {
       const start = performance.now();
       this.initializeMap().then(() => {
         this.logger.debug(`center = ${this.center}`);
+        //TODO: SJekk om dette kallet bør være her
         if (this.center) {
           this.view.center = this.center;
         }
@@ -481,7 +482,7 @@ export class MapComponent implements OnInit {
 
   private async initOfflineMaps() {
     this.logger.debug('initOfflineMaps(): ', DEBUG_TAG);
-    await this.offlineMapService.initWebServer();
+    this.offlineMapService.initWebServer();
 
     this.offlineMapService.mapAdded$().subscribe((mapPackage) => {
       this.logger.debug(
@@ -581,10 +582,10 @@ export class MapComponent implements OnInit {
     this.view.goTo(
       new Point({
         latitude: latLng.lat,
-        longitude: latLng.lng,
-        spatialReference: { wkid: 25833 }
+        longitude: latLng.lng
       })
     );
+    //TODO: Set zoom
     this.isDoingMoveAction = false;
   }
 }


### PR DESCRIPTION
Skrur av webserver ved pause og på igjen når appen er tilbake.
Mulig koden burde ryddes litt i. Dette var bare en kjapp test for å sjekke ut en teori.

Har også fikset feil koordinatsystem i flyTo()-metoden, så vi havner på riktig sted. Dette har ingenting med levering av offline-fliser å gjøre, jeg bare sneik det inn.

Testet på Android og iPhone 8.

