### PR TITLE
RO-1228-Duplicate click handlers

### DIFF
--- a/src/app/modules/map/components/map/map.component.html
+++ b/src/app/modules/map/components/map/map.component.html
@@ -1,5 +1,3 @@
-<!--div *ngIf="loaded" leaflet [leafletOptions]="options" (leafletMapReady)="onLeafletMapReady($event)">
-</div-->
 <div #mapViewNode></div>
 <app-map-controls *ngIf="showMapControls" (mapReady)="onMapReady($event)"></app-map-controls>
 <div class="map-debug-container" [hidden]="!debug">

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -217,7 +217,7 @@ export class MapComponent implements OnInit {
     }
   }
 
-  onMapReady(): void {
+  private onMapReady(): void {
     if (this.showScale) {
       const scaleBar = new ScaleBar({
         view: this.view,
@@ -227,6 +227,7 @@ export class MapComponent implements OnInit {
         position: 'bottom-left'
       });
     }
+    this.mapReady.emit(this);
   }
 
   ngOnDestroy(): void {
@@ -282,7 +283,6 @@ export class MapComponent implements OnInit {
       this.setZoom(null, this.getMaxZoom(userSetting.useRetinaMap));
       this.createBasemap(userSetting);
       this.createSupportMaps(userSetting);
-      this.mapReady.emit(this);
     });
     this.logger.debug('updateLayers(): Finished updating layers', DEBUG_TAG)
   }
@@ -542,6 +542,7 @@ export class MapComponent implements OnInit {
       //   })
       // }
     });
