### PR TITLE
RO-1369: Test av å hente observasjoner inntil 3 år tilbake

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -38,9 +38,9 @@ export const settings = {
     }
   },
   observations: {
-    maxObservationsToFetch: 5000,
+    maxObservationsToFetch: 100000,
     daysBack: {
-      Snow: [0, 1, 2, 3, 7, 7 * 2],
+      Snow: [0, 1, 2, 3, 7, 7 * 2, 365 / 2, 365, 2 * 365, 3 * 365],
       Ice: [0, 1, 2, 7, 7 * 4, 7 * 12],
       Water: [0, 1, 2, 3, 7, 7 * 2],
       Dirt: [0, 1, 2, 3, 7, 7 * 2]


### PR DESCRIPTION
Har lagt til flere valg i filteret for tidsrom, så vi kan teste hvordan det funker å hente observasjoner inntil 3 år tilbake.
Det er kun for snø at man kan hente flere observasjoner enn før.
Denne skal ikke flettes inn!
PR'en er kun for å kunne fyre opp en test-app med denne funksjonen.