### PR TITLE
RO-1301: Online tile request timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5437,6 +5437,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -9729,6 +9739,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filing-cabinet": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-3.0.0.tgz",
@@ -13243,6 +13260,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -20257,7 +20281,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -20970,7 +20998,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/src/app/core/models/user-settings.model.ts
+++ b/src/app/core/models/user-settings.model.ts
@@ -22,4 +22,9 @@ export interface UserSetting {
   featureToggeGpsDebug: boolean;
   infoAboutObservationsRecievedTimestamp?: number;
   infoAboutSupportMapsRecievedTimestamp?: number;
+
+  /**
+   * How many seconds we wait for online map requests before we cancel them 
+   */
+  onlineMapTileRequestTimeout?: number
 }

--- a/src/app/core/services/user-setting/user-settings.default.ts
+++ b/src/app/core/services/user-setting/user-settings.default.ts
@@ -29,5 +29,6 @@ export const DEFAULT_USER_SETTINGS: (langKey: LangKey) => UserSetting = (
   consentForSendingAnalytics: true,
   consentForSendingAnalyticsDialogCompleted: false,
   featureToggeGpsDebug: false,
-  featureToggleDeveloperMode: false
+  featureToggleDeveloperMode: false,
+  onlineMapTileRequestTimeout: 3
 });

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -55,6 +55,7 @@ import { Point } from '@arcgis/core/geometry';
 import { UserMarker } from 'src/app/core/helpers/leaflet/user-marker/user-marker';
 import { Geoposition } from '@ionic-native/geolocation/ngx';
 import Graphic from '@arcgis/core/Graphic';
+import { IceLayerPage } from 'src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page';
 
 const DEBUG_TAG = 'MapComponent';
 
@@ -181,6 +182,7 @@ export class MapComponent implements OnInit {
             // if (userSetting.showMapCenter) {
             //   this.updateMapView(); //TODO
             // }
+            this.setRequestTimeout(userSetting.onlineMapTileRequestTimeout);
           });
 
         this.zone.run(() => {
@@ -236,6 +238,14 @@ export class MapComponent implements OnInit {
 
     if (this.zlWatcher) {
       this.zlWatcher.remove();
+    }
+  }
+
+  private setRequestTimeout(timeout: number) {
+    if (timeout) {
+      esriConfig.request.timeout = timeout * 1000;
+    } else {
+      esriConfig.request.timeout = undefined;
     }
   }
 
@@ -376,6 +386,7 @@ export class MapComponent implements OnInit {
         });
         if (this.isOfflineMapsAvailable()) {
           layer.resampling = false; //see this.disableResamplingOfOnlineBasemap()
+          this.logger.debug(`deaktiverer resampling av fliser i lag '${layer.id}'`);
         }
         return layer;
       }
@@ -571,11 +582,13 @@ export class MapComponent implements OnInit {
       if (layer instanceof WebTileLayer) {
         const tileLayer: any = layer; //hack because compiler doesn't allow resampling on WebTileLayer, but the API supports it
         tileLayer.resampling = false;
+        this.logger.debug(`deaktiverer resampling av fliser i lag '${layer.id}'`);
       }
     });
   }
 
   private isOfflineMapsAvailable(): boolean {
+    //TODO: Denne burde ta hensyn til utsnittet vi viser, for nå vet vi ikke om vi har offline-kart for aktuelt utsnitt
     return this.getBasemapLayerGroup(BasemapLayerType.OFFLINE).layers.length > 0
   }
 

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -242,10 +242,10 @@ export class MapComponent implements OnInit {
   }
 
   private setRequestTimeout(timeout: number) {
-    if (timeout) {
+    if (timeout && this.isOfflineMapsAvailable()) {
       esriConfig.request.timeout = timeout * 1000;
     } else {
-      esriConfig.request.timeout = undefined;
+      esriConfig.request.timeout = 60000; //this is the default Esri timeout
     }
   }
 

--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -32,7 +32,13 @@
       >
     </div>
   </div> 
-
+  
+  <ion-item *ngIf="userSettings">
+    <ion-label>Ventetid (s) på online-kart</ion-label>
+    <ion-input [(ngModel)]="userSettings.onlineMapTileRequestTimeout" (ngModelChange)="saveUserSettings()" type="number" min="1" max="60" inputmode="number">
+    </ion-input>
+  </ion-item>
+  
   <ion-list>
     <ion-list-header>
       <ion-label>Kartpakke</ion-label>


### PR DESCRIPTION
Forsøk på å gjøre kartet mer smidig når det er dårlig dekning, slik at vi ikke opplever "hvit skjerm"
Hvis vi har offline-kart på tlf, blir nå timeout på lasting av online fliser satt til 3 sekunder. Hvis ikke flisa dukker opp innen 3 sek, vil offline-flisa vises i stedet. Timeout kan endres i innstillinger for offline-kart i menyen.
Jeg er usikker på om timeouten påvirker andre Esri-funksjoner enn henting av fliser.
Har gjort det slik at Jostein og andre brukere kan eksperimentere litt.
Sjekken på om vi har offline-kart tilgjengelig er for enkel, den burde tatt hensyn til kartutsnittet, slik at vi ikke tror vi har offline-kart bestandig selv om offline-kartene vi har ikke dekker området vi ser på. Men tar ikke dette nå.