+    this.view.popup.autoOpenEnabled = false;
 
     if (this.isStatic) {
       this.logger.debug('initializeMap(): Deaktiverer mus-hendelser for statisk kart...', DEBUG_TAG);
@@ -776,8 +777,7 @@ export class MapComponent implements OnInit {
    * @param layer the layer of interest
    * @return a stream of click events. Contains the graphics that was hit. If no hit, the event will contain an undefined object
    */
-  createClickEventHandler(layer: Layer): Observable<Graphic|undefined> {
-    this.view.popup.autoOpenEnabled = false;
+  createGraphicClickEventHandler(layer: Layer): Observable<Graphic|undefined> {
     this.clickSubscriptions.push(this.view.on('click', (event) => {
       const screenPoint = {
         x: event.x,

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -537,7 +537,6 @@ export class MapComponent implements OnInit {
       //   })
       // }
     });
-    this.view.popup.autoOpenEnabled = false;
 
     // Disable default popups
     this.view.popup.autoOpenEnabled = false;

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -772,28 +772,24 @@ export class MapComponent implements OnInit {
   /**
    * Listen for click events on graphics on a specific layer.
    * @param layer the layer of interest
-   * @return a stream of click events. Contains the graphics that was hit. If no hit, the event will contain null
+   * @return a stream of click events. Contains the graphics that was hit. If no hit, the event will contain undefined
    */
-  createClickHandlerForGraphicsLayer(layer: GraphicsLayer): Observable<Graphic|null> {
-    const getGraphicsAtScreenPoint = p => this.view
-      .hitTest(p, { include: layer })
-      .catch(err => {
+  createClickHandlerForGraphicsLayer(
+    layer: GraphicsLayer
+  ): Observable<Graphic | undefined> {
+
+    const getGraphicsAtScreenPoint = (
+      p: __esri.MapViewClickEvent
+    ): Promise<__esri.HitTestResult | null> =>
+      this.view.hitTest(p, { include: layer }).catch((err) => {
         this.logger.error(err, DEBUG_TAG, 'hitTest failed');
         return null;
       });
 
-    const getFirstGraphicOrNull = (response: __esri.HitTestResult) => {
-      try {
-        const [firstHit] = response.results;
-        return firstHit.graphic;
-      } catch (error) {
-        return null;
-      }
-    }
-
     return this.click$.pipe(
       switchMap(getGraphicsAtScreenPoint),
-      map(getFirstGraphicOrNull),
+      // Return the graphic of the first hit result
+      map((r) => r?.results?.[0]?.graphic)
     );
   }
 

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -140,6 +140,7 @@ export class MapComponent implements OnInit {
   private firstClickOnZoomToUser = true;
   private isActive: BehaviorSubject<boolean>;
   private clickEvent: Subject<Graphic|undefined> = new Subject(); //a click event
+  private clickEvent$: Observable<Graphic|undefined> = this.clickEvent.asObservable();
   private clickSubscriptions: IHandle[] = [];
 
   // The <div> where we will place the map
@@ -229,7 +230,7 @@ export class MapComponent implements OnInit {
   }
 
   ngOnDestroy(): void {
-    this.clickSubscriptions.forEach(subscription => subscription.remove);
+    this.removeClickSubscriptions();
     if (this.view) {
       this.view.destroy(); // destroy the map view
     }
@@ -240,6 +241,12 @@ export class MapComponent implements OnInit {
 
     if (this.zlWatcher) {
       this.zlWatcher.remove();
+    }
+  }
+
+  private removeClickSubscriptions(): void {
+    while (this.clickSubscriptions.length > 0) {
+      this.clickSubscriptions.pop().remove();
     }
   }
 
@@ -797,7 +804,7 @@ export class MapComponent implements OnInit {
           );
         });
     }));
-    return this.clickEvent.asObservable();
+    return this.clickEvent$;
   }
 
   getCenter(): Point {

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -96,7 +96,7 @@ export class HomePage extends RouterPage implements OnInit {
       this.mapDataInitialized = true;
       mapComponent.addFeatureLayer(this.markerLayer, FeatureLayerType.OBSERVATIONS);
       
-      this.createClickEventHandler(mapComponent, this.markerLayer, this.mapItemBar);
+      this.createObservationMarkerClickEventHandler(mapComponent, this.markerLayer, this.mapItemBar);
 
       const observationObservable = combineLatest([
         this.observationService.observations$,
@@ -156,7 +156,7 @@ export class HomePage extends RouterPage implements OnInit {
     }
   }
 
-  private createClickEventHandler(mapComponent: MapComponent, layer: GraphicsLayer, mapItemBar: MapItemBarComponent): void {
+  private createObservationMarkerClickEventHandler(mapComponent: MapComponent, layer: GraphicsLayer, mapItemBar: MapItemBarComponent): void {
     //TODO: Handle click on registration cluster
     // this.markerLayer.on('clusterclick', (a: any) => {
     //   const groupLatLng: L.LatLng = a.latlng;
@@ -173,7 +173,7 @@ export class HomePage extends RouterPage implements OnInit {
     // });
 
     this.loggingService.debug(`createClickEventHandler for layer ${layer.id}`, DEBUG_TAG);
-    mapComponent.createClickEventHandler(layer)
+    mapComponent.createGraphicClickEventHandler(layer)
     .pipe(takeUntil(this.ngDestroy$))
     .subscribe((clickOnGraphic) => {
       if (clickOnGraphic) {

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -41,7 +41,7 @@ export class HomePage extends RouterPage implements OnInit {
   showGeoSelectInfo = false;
   dataLoadIds$: Observable<string[]>;
   private ngDestroy$ = new Subject();
-  private clickSubscription: IHandle;
+  private mapDataInitialized: boolean;
 
   constructor(
     router: Router,
@@ -91,21 +91,24 @@ export class HomePage extends RouterPage implements OnInit {
   }
 
   onMapReady(mapComponent: MapComponent): void {
-    this.loggingService.debug('onMapReady()...', DEBUG_TAG)
-    mapComponent.addFeatureLayer(this.markerLayer, FeatureLayerType.OBSERVATIONS);
-    
-    this.createClickEventHandler(mapComponent, this.markerLayer, this.mapItemBar);
+    this.loggingService.debug(`onMapReady(). Map data already initialized = ${this.mapDataInitialized}`, DEBUG_TAG)
+    if (!this.mapDataInitialized) {
+      this.mapDataInitialized = true;
+      mapComponent.addFeatureLayer(this.markerLayer, FeatureLayerType.OBSERVATIONS);
+      
+      this.createClickEventHandler(mapComponent, this.markerLayer, this.mapItemBar);
 
-    const observationObservable = combineLatest([
-      this.observationService.observations$,
-      this.userSettingService.showObservations$
-    ]);
-    observationObservable
-      .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(([regObservations, showObservations]) => {
-        this.redrawObservationMarkers(showObservations ? regObservations : []);
-      });
-    this.loggingService.debug('onMapReady() ferdig', DEBUG_TAG)
+      const observationObservable = combineLatest([
+        this.observationService.observations$,
+        this.userSettingService.showObservations$
+      ]);
+      observationObservable
+        .pipe(takeUntil(this.ngUnsubscribe))
+        .subscribe(([regObservations, showObservations]) => {
+          this.redrawObservationMarkers(showObservations ? regObservations : []);
+        });
+    }
+    this.loggingService.debug(`onMapReady() ferdig. Map data initialized = ${this.mapDataInitialized}`, DEBUG_TAG)
   }
 
   async onEnter() {
@@ -169,12 +172,14 @@ export class HomePage extends RouterPage implements OnInit {
     //   }
     // });
 
+    this.loggingService.debug(`createClickEventHandler for layer ${layer.id}`, DEBUG_TAG);
     mapComponent.createClickEventHandler(layer)
     .pipe(takeUntil(this.ngDestroy$))
     .subscribe((clickOnGraphic) => {
       if (clickOnGraphic) {
         if (clickOnGraphic instanceof MapItemMarker) {
           const marker = clickOnGraphic as MapItemMarker;
+          this.loggingService.debug(`graphic was clicked: layer = ${layer.id}, marker = ${marker.id}`, DEBUG_TAG);
           if (marker.isSelected) {
             marker.deselect();
             mapItemBar.hide();
@@ -194,7 +199,6 @@ export class HomePage extends RouterPage implements OnInit {
   }
 
   ngOnDestroy(): void {
-    this.clickSubscription?.remove();
     this.ngDestroy$.next();
     this.ngDestroy$.complete();
   }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -173,7 +173,7 @@ export class HomePage extends RouterPage implements OnInit {
     // });
 
     this.loggingService.debug(`createClickEventHandler for layer ${layer.id}`, DEBUG_TAG);
-    mapComponent.createGraphicClickEventHandler(layer)
+    mapComponent.createClickHandlerForGraphicsLayer(layer)
     .pipe(takeUntil(this.ngDestroy$))
     .subscribe((clickOnGraphic) => {
       if (clickOnGraphic) {


### PR DESCRIPTION
Solveig oppdaget at klikk på observasjons-ikoner i kartet sluttet å virke etter man hadde byttet bakgrunnskart.
Årsaken var at det ble laget nye click-handlere hver gang man endret bakgrunnskart, fordi mapReady.emit() ble kalt etter bakgrunnskart ble byttet (og alle lag lagt til på nytt).
Klikk-handler ble derfor fyrt av dobbelt så mange ganger, så de nullet ut hverandre (som om man klikker på ikonet på nytt for å skjule visninga av observasjonen nederst).
Det er ikke nødvendig å lage nye klikk-handlere når kartene byttes ut, fordi klikk-handlere og datakilder matcher mot ID på lagene, og de er de samme, selv om det er nye lag.