### PR TITLE
Implemented download offline packages with multiple zip parts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4655,9 +4655,9 @@
       }
     },
     "@varsom-regobs-common/translations": {
-      "version": "1.0.167",
-      "resolved": "https://registry.npmjs.org/@varsom-regobs-common/translations/-/translations-1.0.167.tgz",
-      "integrity": "sha512-QcFu9wiIU8anT4lH2JjQ1UeX99SN23/84fEWXjE/ibg5oy168SPS1Ofd87Yxgq4EBYC6eauSigR4TWzCXn24Dw=="
+      "version": "1.0.176",
+      "resolved": "https://registry.npmjs.org/@varsom-regobs-common/translations/-/translations-1.0.176.tgz",
+      "integrity": "sha512-vCMPFw9bxLi6OYGzpYkyhL6wm03kujZ6lipss6r4Lo6dCpZObsqn/GUbynMHYd3HN2sD3qTZK7wwKS+WTaPW4w=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@openid/appauth": "^1.3.0",
     "@sentry/browser": "^6.2.2",
     "@turf/turf": "^6.3.0",
-    "@varsom-regobs-common/translations": "^1.0.167",
+    "@varsom-regobs-common/translations": "^1.0.176",
     "angular-svg-icon": "^11.2.0",
     "clone-deep": "^4.0.1",
     "core-js": "^3.9.1",

--- a/src/app/core/services/offline-map/offline-map.model.ts
+++ b/src/app/core/services/offline-map/offline-map.model.ts
@@ -1,14 +1,15 @@
 import { Progress } from './progress.model';
 
 export interface OfflineTilesMetadata {
-  path: string,
+  mapId: string,
   rootTile: {
     z: number,
     x: number,
     y: number
   },
   zMax: number,
-  url?: string
+  template: string,
+  url?: string;
 }
 
 export interface OfflinePackageMetadata {
@@ -19,10 +20,7 @@ export interface OfflinePackageMetadata {
 
 export interface OfflineMapPackage extends OfflinePackageMetadata {
   name: string;
-  url?: string;
   size?: number;
-  filename?: string;
-  filePath?: string;
   progress?: Progress;
   downloadStart?: number;
   downloadComplete?: number;

--- a/src/app/core/services/offline-map/offline-map.service.spec.ts
+++ b/src/app/core/services/offline-map/offline-map.service.spec.ts
@@ -1,12 +1,16 @@
-// import { TestBed } from '@angular/core/testing';
+import { TestLoggingService } from '../../../modules/shared/services/logging/test-logging.service';
+import { OfflineMapService } from './offline-map.service';
 
-// import { OfflineMapService } from './offline-map.service';
+describe('OfflineMapService', () => {
+  let offlineMapService: OfflineMapService;
 
-// describe('OfflineMapService', () => {
-//   beforeEach(() => TestBed.configureTestingModule({}));
+  it('progress value for 10% for download step of part 1 of 2 should be 0.10 / 4 =  0.025', () => {
+    offlineMapService = new OfflineMapService(null, new TestLoggingService(), null, null, null, null, null, null);
+    expect(offlineMapService.calculateTotalProgress(0.10, 0, 2, 'Downloading')).toBe(0.025);
+  });
 
-//   it('should be created', () => {
-//     const service: OfflineMapService = TestBed.get(OfflineMapService);
-//     expect(service).toBeTruthy();
-//   });
-// });
+  it('progress value for 10% for unzip step of part 2 of 2 should be (0.10 / 4) + (3/4)  =  0.025 + 0.75 =  0.775', () => {
+    offlineMapService = new OfflineMapService(null, new TestLoggingService(), null, null, null, null, null, null);
+    expect(offlineMapService.calculateTotalProgress(0.10, 1, 2, 'Unzipping')).toBe(0.775);
+  });
+});

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
-import { OfflineMapPackage, OfflinePackageMetadata } from './offline-map.model';
+import { OfflineMapPackage, OfflineTilesMetadata } from './offline-map.model';
 import { Progress } from './progress.model';
 import moment from 'moment';
-import { DirectoryEntry, File, Metadata, Entry } from '@ionic-native/file/ngx';
+import { File, Metadata, Entry } from '@ionic-native/file/ngx';
 import { LoggingService } from '../../../modules/shared/services/logging/logging.service';
-import { BehaviorSubject, from, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, from, Observable, Subject, Subscription } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { OnReset } from '../../../modules/shared/interfaces/on-reset.interface';
 import { WebView } from '@ionic-native/ionic-webview/ngx';
@@ -16,6 +16,7 @@ import { AlertController, Platform } from '@ionic/angular';
 import { LogLevel } from '../../../modules/shared/services/logging/log-level.model';
 import { HelperService } from '../helpers/helper.service';
 import { TranslateService } from '@ngx-translate/core';
+import { PackageMetadataCombined } from '../../../pages/offline-map/metadata.model';
 
 const DEBUG_TAG = 'OfflineMapService';
 const METADATA_FILE = 'metadata.json';
@@ -34,7 +35,8 @@ export class OfflineMapService implements OnReset {
   private downloads: BehaviorSubject<OfflineMapPackage[]> = new BehaviorSubject([]);
   downloads$ = this.downloads.asObservable();
 
-  private errorOrCancel: string[] = [];
+  private downloadAndUnzipSubscriptions: Subscription[] = [];
+  private cancel = false;
 
   constructor(
     private file: File,
@@ -66,27 +68,14 @@ export class OfflineMapService implements OnReset {
     // Read offline map package names
     const fileEntries = await this.file.listDir(path, mapsDir);
     const folders = fileEntries.filter((entry) => entry.isDirectory);
-    const packageNames = folders
-      .map((directoryEntry: Entry) => directoryEntry.name);
+    const packageNames = (await Promise.all(folders.map((directoryEntry: Entry) => this.hasCompleteFile(directoryEntry.name) ? directoryEntry.name : null))).filter((packageName) => packageName != null);
     this.loggingService.debug('packageNames', DEBUG_TAG, packageNames);
     
     // Read all folder metadata
     const folderMetadata = await Promise.all(folders.map((folder) => this.getDirectoryMetadata(folder)));
 
     // Read all package metadata
-    const metadata = await Promise.all(packageNames.map((name) => this.getMetadata(name)));
-
-    // Map to map package objects
-    const packages = packageNames.map((name, i): OfflineMapPackage => {
-      return {
-        name,
-        downloadStart: folderMetadata[i].modificationTime.getTime() / 1000,
-        downloadComplete: folderMetadata[i].modificationTime.getTime() / 1000,
-        size: folderMetadata[i].size,
-        progress: { percentage: 100 },
-        maps: metadata[i].maps
-      }
-    })
+    const packages = await Promise.all(packageNames.map((name) => this.getMetadata(name)));
 
     return packages;
   }
@@ -97,51 +86,84 @@ export class OfflineMapService implements OnReset {
     , (error) => reject(error)));
   }
 
-  private resetErrorOrCancelForPackageName(name: string) {
-    this.errorOrCancel = this.errorOrCancel.filter((list) => list !== name);
+  private getNameForPackageMetadata(packageMetadata: PackageMetadataCombined): string {
+    const [x, y, z] = packageMetadata.xyz;
+    return  `${x}-${y}-${z}`;
   }
 
-  public async downloadPackage(filename: string, url: string, sizeInMiB: number): Promise<void> {
+  public async downloadPackage(packageMetadataCombined: PackageMetadataCombined): Promise<void> {
+    this.cancel = false;
+
     //TODO: Ask user to prefer saving to external SD card if available?
-    const availableSpace = await this.checkAvailableDiskSpace(sizeInMiB);
+    const availableSpace = await this.checkAvailableDiskSpace(packageMetadataCombined.sizeInMib);
     if(!availableSpace) {
       return;
     }
 
-    const name = filename.replace('.zip', '');
-    this.resetErrorOrCancelForPackageName(name);
+    const name = this.getNameForPackageMetadata(packageMetadataCombined);
     
 
-    const mapPackage = await this.registerMapPackage(name, filename, sizeInMiB);
-    this.backgroundDownloadService.download(url).subscribe(async (downloadProgress) => {
+    const mapPackage = await this.registerMapPackage(name, packageMetadataCombined.sizeInMib);
+
+    const urls = packageMetadataCombined.packages.map((p) => p.urls).reduce((a, b) => a.concat(b), []);
+    const parts = urls.length;
+
+    this.downloadAndUnzipPart(name, urls[0], urls, mapPackage, 0, parts);
+  }
+
+  private cancelDownloadPackage() {
+    this.cancel = true;
+    for(const sub of this.downloadAndUnzipSubscriptions) {
+      sub.unsubscribe();
+    }
+    this.downloadAndUnzipSubscriptions = [];
+  }
+
+  private downloadAndUnzipPart(name: string, url: string, urls: string[], mapPackage: OfflineMapPackage, partNumber: number, totalParts: number) {
+    const subfolder = url.indexOf('steepness-outlet') >= 0 ? 'steepness-outlet' : 'statensKartverk'; // Hack to create subfolders in package name folder. For example package 135_74_8 needs to have folders 135_74_8/statensKartverk and 135_74_8/steepness-outlet
+    const folder = `${name}/${subfolder}`;
+    this.downloadAndUnzipSubscriptions.push(this.backgroundDownloadService.download(url).subscribe(async (downloadProgress) => {
       switch(downloadProgress.state) {
         case 'IN_PROGRESS':
-          if(downloadProgress.total !== mapPackage.size) {
-            mapPackage.size = downloadProgress.total;
-            this.updatePackageMetadata(mapPackage);
-          }
           this.onProgress(mapPackage, {step: ProgressStep.download,
-            percentage: downloadProgress.progress,
-            description: 'Downloading...'});
+            percentage: this.calculateTotalProgress(downloadProgress.progress, partNumber, totalParts, 'Downloading'),
+            description: `Download part ${partNumber+1}/${totalParts}`});
           break;
         case 'DONE':
              const file = downloadProgress.content;
              const root = await this.getRootFileUrl();
-             mapPackage.size = file.size;
-             this.updatePackageMetadata(mapPackage);
             await this.unzipFile(
                   file,
                   root,
-                  name,
-                  () => this.onUnzipComplete(mapPackage),
-                  (progress) => this.onProgress(mapPackage, progress),
+                  folder,
+                  () => this.onUnzipStepComplete(name, urls, mapPackage, partNumber, totalParts),
+                  (progress) => this.onProgress(mapPackage, {step: ProgressStep.extractZip,
+                    percentage: this.calculateTotalProgress(progress, partNumber, totalParts, 'Unzipping'),
+                    description: `Unzip ${partNumber+1}/${totalParts}`}),
                   (error) => this.onUnzipError(name, error)
             );
           break;
         default:
           break;
       }
-    }, (err) => this.onUnzipError(name, err));
+    }, (err) => this.onUnzipError(name, err)));
+  }
+
+  public calculateTotalProgress(currentProgress: number, currentPart: number, totalParts: number, partOfStep: 'Downloading' | 'Unzipping') {
+    const stepsForEachPart = 2; // Download and unzip
+    const totalPartsOfWork = totalParts * stepsForEachPart;
+    const currentPartOfWork = ((currentPart * stepsForEachPart) + (partOfStep === 'Downloading' ? 0 : 1)) / totalPartsOfWork;
+    const progressForTotalParts = (currentProgress / totalPartsOfWork) + (currentPartOfWork);
+    return progressForTotalParts;
+  }
+
+  private onUnzipStepComplete(name: string, urls: string[], mapPackage: OfflineMapPackage, partNumber: number, totalParts: number) {
+    const nextPart = partNumber + 1;
+    if(nextPart < totalParts) {
+      this.downloadAndUnzipPart(name, urls[nextPart], urls, mapPackage, nextPart, totalParts);
+    }else{
+      this.onDownloadAndUnzipComplete(mapPackage);
+    }
   }
 
   private async checkAvailableDiskSpace(sizeInMiB: number): Promise<boolean> {
@@ -193,14 +215,6 @@ export class OfflineMapService implements OnReset {
     alert.present();
   }
 
-  private updatePackageMetadata(metadata: OfflineMapPackage) {
-    const unzipProgress = this.unzipProgress.value.filter(p => p.name !== metadata.name);
-    this.unzipProgress.next([
-      ...unzipProgress,
-      metadata
-    ]);
-  }
-
   private getDeviceFreeDiskSpace(externalStorage: boolean = false): Promise<number> {
     return new Promise((resolve, reject) => {
       (window as any).DiskSpacePlugin.info({ location: externalStorage ? 2 : 1 }, (success) => resolve(success.free), (err) => reject(err));
@@ -222,31 +236,56 @@ export class OfflineMapService implements OnReset {
     this.packages.next(packages);
   }
 
+  private async readCompleteFile(packageName: string): Promise<{ size: number, downloadComplete: number }> {
+    const path = await this.getMapPackageFileUrl(packageName);
+    const completeFile = await this.file.resolveLocalFilesystemUrl(`${path}/COMPLETE`);
+    const doneSize = await this.file.readAsText(path, 'COMPLETE');
+    return new Promise((resolve, reject) => {
+      completeFile.getMetadata((success) => resolve({ size: +doneSize, downloadComplete: success.modificationTime.getTime() / 1000  }), (err) => reject(err));
+    });
+  }
+
+  private async hasCompleteFile(packageName: string): Promise<boolean> {
+    const path = await this.getMapPackageFileUrl(packageName);
+    return this.file.checkFile(path, 'COMPLETE');
+  }
+
   /**
    * @returns map package metadata
    */
-  private async getMetadata(packageName: string): Promise<OfflinePackageMetadata> {
+  private async getMetadata(packageName: string): Promise<OfflineMapPackage> {
     this.loggingService.debug('Reading metadata for package:', DEBUG_TAG, packageName);
     const path = await this.getMapPackageFileUrl(packageName);
-    this.loggingService.debug('Metadata path:', DEBUG_TAG, path);
-    const data = await this.file.readAsText(path, METADATA_FILE);
-    const metadata = JSON.parse(data) as OfflinePackageMetadata;
-    this.loggingService.debug('Metadata:', DEBUG_TAG, data);
+    const completeFile = await this.readCompleteFile(packageName);
 
-    // Set map urls
-    Object.values(metadata.maps).forEach(m => {
-      const fileUrl = path + m.path;
-      m.url = this.webView.convertFileSrc(fileUrl);
-    });
+    const offlineMapPackage: OfflineMapPackage = {
+      name: packageName,
+      downloadComplete: completeFile.downloadComplete,
+      size: completeFile.size,
+      maps: {},
+    };
 
-    return metadata;
+    const maps = ['steepness-outlet', 'statensKartverk'];
+    for(let map of maps) {
+      const metadataPath = `${path}/${map}`;
+      this.loggingService.debug('Metadata path:', DEBUG_TAG, metadataPath);
+      const data = await this.file.readAsText(metadataPath, METADATA_FILE);
+      const metadata = JSON.parse(data) as OfflineTilesMetadata;
+      this.loggingService.debug('Metadata:', DEBUG_TAG, data);
+
+      offlineMapPackage.maps[map] = { ...metadata, url: this.webView.convertFileSrc(`${path}/${map}`) };
+    }
+
+    this.loggingService.debug('Offline map package metadata: ', DEBUG_TAG, offlineMapPackage);
+
+    return offlineMapPackage;
   }
 
-  async registerMapPackage(name: string, filename: string, sizeInMb: number): Promise<OfflineMapPackage> {
+  async registerMapPackage(name: string, sizeInMiB: number): Promise<OfflineMapPackage> {
     const mapPackage: OfflineMapPackage = {
       name: name,
-      size: sizeInMb * 1000 * 1000,
-      filename: filename,
+      size: sizeInMiB * 1024 * 1024,
+      // filename: name,
       downloadStart: moment().unix(),
       progress: { percentage: 0, step: ProgressStep.download, description: 'Downloading...' },
       downloadComplete: null,
@@ -265,7 +304,7 @@ export class OfflineMapService implements OnReset {
     path: string,
     folder: string,
     onComplete: () => void,
-    onProgress: (progress: Progress) => void,
+    onProgress: (progress: number) => void,
     onError: (error: Error) => void
   ): Promise<void> {
     try {
@@ -281,11 +320,14 @@ export class OfflineMapService implements OnReset {
       );
       const directories = zipEntries.filter((name) => content.files[name].dir);
 
-      if(!isAndroidOrIos(this.platform)) {
-        throw Error('Unzip file not implemented on web!')
-      }
+      // if(!isAndroidOrIos(this.platform)) {
+      //   throw Error('Unzip file not implemented on web!')
+      // }
 
-      this.loggingService.debug('Creating directories');
+      this.loggingService.debug(`Creating directories path: ${path}. Folder: ${folder}`);
+      if(folder.indexOf('/') >= 0) {
+        await this.file.createDir(path, folder.split('/')[0], true); //Create package folder (f.eks 135-74-8)
+      }
       await this.file.createDir(path, folder, true);
       const root = `${path}/${folder}`;
       for (const dir of directories) {
@@ -297,15 +339,17 @@ export class OfflineMapService implements OnReset {
       const mod = Math.floor(files.length / 100);
 
       const unzipFile = async (fileName: string) => {
-        if(this.errorOrCancel.indexOf(folder) >= 0) {
+        if(this.cancel) {
           return;
         }
         const zippedFile: JSZip.JSZipObject = content.files[fileName];
         const buffer = await zippedFile.async('arraybuffer');
 
-        await this.file.writeFile(root, fileName, buffer, {
-          replace: true
-        });
+        if(isAndroidOrIos(this.platform)){
+          await this.file.writeFile(root, fileName, buffer, {
+            replace: true
+          });
+        }
 
         i++;
         if (i % mod === 0) {
@@ -314,11 +358,7 @@ export class OfflineMapService implements OnReset {
             DEBUG_TAG
           );
 
-          await onProgress({
-            percentage: i / files.length, //TODO: report on file size will give better progress estimate
-            step: ProgressStep.extractZip,
-            description: 'Unzip files'
-          });
+          onProgress(i / files.length);
         }
       };
 
@@ -347,14 +387,19 @@ export class OfflineMapService implements OnReset {
       DEBUG_TAG,
       `Error downloading map ${name}`
     );
-    this.errorOrCancel.push(name);
     this.showDownloadOrUnzipErrorMessage();
     this.removeMapPackageByName(name);
   }
 
-  private async onUnzipComplete(mapPackage: OfflineMapPackage) {
+  private async onDownloadAndUnzipComplete(mapPackage: OfflineMapPackage) {
     mapPackage.downloadComplete = moment().unix();
     mapPackage.progress = { percentage: 1.0 };
+
+    // Store new combined metadata
+    if(isAndroidOrIos(this.platform)) {
+      const path = await this.getMapPackageFileUrl(mapPackage.name);
+      await this.file.writeFile(path, 'COMPLETE', `${mapPackage.size}`);
+    }
     
     // Remove from progress tracking
     const unzipProgress = this.unzipProgress.value.filter(p => p.name !== mapPackage.name);
@@ -447,7 +492,7 @@ export class OfflineMapService implements OnReset {
         this.loggingService.error(
           err,
           'background download native',
-          `remove folder failed: ${path}${dirName}`
+          `remove folder failed: ${path}/${dirName}`
         );
       });
   }

--- a/src/app/modules/shared/services/logging/console-logging.service.ts
+++ b/src/app/modules/shared/services/logging/console-logging.service.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-console */
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 import { LogLevel } from './log-level.model';
 import { LoggingService } from './logging.service';
 import { AppMode } from '../../../../core/models/app-mode.enum';
@@ -15,7 +15,7 @@ import { FileLoggingService } from './file-logging.service';
 })
 export class ConsoleLoggingService implements LoggingService {
 
-  constructor(private fileLoggingService: FileLoggingService) {}
+  constructor(@Optional() private fileLoggingService: FileLoggingService) {}
 
   enable(): void {}
 
@@ -45,7 +45,7 @@ export class ConsoleLoggingService implements LoggingService {
     tag?: string,
     ...optionalParams: any[]
   ) {
-    if (this.fileLoggingService.isReady()) {
+    if (this.fileLoggingService != null && this.fileLoggingService.isReady()) {
       this.fileLoggingService.log(message, error, level, tag, optionalParams, error);        
     }
     const msg = `[${level.toUpperCase()}]${

--- a/src/app/modules/shared/services/logging/test-logging.service.ts
+++ b/src/app/modules/shared/services/logging/test-logging.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { AppMode } from '../../../../core/models/app-mode.enum';
+import { LoggedInUser } from '../../../login/models/logged-in-user.model';
+import { LogLevel } from './log-level.model';
+import { LoggingService } from './logging.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TestLoggingService implements LoggingService {
+  configureLogging(appMode: AppMode) {
+    
+  }
+  setUser(user: LoggedInUser) {
+  }
+  error(error: Error, tag?: string, message?: string, ...optionalParams: any[]) {
+   
+  }
+  debug(message: string, tag?: string, ...optionalParams: any[]) {
+    
+  }
+  log(message?: string, error?: Error, level?: LogLevel, tag?: string, ...optionalParams: any[]) {
+    
+  }
+  enable() {
+   
+  }
+  disable() {
+   
+  }
+}

--- a/src/app/modules/test/test.module.ts
+++ b/src/app/modules/test/test.module.ts
@@ -1,6 +1,5 @@
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { LoggingService } from '../shared/services/logging/logging.service';
-import { ConsoleLoggingService } from '../shared/services/logging/console-logging.service';
 import { SharedModule } from '../shared/shared.module';
 import {
   TranslateModule,
@@ -15,6 +14,7 @@ import { UserSettingService } from '../../core/services/user-setting/user-settin
 import { AngularSvgIconModule } from 'angular-svg-icon';
 import { HttpClient } from '@angular/common/http';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { TestLoggingService } from '../shared/services/logging/test-logging.service';
 
 function createTranslateLoader(http: HttpClient) {
   return new TranslateHttpLoader(http, '../assets/i18n/', '.json');
@@ -41,7 +41,7 @@ function createTranslateLoader(http: HttpClient) {
       deps: [TranslateService, UserSettingService],
       multi: true
     },
-    { provide: LoggingService, useClass: ConsoleLoggingService }
+    { provide: LoggingService, useClass: TestLoggingService },
   ]
 })
 export class TestModule {}

--- a/src/app/pages/offline-map/metadata.model.ts
+++ b/src/app/pages/offline-map/metadata.model.ts
@@ -2,6 +2,13 @@ export interface PackageMetadata {
     name: string;
     lastModified: string;
     xyz: number[];
-    url: string;
-    sizeInMb: number;
+    urls: string[];
+    sizeInMib: number;
+  }
+
+  export interface PackageMetadataCombined {
+    name: string;
+    xyz: number[];
+    sizeInMib: number;
+    packages: PackageMetadata[];
   }

--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -23,12 +23,11 @@
       <ion-item (click)="presentActionSheet(item)" *ngFor="let item of packages$ | async">
         <ion-label>{{ item.name }}</ion-label>
         <ion-label>{{ humanReadableByteSize(item.size) }}</ion-label>
-        <ion-label>{{ item.progress?.description }}</ion-label>
+        <!-- <ion-label>{{ item.progress?.description }}</ion-label> -->
         <ion-label *ngIf="isDownloading(item)">
           ({{getPercentage(item) +'%' }})</ion-label>
         <ion-icon slot="end" *ngIf="!!item.downloadComplete" name="checkmark"></ion-icon>
-        <ion-icon slot="end" *ngIf="item.progress?.step === 0" name="cloud-download-outline"></ion-icon>
-        <ion-icon slot="end" *ngIf="item.progress?.step === 1" name="sync-circle-outline"></ion-icon>
+        <ion-icon slot="end" *ngIf="!item.downloadComplete" name="cloud-download-outline"></ion-icon>
       </ion-item>
     </ion-list>
   </div>

--- a/src/app/pages/offline-map/offline-package-modal.component.ts
+++ b/src/app/pages/offline-map/offline-package-modal.component.ts
@@ -1,11 +1,9 @@
 import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
 import { ModalController } from '@ionic/angular';
 import * as L from 'leaflet';
-import * as turf from '@turf/turf';
 import { Polygon, Feature } from 'geojson';
-import { PackageMetadata } from './metadata.model';
+import { PackageMetadataCombined } from './metadata.model';
 import { OfflineMapService } from 'src/app/core/services/offline-map/offline-map.service';
-import { ExternalLinkService } from 'src/app/core/services/external-link/external-link.service';
 
 @Component({
   template: `
@@ -29,13 +27,13 @@ import { ExternalLinkService } from 'src/app/core/services/external-link/externa
         ></app-map>
       </div>
       <ion-grid>
-        <ion-row>
+        <!-- <ion-row>
           <ion-col class="right">Produsert:</ion-col>
           <ion-col>{{ package.properties.lastModified }}</ion-col>
-        </ion-row>
+        </ion-row> -->
         <ion-row>
           <ion-col class="right">Størrelse:</ion-col>
-          <ion-col>{{ package.properties.sizeInMb }} MB</ion-col>
+          <ion-col>{{ package.properties.sizeInMib }} MiB</ion-col>
         </ion-row>
         <ion-row>
           <ion-col>
@@ -65,7 +63,7 @@ import { ExternalLinkService } from 'src/app/core/services/external-link/externa
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OfflinePackageModalComponent implements OnInit {
-  @Input() package: Feature<Polygon, PackageMetadata>;
+  @Input() package: Feature<Polygon, PackageMetadataCombined>;
 
   zoom = 13;
   center: number[];
@@ -73,7 +71,6 @@ export class OfflinePackageModalComponent implements OnInit {
 
   constructor(
     private modalController: ModalController,
-    private externalLinkService: ExternalLinkService,
     private offlineMapService: OfflineMapService
   ) { }
 
@@ -95,12 +92,9 @@ export class OfflinePackageModalComponent implements OnInit {
 
   startDownload() {
     this.offlineMapService.downloadPackage(
-      this.package.properties.name,
-      this.package.properties.url,
-      this.package.properties.sizeInMb
+      this.package.properties
     );
     this.dismiss();
-    // window.open(this.package.properties.url, '_blank');
   }
 
   dismiss() {


### PR DESCRIPTION
Downloads new package format with "statensKartverk" and "steepness-outlet" maps separated in each package. Also downloads multiple zip parts and extracts to map package folder.

Writes "COMPLETE" file when map package has completed extracting all files.
Only add offline map packages where "COMPLETE" file exists.

Also fixed unit tests so they don't fail and added couple of tests to offline-map.service.spec to calculate total progress.