### PR TITLE
RO 1229: Stedfesting av observasjon

### DIFF
--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
@@ -69,7 +69,7 @@
                           <ion-label class="small-text ion-no-margin">
                             <span>{{ locationMarker.geometry.latitude | number:'0.3'
                               }}&deg;{{'MAP_CENTER_INFO.NORTH_SHORT'|translate}},
-                              {{ locationMarker.geometry.latitude | number:'0.3'
+                              {{ locationMarker.geometry.longitude | number:'0.3'
                               }}&deg;{{'MAP_CENTER_INFO.EAST_SHORT'|translate}}</span>
                             <span *ngIf="!isLoading && viewInfo && viewInfo.elevation !== null">, {{ viewInfo.elevation
                               }}

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -147,9 +147,9 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
             .pipe(take(1))
             .toPromise();
           if (lastView) {
-            this.locationMarker = this.createMarker(lastView.center);
+            this.locationMarker = this.createMarker(lastView.center); //set marker in map center
           } else {
-            this.locationMarker = this.createMarkerFromLatLng(59.1, 10.3);
+            this.locationMarker = this.createMarkerFromLatLng(59.1, 10.3); //mark a default/fallback location
           }
         }
       }
@@ -186,7 +186,8 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
         url: symbolPath ? symbolPath : this.locationMarkerIconUrl,
         width: '25px',
         height: '41px',
-        yoffset: '15px'
+        yoffset: '20px',
+        xoffset: '3px'
       })
     });
   }
@@ -246,6 +247,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
       layer.add(marker);
       //TODO: Få tidligere brukte lokasjoner til å legge seg under lokasjonen man jobber med
       //TODO: Handle click on previously used location marker.on('click', () => this.setToPrevouslyUsedLocation(loc));
+      //TODO: Fjern lokasjoner som ikke er innenfor utsnittet lengre, for å unngå minnelekkasje
     }
   }
 
@@ -259,7 +261,6 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
     if (this.fromMarker) {
       this.markerLayer.add(this.fromMarker);
     }
