### PR TITLE
Låst typescript-versjon til 4.1.3 for å unngå trøbbel med den angular…

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "prettify-xml": "^1.2.0",
     "protractor": "~7.0.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.3"
+    "typescript": "4.1.3"
   },
   "description": "Report incidents in nature",
   "cordova": {


### PR DESCRIPTION
Låst typescript-versjon til 4.1.3 for å unngå trøbbel med den Angular-versjonen vi bruker nå. Har slitt med denne feilmeldinga: 
`Error: The Angular Compiler requires TypeScript >=4.0.0 and <4.2.0 but 4.3.5 was found instead.`