### PR TITLE
chore: Explicitly state the license

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "regobs4",
   "version": "4.4.7",
   "author": "NVE",
+  "license": "NLOD-2.0",
   "homepage": "http://www.nve.no",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
The artifacts in this repository are governed by the Norwegian Licence
for Open Government Data (NLOD) 2.0 -- declare this in the
`package.json` so that it is known to future users.

Fixes: nve/regObs4#18
Related issue: spdx/license-list-XML#1261