### PR TITLE
RO-1222: Popup-kart kræsjet fordi jeg ikke hadde tilpasset denne til endret gr…

### DIFF
--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -386,28 +386,30 @@ export class MapComponent implements OnInit {
     const group = this.getFeatureLayerGroup(FeatureLayerType.SUPPORT_MAP);
     group.removeAll()
 
-    for (const supportTile of this.userSettingService.getSupportTilesOptions(
-      userSetting
-    )) {
-      if (supportTile.enabled) {
-        const layer = new WebTileLayer({
-          id: supportTile.name,
-          urlTemplate: supportTile.url,
-          opacity: supportTile.opacity
-        });
+    if (this.showSupportMaps) {
+      for (const supportTile of this.userSettingService.getSupportTilesOptions(
+        userSetting
+      )) {
+        if (supportTile.enabled) {
+          const layer = new WebTileLayer({
+            id: supportTile.name,
+            urlTemplate: supportTile.url,
+            opacity: supportTile.opacity
+          });
 
-        //TODO: Flere valg for støttekart
-        // const supportMapTileLayer = L.tileLayer(supportTile.url, {
-        //   ...this.getTileLayerDefaultOptions(userSetting),
-        //   updateInterval: 600,
-        //   keepBuffer: 0,
-        //   updateWhenIdle: true,
-        //   minZoom: settings.map.tiles.minZoomSupportMaps,
-        //   bounds: <any>settings.map.tiles.supportTilesBounds
-        // });
-        // supportMapTileLayer.setOpacity(supportTile.opacity);
-        // supportMapTileLayer.addTo(this.tilesLayer);
-        group.add(layer);
+          //TODO: Flere valg for støttekart
+          // const supportMapTileLayer = L.tileLayer(supportTile.url, {
+          //   ...this.getTileLayerDefaultOptions(userSetting),
+          //   updateInterval: 600,
+          //   keepBuffer: 0,
+          //   updateWhenIdle: true,
+          //   minZoom: settings.map.tiles.minZoomSupportMaps,
+          //   bounds: <any>settings.map.tiles.supportTilesBounds
+          // });
+          // supportMapTileLayer.setOpacity(supportTile.opacity);
+          // supportMapTileLayer.addTo(this.tilesLayer);
+          group.add(layer);
+        }
       }
     }
   }

--- a/src/app/modules/map/pages/modal-map-image/modal-map-image.page.ts
+++ b/src/app/modules/map/pages/modal-map-image/modal-map-image.page.ts
@@ -2,10 +2,10 @@ import { Component, OnInit, Input } from '@angular/core';
 import { GeoHazard } from '../../../../core/models/geo-hazard.enum';
 import { ModalController } from '@ionic/angular';
 import { Point } from '@arcgis/core/geometry';
-import MapView from '@arcgis/core/views/MapView';
 import Graphic from '@arcgis/core/Graphic';
 import { MarkerHelper } from '../../../../core/helpers/arcgis/markerHelper';
 import GraphicsLayer from '@arcgis/core/layers/GraphicsLayer';
+import { FeatureLayerType, MapComponent } from '../../components/map/map.component';
 
 @Component({
   selector: 'app-modal-map-image',
@@ -15,8 +15,6 @@ import GraphicsLayer from '@arcgis/core/layers/GraphicsLayer';
 export class ModalMapImagePage implements OnInit {
   @Input() location: { latLng: L.LatLng; geoHazard: GeoHazard };
   centerLocation: Point;
-
-  private mapView: MapView;
   private markerLayer = new GraphicsLayer({ id: 'MARKERS' });
 
   constructor(private modalController: ModalController) {}
@@ -28,15 +26,14 @@ export class ModalMapImagePage implements OnInit {
     });
   }
 
-  onMapReady(map: MapView) {
-    this.mapView = map;
+  onMapReady(mapComponent: MapComponent) {
     const symbol = MarkerHelper.getGeoHazardSvg(this.location.geoHazard);
     const marker = new Graphic({
       geometry: this.centerLocation,
       symbol: symbol
     });
     this.markerLayer.add(marker);
-    this.mapView.map.add(this.markerLayer);
+    mapComponent.addFeatureLayer(this.markerLayer, FeatureLayerType.OBSERVATIONS);
   }
 
   close() {


### PR DESCRIPTION
Popup-kart kræsjet fordi jeg ikke hadde tilpasset denne til endret grensesnitt i MapComponent. Dette gjorde at markøren ikke ble vist.
Fikk også MapComponent til å ta hensyn til at støttekart skulle være av i popup.