-    // this.locationGroup.addTo(this.map); //TODO: Cluster
     this.mapView.on('drag', () => {
       this.ngZone.run(() => {
         this.isLoading = true;
@@ -328,8 +329,8 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
     this.updatePathAndDistance();
   }
 
+  //fetch height, steepness and name for current location
   private updateMapViewInfo() {
-    //TODO: Hvorfor gjør man dette?
     const center = this.locationMarker.geometry as Point; //TODO: Is this safe
     this.mapSearchService
       .getViewInfo(
@@ -411,13 +412,9 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
         ) {
           this.fromMarker.visible = false;
           this.pathLine.visible = false;
-          // this.fromMarker.setOpacity(0);
-          // this.pathLine.setStyle({ opacity: 0 });
         } else {
           this.fromMarker.visible = true;
           this.pathLine.visible = true;
-          // this.fromMarker.setOpacity(1);
-          // this.pathLine.setStyle({ opacity: 0.9 }); TODO: Sjekk om vi må ha dette
         }
       }
     }

--- a/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.ts
+++ b/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.ts
@@ -7,6 +7,7 @@ import * as L from 'leaflet';
 import { BasePageService } from '../../base-page-service';
 import { ActivatedRoute } from '@angular/router';
 import moment from 'moment';
+import { Point } from '@arcgis/core/geometry';
 
 @Component({
   selector: 'app-landslide-obs',
@@ -153,12 +154,12 @@ export class LandslideObsPage extends BasePage {
     modal.present();
     const result = await modal.onDidDismiss();
     if (result.data) {
-      const start: L.LatLng = result.data.start;
-      const end: L.LatLng = result.data.end;
-      this.registration.request.LandSlideObs.StartLat = start.lat;
-      this.registration.request.LandSlideObs.StartLong = start.lng;
-      this.registration.request.LandSlideObs.StopLat = end.lat;
-      this.registration.request.LandSlideObs.StopLong = end.lng;
+      const start: Point = result.data.start;
+      const end: Point = result.data.end;
+      this.registration.request.LandSlideObs.StartLat = start.latitude;
+      this.registration.request.LandSlideObs.StartLong = start.longitude;
+      this.registration.request.LandSlideObs.StopLat = end.latitude;
+      this.registration.request.LandSlideObs.StopLong = end.longitude;
     }
   }
 }

--- a/src/app/modules/registration/pages/obs-location/obs-location.page.html
+++ b/src/app/modules/registration/pages/obs-location/obs-location.page.html
@@ -9,7 +9,7 @@
   </ion-toolbar>
 </ion-header>
 <ion-content>
-  <app-set-location-in-map *ngIf="isLoaded" [geoHazard]="geoHazard" [locationMarker]="locationMarker"
+  <app-set-location-in-map *ngIf="isLoaded" [geoHazard]="geoHazard" [location]="point"
     (locationSet)="onLocationSet($event)" [selectedLocation]="selectedLocation" [allowEditLocationName]="true"
     [isSaveDisabled]="isSaveDisabled">
   </app-set-location-in-map>

--- a/src/app/modules/registration/pages/obs-location/obs-location.page.ts
+++ b/src/app/modules/registration/pages/obs-location/obs-location.page.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, NgZone, OnDestroy, ViewChild } from '@angular/core';
-import * as L from 'leaflet';
 import { IRegistration } from '../../models/registration.model';
 import { RegistrationService } from '../../services/registration.service';
 import { NavController } from '@ionic/angular';
@@ -17,6 +16,7 @@ import { SetLocationInMapComponent } from '../../components/set-location-in-map/
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
 import { take } from 'rxjs/operators';
 import { RegobsAuthService } from '../../../auth/services/regobs-auth.service';
+import { Point } from '@arcgis/core/geometry';
 
 const DEBUG_TAG = 'ObsLocationPage';
 
@@ -26,7 +26,7 @@ const DEBUG_TAG = 'ObsLocationPage';
   styleUrls: ['./obs-location.page.scss']
 })
 export class ObsLocationPage implements OnInit, OnDestroy {
-  locationMarker: L.Marker;
+  point: Point;
   isLoaded = false;
   selectedLocation: ObsLocationsResponseDtoV2;
   registration: IRegistration;
@@ -73,20 +73,10 @@ export class ObsLocationPage implements OnInit, OnDestroy {
       this.geoHazard = userSettings.currentGeoHazard[0];
     }
     if (this.hasLocation(this.registration)) {
-      const locationMarkerIcon = L.icon({
-        iconUrl: '/assets/icon/map/obs-location.svg',
-        iconSize: [25, 41],
-        iconAnchor: [12, 41],
-        shadowUrl: 'leaflet/marker-shadow.png',
-        shadowSize: [41, 41]
+      this.point = new Point({
+        latitude: this.registration.request.ObsLocation.Latitude,
+        longitude: this.registration.request.ObsLocation.Longitude
       });
-      this.locationMarker = L.marker(
-        {
-          lat: this.registration.request.ObsLocation.Latitude,
-          lng: this.registration.request.ObsLocation.Longitude
-        },
-        { icon: locationMarkerIcon }
-      );
       this.selectedLocation = {
         Name:
           this.registration.request.ObsLocation.LocationName ||

--- a/src/app/modules/registration/pages/set-avalanche-position/set-avalanche-position.page.html
+++ b/src/app/modules/registration/pages/set-avalanche-position/set-avalanche-position.page.html
@@ -13,6 +13,6 @@
   <app-set-location-in-map *ngIf="fromMarker" [geoHazard]="geoHazard" (mapReady)="onMapReady($event)" [fromMarker]="fromMarker"
     [locationMarker]="locationMarker" (locationSet)="onLocationSet($event)" [confirmLocationText]="confirmLocationText"
     fromLocationText="REGISTRATION.OBS_LOCATION.TITLE" [showPreviousUsedLocations]="false" [locationTitle]="locationText"
-    [showPolyline]="false" [showFromMarkerInDetails]="false" [locationMarkerIconUrl]="locationMarkerIconUrl">
+    [showPolyline]="false" [showFromMarkerInDetails]="false" [locationMarkerIconUrl]="locationMarkerIconUrl" (markerLayerReady)="onMarkerLayerReady($event)">
   </app-set-location-in-map>
 </ion-content>

--- a/src/app/modules/registration/pages/set-damage-location/set-damage-location.page.html
+++ b/src/app/modules/registration/pages/set-damage-location/set-damage-location.page.html
@@ -9,7 +9,7 @@
   </ion-toolbar>
 </ion-header>
 <ion-content>
-  <app-set-location-in-map *ngIf="fromMarker" [geoHazard]="geoHazard" [fromMarker]="fromMarker" [locationMarker]="locationMarker"
+  <app-set-location-in-map *ngIf="fromMarker" [geoHazard]="geoHazard" [fromMarker]="fromMarker" [location]="location"
     [locationMarkerIconUrl]="locationMarkerIconUrl" (locationSet)="onLocationSet($event)" confirmLocationText="REGISTRATION.SET_DAMAGE_LOCATION.CONFIRM_TEXT"
     fromLocationText="REGISTRATION.OBS_LOCATION.TITLE" [showPreviousUsedLocations]="false" locationTitle="REGISTRATION.SET_DAMAGE_LOCATION.TITLE">
   </app-set-location-in-map>

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -8,6 +8,7 @@ import * as L from 'leaflet';
 import { SetAvalanchePositionPage } from '../../set-avalanche-position/set-avalanche-position.page';
 import moment from 'moment';
 import { SelectOption } from '../../../../shared/components/input/select/select-option.model';
+import { Point } from '@arcgis/core/geometry';
 
 @Component({
   selector: 'app-avalanche-obs',
@@ -151,12 +152,12 @@ export class AvalancheObsPage extends BasePage {
     modal.present();
     const result = await modal.onDidDismiss();
     if (result.data) {
-      const start: L.LatLng = result.data.start;
-      const end: L.LatLng = result.data.end;
-      this.registration.request.AvalancheObs.StartLat = start.lat;
-      this.registration.request.AvalancheObs.StartLong = start.lng;
-      this.registration.request.AvalancheObs.StopLat = end.lat;
-      this.registration.request.AvalancheObs.StopLong = end.lng;
+      const start: Point = result.data.start;
+      const end: Point = result.data.end;
+      this.registration.request.AvalancheObs.StartLat = start.latitude;
+      this.registration.request.AvalancheObs.StartLong = start.longitude;
+      this.registration.request.AvalancheObs.StopLat = end.latitude;
+      this.registration.request.AvalancheObs.StopLong = end.longitude;
     }
   }
 }


### PR DESCRIPTION
"Første versjon" av stedfesting av observasjon.
Flg. skal virke:
- at du kan plassere en observasjon på et sted og endre plassering

Vi må sjekke at denne fungerer godt sammen med RO-1224, når denne er på plass.

Flg. gjenstår, og vil bli skilt ut i egne oppgaver:
- løse ørten TODO's i koden
- ikonene er uklare
- tegne strek mellom GPS-posisjon og observasjons-markør
- vise tidligere brukte/navngitte lokasjoner
- velge en tidligere brukt/navngitt lokasjon som lokasjon
- stedfesting av start/stopp på skredhendelse
- stedfesting av skader for vann-observasjoner