### PR TITLE
Feature/ro 1434 image upload

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,7 @@
       "error",
       {
         "ignorePattern": "^import |// import",
-        "code": 200
+        "code": 140
       }
     ],
     "no-multiple-empty-lines": [

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "trailingComma": "none",
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "printWidth": 200
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,5 @@
   "singleQuote": true,
   "trailingComma": "none",
   "endOfLine": "auto",
-  "printWidth": 200
+  "printWidth": 140
 }

--- a/src/app/modules/common-registration/models/attachment-upload-edit.interface.ts
+++ b/src/app/modules/common-registration/models/attachment-upload-edit.interface.ts
@@ -4,14 +4,14 @@ export interface AttachmentUploadEditModel extends AttachmentEditModel {
   id: string;
   type: AttachmentType;
   fileSize?: number;
-  fileName?: string;
+  fileName?: string; //attachment filename
   error?: Error;
-  ref?: string;  // Guid
+  ref?: string; // Guid
 }
 
 export type ExistingOrNewAttachmentModel = AttachmentUploadEditModel | AttachmentEditModel;
 export type NewAttachmentType = 'new';
-export type ExistingAttachmentType = 'existing'
+export type ExistingAttachmentType = 'existing';
 export type ExistingOrNewAttachmentType = NewAttachmentType | ExistingAttachmentType;
 export interface ExistingOrNewAttachment {
   type: ExistingOrNewAttachmentType;

--- a/src/app/modules/common-registration/registration.module.ts
+++ b/src/app/modules/common-registration/registration.module.ts
@@ -15,6 +15,7 @@ import { RegobsRegistrationPipesModule } from './registration.pipes';
 import { OfflineDbNewAttachmentService } from './services/add-new-attachment/offline-db-new-attachment.service';
 import { FOR_ROOT_OPTIONS_TOKEN, IRegistrationModuleOptions, SUMMARY_PROVIDER_TOKEN } from './module.options';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import FileAttachmentService from './services/add-new-attachment/file-attachment.service';
 
 export function offlineDbServiceOptionsFactory(options?: IRegistrationModuleOptions): OfflineDbServiceOptions {
   const offlineDbServiceOptions = new OfflineDbServiceOptions();
@@ -38,7 +39,7 @@ export function getFakeHelpTextApiService(): unknown {
   return fakeService;
 }
 
-export function createTranslateLoader(http: HttpClient): TranslateHttpLoader  {
+export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
 }
 
@@ -51,19 +52,13 @@ export const translateModuleForRoot = TranslateModule.forRoot({
 });
 
 @NgModule({
-  imports: [
-    CoreModule,
-    RegobsApiModuleWithConfig,
-    translateModuleForRoot,
-  ],
+  imports: [CoreModule, RegobsApiModuleWithConfig, translateModuleForRoot],
   declarations: [],
-  exports: [
-    RegobsRegistrationPipesModule,
-  ]
+  exports: [RegobsRegistrationPipesModule]
 })
 export class RegistrationModule {
   static forRoot(options?: IRegistrationModuleOptions): ModuleWithProviders<RegistrationModule> {
-    return ({
+    return {
       ngModule: RegistrationModule,
       providers: [
         {
@@ -76,13 +71,18 @@ export class RegistrationModule {
           deps: [FOR_ROOT_OPTIONS_TOKEN]
         },
         {
-          provide: 'OfflineRegistrationSyncService', useClass: RegobsApiSyncCallbackService
+          provide: 'OfflineRegistrationSyncService',
+          useClass: RegobsApiSyncCallbackService
         },
         {
-          provide: SUMMARY_PROVIDER_TOKEN, useClass: GeneralObservationSummaryProvider, multi: true
+          provide: SUMMARY_PROVIDER_TOKEN,
+          useClass: GeneralObservationSummaryProvider,
+          multi: true
         },
         {
-          provide: SUMMARY_PROVIDER_TOKEN, useClass: WeatherSummaryProvider, multi: true
+          provide: SUMMARY_PROVIDER_TOKEN,
+          useClass: WeatherSummaryProvider,
+          multi: true
         },
         {
           provide: HTTP_INTERCEPTORS,
@@ -90,11 +90,12 @@ export class RegistrationModule {
           multi: true
         },
         {
-          provide: NewAttachmentService, useClass: OfflineDbNewAttachmentService
+          provide: NewAttachmentService,
+          useClass: window.hasOwnProperty('cordova') ? FileAttachmentService : OfflineDbNewAttachmentService
         },
-        TranslateService,
+        TranslateService
       ]
-    });
+    };
   }
 
   static forChild(options?: IRegistrationModuleOptions): ModuleWithProviders<RegistrationModule> {
@@ -102,7 +103,7 @@ export class RegistrationModule {
   }
 
   static forTesting(): ModuleWithProviders<RegistrationModule> {
-    return ({
+    return {
       ngModule: RegistrationModule,
       providers: [
         {
@@ -111,23 +112,29 @@ export class RegistrationModule {
         },
         {
           provide: OfflineDbServiceOptions,
-          useValue: { adapter: 'memory' },
+          useValue: { adapter: 'memory' }
         },
         {
-          provide: 'OfflineRegistrationSyncService', useClass: FakeItemSyncCallbackService
+          provide: 'OfflineRegistrationSyncService',
+          useClass: FakeItemSyncCallbackService
         },
         {
-          provide: SUMMARY_PROVIDER_TOKEN, useClass: GeneralObservationSummaryProvider, multi: true
+          provide: SUMMARY_PROVIDER_TOKEN,
+          useClass: GeneralObservationSummaryProvider,
+          multi: true
         },
         {
-          provide: SUMMARY_PROVIDER_TOKEN, useClass: WeatherSummaryProvider, multi: true
+          provide: SUMMARY_PROVIDER_TOKEN,
+          useClass: WeatherSummaryProvider,
+          multi: true
         },
         {
-          provide: NewAttachmentService, useClass: OfflineDbNewAttachmentService
+          provide: NewAttachmentService,
+          useClass: OfflineDbNewAttachmentService
         },
         { provide: KdvElementsService, useFactory: getFakeKdvElementsService },
-        { provide: HelpTextApiService, useFactory: getFakeHelpTextApiService },
+        { provide: HelpTextApiService, useFactory: getFakeHelpTextApiService }
       ]
-    });
+    };
   }
 }

--- a/src/app/modules/common-registration/services/add-new-attachment/file-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/file-attachment.service.ts
@@ -141,11 +141,17 @@ export default class FileAttachmentService implements NewAttachmentService {
   }
 
   private async removeAttachmentInternal(registrationId: string, attachmentId: string): Promise<boolean> {
-    const path = `${await this.getRootPath()}/${registrationId}/`;
+    const rootPath = await this.getRootPath();
+    const path = `${rootPath}/${registrationId}/`;
     const metadataFileName = this.getMetadataFileName(attachmentId);
     const metadata = await this.readMetadataFile(registrationId, metadataFileName);
     await this.file.removeFile(path, metadata.fileName);
     await this.file.removeFile(path, metadataFileName);
+
+    const remainingEntries = await this.file.listDir(rootPath, registrationId);
+    if (remainingEntries.length === 0) {
+      await this.file.removeDir(rootPath, registrationId);
+    }
     this.attachmentsChanged.next();
     return true;
   }

--- a/src/app/modules/common-registration/services/add-new-attachment/file-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/file-attachment.service.ts
@@ -1,0 +1,154 @@
+import { GeoHazard, uuidv4 } from '@varsom-regobs-common/core';
+import { filter, from, Observable, Subject, switchMap, tap } from 'rxjs';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { AttachmentType, AttachmentUploadEditModel } from '../../models/attachment-upload-edit.interface';
+import { RegistrationTid } from '../../registration.models';
+import { NewAttachmentService } from './new-attachment.service';
+import { File } from '@ionic-native/file/ngx';
+import { Injectable } from '@angular/core';
+
+const DEBUG_TAG = 'FileAttachmentService';
+const ROOT_DIR = 'attachments';
+
+/**
+ * Provides attachments saved on local drive
+ */
+@Injectable()
+export default class FileAttachmentService implements NewAttachmentService {
+  private hasCreatedRootFolder = false;
+  private registrationIdEvents = new Subject<string>(); //get a tick with registrationId each time a registration's attachment changes
+
+  constructor(private file: File, private loggingService: LoggingService) {
+    this.registrationIdEvents.pipe(tap((registrationId) => this.loggingService.debug(`Attachments changed for registrationId ${registrationId}`, DEBUG_TAG)));
+  }
+
+  async addAttachment(registrationId: string, data: Blob, mimeType: string, geoHazard: GeoHazard, registrationTid: RegistrationTid, type?: AttachmentType, ref?: string): Promise<void> {
+    const rootDir = await this.getRootPath();
+    await this.file.createDir(rootDir, registrationId, true);
+    const attachmentId = uuidv4();
+
+    const attachmentFileName = `${attachmentId}.${this.getFileExtension(mimeType)}`;
+    await this.file.writeFile(`${rootDir}/${registrationId}`, attachmentFileName, data, { replace: true });
+
+    const metadata: AttachmentUploadEditModel = {
+      GeoHazardTID: geoHazard,
+      RegistrationTID: registrationTid,
+      AttachmentMimeType: mimeType,
+      id: attachmentId,
+      type,
+      fileSize: data.size,
+      fileName: attachmentFileName,
+      ref
+    };
+    this.loggingService.debug(`Attachment saved in ${rootDir}/${registrationId}/${attachmentFileName}`, DEBUG_TAG, metadata);
+    this.saveAttachmentMeta(registrationId, metadata);
+  }
+
+  saveAttachmentMeta$(registrationId: string, meta: AttachmentUploadEditModel): Observable<unknown> {
+    return from(this.getRootPath().then((rootDir) => this.file.writeFile(`${rootDir}/${registrationId}`, `${meta.id}.json`, JSON.stringify(meta), { replace: true })));
+  }
+
+  saveAttachmentMeta(registrationId: string, meta: AttachmentUploadEditModel): void {
+    this.saveAttachmentMeta$(registrationId, meta)
+      .pipe(tap(() => this.registrationIdEvents.next(registrationId))) //TODO: Dette burde vi gjort i saveAttachmentMeta$() fordi denne kan også kalles direkte
+      .subscribe();
+  }
+
+  getAttachments(registrationId: string): Observable<AttachmentUploadEditModel[]> {
+    return this.registrationIdEvents.pipe(
+      filter((registrationIdForEvent) => registrationId === registrationIdForEvent),
+      switchMap((registrationId) => from(this.getAttachmentsFromFile(registrationId)))
+    );
+    // return from(this.getAttachmentsFromFile(registrationId)); //TODO: SKal nok være levende, så må poste events hver gang vi legger til fil eller sletter en fil
+  }
+
+  getBlob(registrationId: string, attachmentId: string): Observable<Blob> {
+    return from(this.getBlobInternal(registrationId, attachmentId));
+  }
+
+  removeAttachment$(registrationId: string, attachmentId: string): Observable<boolean> {
+    return from(this.removeAttachmentInternal(registrationId, attachmentId));
+  }
+
+  removeAttachment(registrationId: string, attachmentId: string): void {
+    this.removeAttachment$(registrationId, attachmentId).subscribe();
+  }
+
+  async removeAttachments(registrationId: string): Promise<void> {
+    const path = await this.getRootPath();
+    await this.file.removeDir(path, registrationId);
+    //TODO: Gi beskjed om endringer
+  }
+
+  removeAttachments$(registrationId: string): Observable<void> {
+    return from(this.removeAttachments(registrationId));
+  }
+
+  /**
+   * Get file url for data directory
+   * @returns file url as string, with trailing /
+   */
+  private getDataDirectoryFileUrl(): string {
+    if (this.file && this.file.dataDirectory) {
+      const fileUrl = this.file.dataDirectory;
+      return fileUrl;
+    }
+    return undefined;
+  }
+
+  /**
+   * Get root directory folder path
+   * @returns directory path as string
+   */
+  private async getRootPath(): Promise<string> {
+    const dataFolder = this.getDataDirectoryFileUrl();
+    if (!this.hasCreatedRootFolder) {
+      await this.file.createDir(dataFolder, ROOT_DIR, true);
+      this.hasCreatedRootFolder = true;
+    }
+    return `${dataFolder}/${ROOT_DIR}`;
+  }
+
+  private async getAttachmentsFromFile(registrationId: string): Promise<AttachmentUploadEditModel[]> {
+    const path = await this.getRootPath();
+    const entries = await this.file.listDir(path, registrationId);
+    return await Promise.all(entries.filter((entry) => entry.isFile).map((entry) => this.readMetadataFile(registrationId, entry.name)));
+  }
+
+  private async readMetadataFile(registrationId: string, filename: string): Promise<AttachmentUploadEditModel> {
+    const rootDir = await this.getRootPath();
+    const content = await this.file.readAsText(`${rootDir}/${registrationId}`, filename);
+    return JSON.parse(content);
+  }
+
+  private async getBlobInternal(registrationId: string, attachmentId: string): Promise<Blob> {
+    const rootDir = await this.getRootPath();
+    const metadata = await this.readMetadataFile(registrationId, `${attachmentId}.json`);
+    const buffer = await this.file.readAsArrayBuffer(`${rootDir}/${registrationId}`, metadata.fileName);
+    return new Blob([buffer], { type: metadata.AttachmentMimeType });
+  }
+
+  private async removeAttachmentInternal(registrationId: string, attachmentId: string): Promise<boolean> {
+    const rootPath = await this.getRootPath();
+    const metadataFileName = this.getMetadataFileName(attachmentId);
+    const metadata = await this.readMetadataFile(registrationId, metadataFileName);
+    await this.file.removeFile(rootPath, metadata.fileName);
+    await this.file.removeFile(rootPath, metadataFileName);
+    return true;
+    //TODO: Gi beskjed om endringer
+  }
+
+  private getMetadataFileName(attachmentId: string): string {
+    return `${attachmentId}.json`;
+  }
+
+  private getFileExtension(mimeType: string): string {
+    switch (mimeType) {
+      case 'image/jpeg':
+        return 'jpg';
+      case 'image/png':
+        return 'png';
+    }
+    return 'jpg';
+  }
+}

--- a/src/app/modules/common-registration/services/add-new-attachment/new-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/new-attachment.service.ts
@@ -2,15 +2,22 @@ import { Observable } from 'rxjs';
 import { GeoHazard } from '@varsom-regobs-common/core';
 import { AttachmentType, AttachmentUploadEditModel, RegistrationTid } from '../../registration.models';
 
+/**
+ * Handle storage of new registration attachments on client before they are sent to server
+ */
 export abstract class NewAttachmentService {
   abstract addAttachment(registrationId: string, data: Blob, mimeType: string, geoHazard: GeoHazard, registrationTid: RegistrationTid, type?: AttachmentType, ref?: string): void;
-  abstract saveAttachmentMeta$(meta: AttachmentUploadEditModel): Observable<unknown>;
-  abstract saveAttachmentMeta(meta: AttachmentUploadEditModel): void;
-  abstract getUploadedAttachments(registrationId: string): Observable<AttachmentUploadEditModel[]>;
-  abstract getUploadedAttachment(registrationId: string, attachmentId: string): Observable<AttachmentUploadEditModel>;
+  abstract saveAttachmentMeta$(registrationId: string, meta: AttachmentUploadEditModel): Observable<unknown>;
+  abstract saveAttachmentMeta(registrationId: string, meta: AttachmentUploadEditModel): void;
+
+  /**
+   * Get list of attachment metadata each time an attachment (or attachment metadata) changes on provided registration
+   */
+  abstract getAttachments(registrationId: string): Observable<AttachmentUploadEditModel[]>;
+
   abstract getBlob(registrationId: string, attachmentId: string): Observable<Blob>;
   abstract removeAttachment(registrationId: string, attachmentId: string): void;
   abstract removeAttachment$(registrationId: string, attachmentId: string): Observable<boolean>;
-  abstract removeAttachmentsForRegistration(registrationId: string): Promise<void>;
-  abstract removeAttachmentsForRegistration$(registrationId: string): Observable<void>;
+  abstract removeAttachments(registrationId: string): Promise<void>;
+  abstract removeAttachments$(registrationId: string): Observable<void>;
 }

--- a/src/app/modules/common-registration/services/add-new-attachment/new-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/new-attachment.service.ts
@@ -6,9 +6,16 @@ import { AttachmentType, AttachmentUploadEditModel, RegistrationTid } from '../.
  * Handle storage of new registration attachments on client before they are sent to server
  */
 export abstract class NewAttachmentService {
-  abstract addAttachment(registrationId: string, data: Blob, mimeType: string, geoHazard: GeoHazard, registrationTid: RegistrationTid, type?: AttachmentType, ref?: string): void;
+  abstract addAttachment(
+    registrationId: string,
+    data: Blob,
+    mimeType: string,
+    geoHazard: GeoHazard,
+    registrationTid: RegistrationTid,
+    type?: AttachmentType,
+    ref?: string
+  ): Promise<void>;
   abstract saveAttachmentMeta$(registrationId: string, meta: AttachmentUploadEditModel): Observable<unknown>;
-  abstract saveAttachmentMeta(registrationId: string, meta: AttachmentUploadEditModel): void;
 
   /**
    * Get list of attachment metadata each time an attachment (or attachment metadata) changes on provided registration

--- a/src/app/modules/common-registration/services/add-new-attachment/offline-db-new-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/offline-db-new-attachment.service.ts
@@ -1,63 +1,77 @@
 import { Injectable } from '@angular/core';
-import { combineLatest, concat, EMPTY, forkJoin, from, Observable, of } from 'rxjs';
+import { combineLatest, EMPTY, forkJoin, from, Observable, of } from 'rxjs';
 import { AppMode, AppModeService, GeoHazard, LoggerService, uuidv4 } from '@varsom-regobs-common/core';
 import { AttachmentType, AttachmentUploadEditModel } from '../../models/attachment-upload-edit.interface';
 import { OfflineDbService, TABLE_NAMES } from '../offline-db/offline-db.service';
 import { NewAttachmentService } from './new-attachment.service';
-import { catchError, filter, map, startWith, switchMap, take, toArray, withLatestFrom } from 'rxjs/operators';
+import { catchError, filter, map, startWith, switchMap, take } from 'rxjs/operators';
 import { RxAttachmentMetaCollection, RxAttachmentMetaDocument, RxRegistrationCollection, RxRegistrationDocument } from '../../db/RxDB';
 import { RegistrationTid } from '../../models/registration-tid.enum';
 
 @Injectable()
 export class OfflineDbNewAttachmentService implements NewAttachmentService {
-
-  constructor(
-    private offlineDbService: OfflineDbService,
-    protected appModeService: AppModeService,
-    protected loggerService: LoggerService
-  ) {}
+  constructor(private offlineDbService: OfflineDbService, protected appModeService: AppModeService, protected loggerService: LoggerService) {}
 
   addAttachment(registrationId: string, data: Blob, mimeType: string, geoHazard: GeoHazard, registrationTid: RegistrationTid, type?: AttachmentType, ref?: string): void {
     const attachmentId = uuidv4();
-    this.getRegistrationOfflineDocumentById(registrationId).pipe(take(1), switchMap((doc) =>
-      this.saveAttachmentMeta$({
-        id: attachmentId,
-        AttachmentMimeType: mimeType,
-        GeoHazardTID: geoHazard,
-        RegistrationTID: registrationTid,
-        type,
-        ref,
-        fileSize: data.size,
-      }).pipe(switchMap(() => from(doc.putAttachment({
-        id: attachmentId,
-        data,
-        type: mimeType
-      }
-      ))))), catchError((err) => {
-      this.loggerService.error(() => 'Could not add attachment', err);
-      return EMPTY;
-    })).subscribe();
+    this.getRegistrationOfflineDocumentById(registrationId)
+      .pipe(
+        take(1),
+        switchMap((doc) =>
+          this.saveAttachmentMeta$(registrationId, {
+            id: attachmentId,
+            AttachmentMimeType: mimeType,
+            GeoHazardTID: geoHazard,
+            RegistrationTID: registrationTid,
+            type,
+            ref,
+            fileSize: data.size
+          }).pipe(
+            switchMap(() =>
+              from(
+                doc.putAttachment({
+                  id: attachmentId,
+                  data,
+                  type: mimeType
+                })
+              )
+            )
+          )
+        ),
+        catchError((err) => {
+          this.loggerService.error(() => 'Could not add attachment', err);
+          return EMPTY;
+        })
+      )
+      .subscribe();
   }
 
-  saveAttachmentMeta(meta: AttachmentUploadEditModel): void {
-    this.saveAttachmentMeta$(meta).pipe(catchError((err) => {
-      this.loggerService.error(() => 'Could not save attachment metadata', err);
-      return EMPTY;
-    })).subscribe();
+  saveAttachmentMeta(registrationId: string, meta: AttachmentUploadEditModel): void {
+    this.saveAttachmentMeta$(registrationId, meta)
+      .pipe(
+        catchError((err) => {
+          this.loggerService.error(() => 'Could not save attachment metadata', err);
+          return EMPTY;
+        })
+      )
+      .subscribe();
   }
 
-  getUploadedAttachments(registrationId: string): Observable<AttachmentUploadEditModel[]> {
+  getAttachments(registrationId: string): Observable<AttachmentUploadEditModel[]> {
     return combineLatest([this.getRegistrationOfflineDocumentById(registrationId), this.getAnyChangesToMetaData$()]).pipe(
-      switchMap(([doc]) => ((doc && doc.allAttachments().length > 0) ? this.getAttachmentMetaFromDocument(doc) : of([]))));
+      switchMap(([doc]) => (doc && doc.allAttachments().length > 0 ? this.getAttachmentMetaFromDocument(doc) : of([])))
+    );
   }
 
   private getAnyChangesToMetaData$() {
     return this.getAttachmentMetaDbCollectionForAppMode().pipe(
-      switchMap((collection) => collection.$), startWith({}));
+      switchMap((collection) => collection.$),
+      startWith({})
+    );
   }
 
-  getUploadedAttachment(registrationId: string, attachmentId: string): Observable<AttachmentUploadEditModel> {
-    return this.getUploadedAttachments(registrationId).pipe(map((result) => result.find((a) => a.id === attachmentId)));
+  getAttachment(registrationId: string, attachmentId: string): Observable<AttachmentUploadEditModel> {
+    return this.getAttachments(registrationId).pipe(map((result) => result.find((a) => a.id === attachmentId)));
   }
 
   getBlob(registrationId: string, attachmentId: string): Observable<Blob> {
@@ -65,7 +79,7 @@ export class OfflineDbNewAttachmentService implements NewAttachmentService {
       filter((doc) => !!doc),
       switchMap((doc) => of(doc.getAttachment(attachmentId))),
       filter((attachment) => !!attachment),
-      switchMap((attachment) => from(attachment.getData() as Promise<Blob>)),
+      switchMap((attachment) => from(attachment.getData() as Promise<Blob>))
     );
   }
 
@@ -73,27 +87,34 @@ export class OfflineDbNewAttachmentService implements NewAttachmentService {
     this.removeAttachment$(registrationId, attachmentId).subscribe();
   }
 
-  removeAttachmentsForRegistration$(registrationId: string): Observable<void> {
-    return from(this.removeAttachmentsForRegistration(registrationId));
+  removeAttachments$(registrationId: string): Observable<void> {
+    return from(this.removeAttachments(registrationId));
   }
 
   removeAttachment$(registrationId: string, attachmentId: string): Observable<boolean> {
-    return this.getRegistrationAttachmentDocument(registrationId, attachmentId)
-      .pipe(take(1), switchMap((a) => from(a.remove())),
-        switchMap(() => this.getAttachmentMetaDocument(attachmentId).pipe(take(1), switchMap((metaDoc) => from(metaDoc.remove())))));
+    return this.getRegistrationAttachmentDocument(registrationId, attachmentId).pipe(
+      take(1),
+      switchMap((a) => from(a.remove())),
+      switchMap(() =>
+        this.getAttachmentMetaDocument(attachmentId).pipe(
+          take(1),
+          switchMap((metaDoc) => from(metaDoc.remove()))
+        )
+      )
+    );
   }
 
-  async removeAttachmentsForRegistration(registrationId: string): Promise<void> {
+  async removeAttachments(registrationId: string): Promise<void> {
     const regDoc = await this.getRegistrationOfflineDocumentById(registrationId).pipe(take(1)).toPromise();
-    if(!regDoc) {
+    if (!regDoc) {
       this.loggerService.debug('No registration document found!');
       return;
     }
     const metaDocs = await this.getAttachmentMetaDocumentsFromRegistrationDocument(regDoc).pipe(take(1)).toPromise();
-    for(const metaDoc of metaDocs) {
-      try{
+    for (const metaDoc of metaDocs) {
+      try {
         await metaDoc.remove();
-      }catch(err) {
+      } catch (err) {
         this.loggerService.debug('Could not remove attachment meta document from registration document', metaDoc, err);
       }
     }
@@ -104,31 +125,33 @@ export class OfflineDbNewAttachmentService implements NewAttachmentService {
   private getRegistrationAttachmentDocument(registrationId: string, attachmentId: string) {
     return this.getRegistrationOfflineDocumentById(registrationId).pipe(
       filter((doc) => !!doc),
-      map((doc) => doc.getAttachment(attachmentId)));
+      map((doc) => doc.getAttachment(attachmentId))
+    );
   }
 
   private getAttachmentMetaFromDocument(doc: RxRegistrationDocument) {
-    return this.getAttachmentMetaDocumentsFromRegistrationDocument(doc)
-      .pipe(map((attachmentMetaDocs: RxAttachmentMetaDocument[]) => attachmentMetaDocs.filter((doc) => !!doc).map((mdoc) => mdoc.toJSON())));
+    return this.getAttachmentMetaDocumentsFromRegistrationDocument(doc).pipe(
+      map((attachmentMetaDocs: RxAttachmentMetaDocument[]) => attachmentMetaDocs.filter((doc) => !!doc).map((mdoc) => mdoc.toJSON()))
+    );
   }
 
   private getAttachmentMetaDocumentsFromRegistrationDocument(doc: RxRegistrationDocument): Observable<RxAttachmentMetaDocument[]> {
     const attachments = doc.allAttachments();
-    if(attachments.length <= 0) {
+    if (attachments.length <= 0) {
       return of([]);
     }
     return forkJoin(doc.allAttachments().map((attachment) => this.getAttachmentMetaDocument(attachment.id).pipe(take(1))));
   }
 
   private getAttachmentMetaDocument(id: string): Observable<RxAttachmentMetaDocument> {
-    return this.getAttachmentMetaDbCollectionForAppMode().pipe(
-      switchMap((collection) => collection.findByIds$([id]).pipe(map((result) => result.get(id)))));
+    return this.getAttachmentMetaDbCollectionForAppMode().pipe(switchMap((collection) => collection.findByIds$([id]).pipe(map((result) => result.get(id)))));
   }
 
-  public saveAttachmentMeta$(attachmentMetaData: AttachmentUploadEditModel): Observable<RxAttachmentMetaDocument> {
+  public saveAttachmentMeta$(registrationId: string, attachmentMetaData: AttachmentUploadEditModel): Observable<RxAttachmentMetaDocument> {
     return this.getAttachmentMetaDbCollectionForAppMode().pipe(
       take(1),
-      switchMap((dbCollection) => from(dbCollection.atomicUpsert(attachmentMetaData))));
+      switchMap((dbCollection) => from(dbCollection.atomicUpsert(attachmentMetaData)))
+    );
   }
 
   private getAttachmentMetaDbCollectionForAppMode(): Observable<RxAttachmentMetaCollection> {
@@ -142,7 +165,8 @@ export class OfflineDbNewAttachmentService implements NewAttachmentService {
   protected getRegistrationOfflineDocumentById(id: string): Observable<RxRegistrationDocument> {
     return this.getRegistrationDbCollectionForAppMode().pipe(
       switchMap((dbCollection) => dbCollection.findByIds$([id])),
-      map((result) => result.get(id)));
+      map((result) => result.get(id))
+    );
   }
 
   private getRegistrationDbCollectionForAppMode(): Observable<RxRegistrationCollection> {

--- a/src/app/modules/common-registration/services/add-new-attachment/offline-db-new-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/offline-db-new-attachment.service.ts
@@ -10,9 +10,21 @@ import { RegistrationTid } from '../../models/registration-tid.enum';
 
 @Injectable()
 export class OfflineDbNewAttachmentService implements NewAttachmentService {
-  constructor(private offlineDbService: OfflineDbService, protected appModeService: AppModeService, protected loggerService: LoggerService) {}
+  constructor(
+    private offlineDbService: OfflineDbService,
+    protected appModeService: AppModeService,
+    protected loggerService: LoggerService
+  ) {}
 
-  addAttachment(registrationId: string, data: Blob, mimeType: string, geoHazard: GeoHazard, registrationTid: RegistrationTid, type?: AttachmentType, ref?: string): void {
+  async addAttachment(
+    registrationId: string,
+    data: Blob,
+    mimeType: string,
+    geoHazard: GeoHazard,
+    registrationTid: RegistrationTid,
+    type?: AttachmentType,
+    ref?: string
+  ): Promise<void> {
     const attachmentId = uuidv4();
     this.getRegistrationOfflineDocumentById(registrationId)
       .pipe(
@@ -40,17 +52,6 @@ export class OfflineDbNewAttachmentService implements NewAttachmentService {
         ),
         catchError((err) => {
           this.loggerService.error(() => 'Could not add attachment', err);
-          return EMPTY;
-        })
-      )
-      .subscribe();
-  }
-
-  saveAttachmentMeta(registrationId: string, meta: AttachmentUploadEditModel): void {
-    this.saveAttachmentMeta$(registrationId, meta)
-      .pipe(
-        catchError((err) => {
-          this.loggerService.error(() => 'Could not save attachment metadata', err);
           return EMPTY;
         })
       )
@@ -144,7 +145,9 @@ export class OfflineDbNewAttachmentService implements NewAttachmentService {
   }
 
   private getAttachmentMetaDocument(id: string): Observable<RxAttachmentMetaDocument> {
-    return this.getAttachmentMetaDbCollectionForAppMode().pipe(switchMap((collection) => collection.findByIds$([id]).pipe(map((result) => result.get(id)))));
+    return this.getAttachmentMetaDbCollectionForAppMode().pipe(
+      switchMap((collection) => collection.findByIds$([id]).pipe(map((result) => result.get(id))))
+    );
   }
 
   public saveAttachmentMeta$(registrationId: string, attachmentMetaData: AttachmentUploadEditModel): Observable<RxAttachmentMetaDocument> {

--- a/src/app/modules/common-registration/services/item-sync-callback/regobs-api-sync-callback.service.ts
+++ b/src/app/modules/common-registration/services/item-sync-callback/regobs-api-sync-callback.service.ts
@@ -15,16 +15,15 @@ import cloneDeep from 'clone-deep';
 
 @Injectable()
 export class RegobsApiSyncCallbackService implements ItemSyncCallbackService<IRegistration> {
-
-  constructor(private regobsApiRegistrationService: RegistrationService,
+  constructor(
+    private regobsApiRegistrationService: RegistrationService,
     private languageService: LanguageService,
     private apiAttachmentService: ApiAttachmentService,
     private newAttachmentService: NewAttachmentService,
     private loggerService: LoggerService,
     private httpClient: HttpClient,
-    private progressService: ProgressService,
-  ) {
-  }
+    private progressService: ProgressService
+  ) {}
 
   deleteItem(item: IRegistration): Observable<boolean> {
     if (!item || !item.response || !(item.response.RegId > 0)) {
@@ -34,45 +33,52 @@ export class RegobsApiSyncCallbackService implements ItemSyncCallbackService<IRe
   }
 
   syncItem(item: IRegistration, ignoreVersionCheck: boolean): Observable<ItemSyncCompleteStatus<IRegistration>> {
-    return this.languageService.language$.pipe(take(1), switchMap((langKey) => this.insertOrUpdate(item, langKey, ignoreVersionCheck)));
+    return this.languageService.language$.pipe(
+      take(1),
+      switchMap((langKey) => this.insertOrUpdate(item, langKey, ignoreVersionCheck))
+    );
   }
 
-  insertOrUpdate(item: IRegistration, langKey: LangKey, ignoreVersionCheck: boolean
-  ): Observable<ItemSyncCompleteStatus<IRegistration>> {
+  insertOrUpdate(item: IRegistration, langKey: LangKey, ignoreVersionCheck: boolean): Observable<ItemSyncCompleteStatus<IRegistration>> {
     this.loggerService.debug('Start insertOrUpdate: ', item, langKey);
-    return this.uploadAttachments(item).pipe(switchMap((uploadAttachmentResult) => {
-      this.loggerService.debug('Result from attachment upload: ', uploadAttachmentResult);
-      this.loggerService.debug('Registration is now: ', item);
-      const uploadSuccess = !uploadAttachmentResult.some((a) => a.error);
-      let attachmentStatusCode: number = undefined;
-      if (!uploadSuccess) {
-        attachmentStatusCode = uploadAttachmentResult.map((a) => (a.error as HttpErrorResponse).status || 0).reduce((pv, cv) => cv > pv ? cv : pv, 0);
-      }
-      // Set request attachments on temporary request item, so it will not be removed / invalid if failure
-      const clonedItem = cloneDeep(item);
-      this.setRequestAttachments(clonedItem, uploadAttachmentResult);
-      return this.callInsertOrUpdate(clonedItem, langKey, ignoreVersionCheck)
-        // TODO: Hvorfor removeAllNewAttachments her?
-        .pipe(switchMap((result) => this.removeAllNewAttachments(clonedItem).pipe(map(() => result))),
-          map((result) => ({
-            success: uploadSuccess,
-            item: ({ ...cloneDeep(item), response: result }),
-            statusCode: attachmentStatusCode,
-            error: uploadSuccess ? undefined : 'Could not upload attachments'
-          })),
-          catchError((err: HttpErrorResponse) => {
-            const errorMsg = this.getErrorModelStateMessageOrErrorMsg(err);
-            return of(({ success: false, item: item, statusCode: err.status, error: errorMsg }));
-          })
+    return this.uploadAttachments(item).pipe(
+      switchMap((uploadAttachmentResult) => {
+        this.loggerService.debug('Result from attachment upload: ', uploadAttachmentResult);
+        this.loggerService.debug('Registration is now: ', item);
+        const uploadSuccess = !uploadAttachmentResult.some((a) => a.error);
+        let attachmentStatusCode: number = undefined;
+        if (!uploadSuccess) {
+          attachmentStatusCode = uploadAttachmentResult.map((a) => (a.error as HttpErrorResponse).status || 0).reduce((pv, cv) => (cv > pv ? cv : pv), 0);
+        }
+        // Set request attachments on temporary request item, so it will not be removed / invalid if failure
+        const clonedItem = cloneDeep(item);
+        this.setRequestAttachments(clonedItem, uploadAttachmentResult);
+        return (
+          this.callInsertOrUpdate(clonedItem, langKey, ignoreVersionCheck)
+            // TODO: Hvorfor removeAllNewAttachments her?
+            .pipe(
+              switchMap((result) => this.removeAllNewAttachments(clonedItem).pipe(map(() => result))),
+              map((result) => ({
+                success: uploadSuccess,
+                item: { ...cloneDeep(item), response: result },
+                statusCode: attachmentStatusCode,
+                error: uploadSuccess ? undefined : 'Could not upload attachments'
+              })),
+              catchError((err: HttpErrorResponse) => {
+                const errorMsg = this.getErrorModelStateMessageOrErrorMsg(err);
+                return of({ success: false, item: item, statusCode: err.status, error: errorMsg });
+              })
+            )
         );
-    }));
+      })
+    );
   }
 
   private getErrorModelStateMessageOrErrorMsg(err: HttpErrorResponse): string {
-    if(err && err.error) {
+    if (err && err.error) {
       return JSON.stringify(err.error);
     }
-    if(err && err.message) {
+    if (err && err.message) {
       return err.message;
     }
     return 'Unknown error';
@@ -82,9 +88,10 @@ export class RegobsApiSyncCallbackService implements ItemSyncCallbackService<IRe
    * Add uploaded attachments with uploadId to request attachments
    **/
   private setRequestAttachments(reg: IRegistration, uploadedAttachments: AttachmentUploadEditModel[]) {
-    if(uploadedAttachments && uploadedAttachments.length > 0) {
-      for(const uploadedAttachment of uploadedAttachments) {
-        if(uploadedAttachment.AttachmentUploadId) { // Only set request attachments with uploadId
+    if (uploadedAttachments && uploadedAttachments.length > 0) {
+      for (const uploadedAttachment of uploadedAttachments) {
+        if (uploadedAttachment.AttachmentUploadId) {
+          // Only set request attachments with uploadId
           this.addUploadedAttachmentToRequest(uploadedAttachment, reg);
         }
       }
@@ -94,54 +101,60 @@ export class RegobsApiSyncCallbackService implements ItemSyncCallbackService<IRe
   private callInsertOrUpdate(item: IRegistration, langKey: LangKey, ignoreVersionCheck?: boolean): Observable<RegistrationViewModel> {
     // TODO: Hvorfor trenger vi både RegistrationInsertOrUpdate og RegistrationInsert?
     // Kunne vi bare brukt InsertOrUpdate hver gang?
-    return item.response ?
-      // PUT
-      this.regobsApiRegistrationService.RegistrationInsertOrUpdate({
-        registration: item.request,
-        id: item.response.RegId,
-        langKey,
-        externalReferenceId: item.id,
-        ignoreVersionCheck: ignoreVersionCheck })
-      // POST
-      : this.regobsApiRegistrationService.RegistrationInsert({
-        registration: item.request,
-        langKey,
-        externalReferenceId: item.id
-      });
+    return item.response
+      ? // PUT
+        this.regobsApiRegistrationService.RegistrationInsertOrUpdate({
+          registration: item.request,
+          id: item.response.RegId,
+          langKey,
+          externalReferenceId: item.id,
+          ignoreVersionCheck: ignoreVersionCheck
+        })
+      : // POST
+        this.regobsApiRegistrationService.RegistrationInsert({
+          registration: item.request,
+          langKey,
+          externalReferenceId: item.id
+        });
   }
 
   removeAllNewAttachments(item: IRegistration): Observable<IRegistration> {
-    return this.newAttachmentService.removeAttachmentsForRegistration$(item.id).pipe(map(() => item));
+    return this.newAttachmentService.removeAttachments$(item.id).pipe(map(() => item));
   }
 
   uploadAttachments(item: IRegistration): Observable<AttachmentUploadEditModel[]> {
-    return this.getAttachmentsToUpload(item).pipe(take(1), switchMap((attachmentsToUpload) => {
-      if (attachmentsToUpload.length > 0) {
-        this.loggerService.debug('Attachments to upload: ', attachmentsToUpload);
-        return forkJoin(attachmentsToUpload.map((a) =>
-          this.uploadAttachmentAndSetAttachmentUploadId(item, a).pipe(take(1))));
-      }
-      this.loggerService.debug('No attachments to uplaod');
-      return of([]);
-    }));
+    return this.getAttachmentsToUpload(item).pipe(
+      take(1),
+      switchMap((attachmentsToUpload) => {
+        if (attachmentsToUpload.length > 0) {
+          this.loggerService.debug('Attachments to upload: ', attachmentsToUpload);
+          return forkJoin(attachmentsToUpload.map((a) => this.uploadAttachmentAndSetAttachmentUploadId(item, a).pipe(take(1))));
+        }
+        this.loggerService.debug('No attachments to uplaod');
+        return of([]);
+      })
+    );
   }
 
-  uploadAttachmentAndSetAttachmentUploadId(reg: IRegistration,
-    attachmentUpload: AttachmentUploadEditModel): Observable<AttachmentUploadEditModel> {
+  uploadAttachmentAndSetAttachmentUploadId(reg: IRegistration, attachmentUpload: AttachmentUploadEditModel): Observable<AttachmentUploadEditModel> {
     attachmentUpload.error = undefined;
     return this.newAttachmentService.getBlob(reg.id, attachmentUpload.id).pipe(
       switchMap((blob) =>
-        this.uploadAttachmentWithProgress(attachmentUpload.id, blob).pipe(switchMap((uploadId) => {
-          this.loggerService.debug('Attachment uploaded. Setting uploadId', attachmentUpload, uploadId);
-          // this.addAttachmentToRequest(uploadId, attachmentUpload, reg);
-          attachmentUpload.AttachmentUploadId = uploadId;
-          return this.newAttachmentService.saveAttachmentMeta$(attachmentUpload).pipe(map(() => attachmentUpload));
-        }))),
+        this.uploadAttachmentWithProgress(attachmentUpload.id, blob).pipe(
+          switchMap((uploadId) => {
+            this.loggerService.debug('Attachment uploaded. Setting uploadId', attachmentUpload, uploadId);
+            // this.addAttachmentToRequest(uploadId, attachmentUpload, reg);
+            attachmentUpload.AttachmentUploadId = uploadId;
+            return this.newAttachmentService.saveAttachmentMeta$(reg.id, attachmentUpload).pipe(map(() => attachmentUpload));
+          })
+        )
+      ),
       catchError((err: Error) => {
         this.loggerService.debug('Could not upload attachment. Setting error.', err);
         attachmentUpload.error = err;
         return of(attachmentUpload);
-      }));
+      })
+    );
   }
 
   private addUploadedAttachmentToRequest(attachmentUploadEditModel: AttachmentUploadEditModel, reg: IRegistration) {
@@ -154,7 +167,7 @@ export class RegobsApiSyncCallbackService implements ItemSyncCallbackService<IRe
       RegistrationTID: attachmentUploadEditModel.RegistrationTID,
       Comment: attachmentUploadEditModel.Comment,
       AttachmentMimeType: attachmentUploadEditModel.AttachmentMimeType,
-      IsMainAttachment: attachmentUploadEditModel.IsMainAttachment,
+      IsMainAttachment: attachmentUploadEditModel.IsMainAttachment
     };
     if (attachmentUploadEditModel.type === 'WaterLevelMeasurementAttachment') {
       this.addWaterLevelAttachment(attachment, reg, attachmentUploadEditModel.ref);
@@ -187,28 +200,35 @@ export class RegobsApiSyncCallbackService implements ItemSyncCallbackService<IRe
   }
 
   getAttachmentsToUpload(item: IRegistration): Observable<AttachmentUploadEditModel[]> {
-    return this.newAttachmentService.getUploadedAttachments(item.id);
+    return this.newAttachmentService.getAttachments(item.id);
   }
 
   uploadAttachmentWithProgress(id: string, blob: Blob): Observable<string> {
     const attachmentPostPath = `${this.apiAttachmentService.rootUrl}${ApiAttachmentService.AttachmentPostPath}`;
     const formData = new FormData();
     formData.append('file', blob);
-    return this.httpClient.post(attachmentPostPath, formData, {
-      responseType: 'json', reportProgress: true, observe: 'events', headers: {'ngsw-bypass': '' }
-    }).pipe(tap((event) => {
-      this.loggerService.debug('uploadAttachmentWithProgress got event:', event);
-      if (event.type === HttpEventType.UploadProgress) {
-        this.progressService.setAttachmentProgress(id, event.total, event.loaded);
-      }
-    }), filter((event) => event.type === HttpEventType.Response),
-    map((event: HttpResponse<string>) => {
-      if (!event.ok) {
-        throw Error(`Could not upload attachment: Status: ${event.statusText}`);
-      }
-      return event.body;
-    }),
-    tap((result) => this.loggerService.debug(`Attachment uploaded with attachment id: ${result} `))
-    );
+    return this.httpClient
+      .post(attachmentPostPath, formData, {
+        responseType: 'json',
+        reportProgress: true,
+        observe: 'events',
+        headers: { 'ngsw-bypass': '' }
+      })
+      .pipe(
+        tap((event) => {
+          this.loggerService.debug('uploadAttachmentWithProgress got event:', event);
+          if (event.type === HttpEventType.UploadProgress) {
+            this.progressService.setAttachmentProgress(id, event.total, event.loaded);
+          }
+        }),
+        filter((event) => event.type === HttpEventType.Response),
+        map((event: HttpResponse<string>) => {
+          if (!event.ok) {
+            throw Error(`Could not upload attachment: Status: ${event.statusText}`);
+          }
+          return event.body;
+        }),
+        tap((result) => this.loggerService.debug(`Attachment uploaded with attachment id: ${result} `))
+      );
   }
 }

--- a/src/app/modules/common-registration/services/registration/registration.service.ts
+++ b/src/app/modules/common-registration/services/registration/registration.service.ts
@@ -115,27 +115,8 @@ export class RegistrationService {
   private saveRegistrationToOfflineStorage(reg: IRegistration): Observable<RxRegistrationDocument> {
     return this.getRegistrationDbCollectionForAppMode().pipe(
       take(1),
-      switchMap((collection) =>
-        collection.findByIds$([reg.id]).pipe(
-          map((result) => result.get(reg.id)),
-          switchMap((doc) => from(this.insertOrUpdate(reg, doc, collection)))
-        )
-      )
+      switchMap((collection) => from(collection.atomicUpsert(reg)))
     );
-  }
-
-  private insertOrUpdate(
-    reg: IRegistration,
-    doc: RxRegistrationDocument,
-    collection: RxRegistrationCollection
-  ): Promise<RxRegistrationDocument> {
-    if (doc) {
-      return doc.update({
-        $set: reg
-      });
-    } else {
-      return collection.insert(reg);
-    }
   }
 
   public deleteRegistration(id: string): Observable<boolean> {

--- a/src/app/modules/common-registration/services/registration/registration.service.ts
+++ b/src/app/modules/common-registration/services/registration/registration.service.ts
@@ -10,7 +10,15 @@ import { ItemSyncCallbackService } from '../item-sync-callback/item-sync-callbac
 import moment from 'moment';
 import { RegistrationTid } from '../../models/registration-tid.enum';
 import { Summary, AttachmentViewModel, RegistrationViewModel, RegistrationEditModel } from '@varsom-regobs-common/regobs-api';
-import { getAllAttachments, getPropertyName, getRegistrationTidsForGeoHazard, hasAnyObservations, isArrayType, isObservationEmptyForRegistrationTid, isObservationModelEmptyForRegistrationTid } from '../../registration.helpers';
+import {
+  getAllAttachments,
+  getPropertyName,
+  getRegistrationTidsForGeoHazard,
+  hasAnyObservations,
+  isArrayType,
+  isObservationEmptyForRegistrationTid,
+  isObservationModelEmptyForRegistrationTid
+} from '../../registration.helpers';
 import { ProgressService } from '../progress/progress.service';
 import { InternetConnectivity } from 'ngx-connectivity';
 import { KdvService } from '../kdv/kdv.service';
@@ -31,7 +39,6 @@ const SYNC_BUFFER_MS = 3 * 1000; // Wait at least 3 seconds before next sync att
   providedIn: 'root'
 })
 export class RegistrationService {
-
   public readonly registrationStorage$: Observable<IRegistration[]>;
   private _registrationSyncSubscription: Subscription;
 
@@ -49,9 +56,12 @@ export class RegistrationService {
     private fallbackSummaryProvider: FallbackSummaryProvider,
     @Inject(FOR_ROOT_OPTIONS_TOKEN) private options: IRegistrationModuleOptions
   ) {
-    this.registrationStorage$ = this.getRegistrationObservable().pipe(tap((reg) => {
-      this.loggerService.debug('Registrations changed', reg);
-    }), shareReplay(1));
+    this.registrationStorage$ = this.getRegistrationObservable().pipe(
+      tap((reg) => {
+        this.loggerService.debug('Registrations changed', reg);
+      }),
+      shareReplay(1)
+    );
     this.initAutoSync();
   }
 
@@ -65,9 +75,9 @@ export class RegistrationService {
     if (updateChangedTimestamp) {
       reg.changed = moment().unix();
     }
-    if(reg.syncStatus === SyncStatus.Sync) {
+    if (reg.syncStatus === SyncStatus.Sync) {
       return this.saveAndSyncSingleRegistration(reg, ignoreVersionCheck);
-    }else{
+    } else {
       return this.saveRegistrationToOfflineStorage(reg).pipe(map(() => true));
     }
   }
@@ -77,17 +87,29 @@ export class RegistrationService {
     if (this._registrationSyncSubscription) {
       this._registrationSyncSubscription.unsubscribe();
     }
-    return this.saveRegistrationToOfflineStorage(reg).pipe(switchMap(() => this.syncSingleRegistration(reg, ignoreVersionCheck)), tap(() => {
-      this.loggerService.debug('Single registration synced. Start autosync.');
-      this.initAutoSync();
-    }));
+    return this.saveRegistrationToOfflineStorage(reg).pipe(
+      switchMap(() => this.syncSingleRegistration(reg, ignoreVersionCheck)),
+      tap(() => {
+        this.loggerService.debug('Single registration synced. Start autosync.');
+        this.initAutoSync();
+      })
+    );
   }
 
   private saveRegistrationToOfflineStorage(reg: IRegistration): Observable<RxRegistrationDocument> {
-    return this.getRegistrationDbCollectionForAppMode().pipe(take(1),
-      switchMap((collection) => from(collection.atomicUpsert(reg)).pipe((switchMap((doc) =>
-        this.getRegistrationObservable().pipe(take(1), map(() => doc)))))
-      ));
+    return this.getRegistrationDbCollectionForAppMode().pipe(
+      take(1),
+      switchMap((collection) =>
+        from(collection.atomicUpsert(reg)).pipe(
+          switchMap((doc) =>
+            this.getRegistrationObservable().pipe(
+              take(1),
+              map(() => doc)
+            )
+          )
+        )
+      )
+    );
   }
 
   private updateDocInOfflineStorage(doc: RxRegistrationDocument, reg: IRegistration): Promise<RxRegistrationDocument> {
@@ -108,15 +130,15 @@ export class RegistrationService {
   public deleteRegistration(id: string): Observable<boolean> {
     return this.getRegistrationOfflineDocumentById(id).pipe(
       take(1),
-      switchMap((doc) => doc ? this.offlineRegistrationSyncService.deleteItem(doc.toJSON()).pipe(map(() => doc)) : of(undefined)),
-      switchMap((doc: RxRegistrationDocument) => doc ? from(doc.remove()) : of(false))
+      switchMap((doc) => (doc ? this.offlineRegistrationSyncService.deleteItem(doc.toJSON()).pipe(map(() => doc)) : of(undefined))),
+      switchMap((doc: RxRegistrationDocument) => (doc ? from(doc.remove()) : of(false)))
     );
   }
 
   public deleteRegistrationFromOfflineStorage(id: string): Observable<unknown> {
     return this.getRegistrationOfflineDocumentById(id).pipe(
       take(1),
-      switchMap((doc) => doc ? from(doc.remove()) : of(false))
+      switchMap((doc) => (doc ? from(doc.remove()) : of(false)))
     );
   }
 
@@ -149,28 +171,34 @@ export class RegistrationService {
 
   public getFirstDraftForGeoHazard(geoHazard: GeoHazard, draftsOnly = true): Promise<IRegistration> {
     return this.getDraftsForGeoHazardObservable(geoHazard, draftsOnly)
-      .pipe(map((rows) => rows.sort((a, b) => b.changed - a.changed)[0]), take(1)).toPromise();
+      .pipe(
+        map((rows) => rows.sort((a, b) => b.changed - a.changed)[0]),
+        take(1)
+      )
+      .toPromise();
   }
 
   public getDraftsForGeoHazardObservable(geoHazard: GeoHazard, draftsOnly = true): Observable<IRegistration[]> {
-    return this.registrationStorage$.pipe(map((records) =>
-      records.filter((reg) =>
-        reg.request.GeoHazardTID === geoHazard
-        && (draftsOnly ? reg.syncStatus === SyncStatus.Draft : true)
-        //All items in registration storage is "drafts"/not complete until deleted from storage (when done)
-      )));
+    return this.registrationStorage$.pipe(
+      map((records) =>
+        records.filter(
+          (reg) => reg.request.GeoHazardTID === geoHazard && (draftsOnly ? reg.syncStatus === SyncStatus.Draft : true)
+          //All items in registration storage is "drafts"/not complete until deleted from storage (when done)
+        )
+      )
+    );
   }
 
   public getAllRegistrations$(geoHazard?: GeoHazard): Observable<IRegistration[]> {
     return this.getRegistrationDbCollectionForAppMode().pipe(
       switchMap((collection) => collection.find().$),
       map((docs) => docs.map((d) => d.toJSON())),
-      map((regs) => regs.filter((r) => geoHazard ? r.geoHazard === geoHazard : true)));
+      map((regs) => regs.filter((r) => (geoHazard ? r.geoHazard === geoHazard : true)))
+    );
   }
 
   public deleteAllRegistrationsFromOfflineStorage$(geoHazard?: GeoHazard): Observable<unknown> {
-    return this.getAllRegistrations$(geoHazard).pipe(
-      switchMap((regs) => regs.length > 0 ? forkJoin(regs.map((reg) => this.deleteRegistrationFromOfflineStorage(reg.id))) : of({})));
+    return this.getAllRegistrations$(geoHazard).pipe(switchMap((regs) => (regs.length > 0 ? forkJoin(regs.map((reg) => this.deleteRegistrationFromOfflineStorage(reg.id))) : of({}))));
   }
 
   public deleteAllRegistrationsFromOfflineStorage(geoHazard?: GeoHazard): void {
@@ -183,13 +211,13 @@ export class RegistrationService {
       map((reg) => {
         const regToEdit = cloneDeep(reg);
         this.makeExistingRegistrationEditable(regToEdit);
-        if(isArrayType(registrationTid) && regToEdit.request[getPropertyName(registrationTid)].length > index ) {
+        if (isArrayType(registrationTid) && regToEdit.request[getPropertyName(registrationTid)].length > index) {
           (regToEdit.request[getPropertyName(registrationTid)] as Array<unknown>).splice(index, 1);
           // Deletes images if no forms left in array
-          if((regToEdit.request[getPropertyName(registrationTid)] as Array<unknown>).length === 0) {
+          if ((regToEdit.request[getPropertyName(registrationTid)] as Array<unknown>).length === 0) {
             this.deleteExistingAttachmentsForRegistrationType(regToEdit, registrationTid);
           }
-        }else if(!isArrayType(registrationTid)){
+        } else if (!isArrayType(registrationTid)) {
           delete regToEdit.request[getPropertyName(registrationTid)];
           this.deleteExistingAttachmentsForRegistrationType(regToEdit, registrationTid);
         }
@@ -200,7 +228,7 @@ export class RegistrationService {
   }
 
   private deleteExistingAttachmentsForRegistrationType(reg: IRegistration, registrationTid: RegistrationTid): IRegistration {
-    if(reg && reg.request && reg.request.Attachments) {
+    if (reg && reg.request && reg.request.Attachments) {
       reg.request.Attachments = reg.request.Attachments.filter((a) => a.RegistrationTID !== registrationTid);
     }
     return reg;
@@ -216,10 +244,9 @@ export class RegistrationService {
       request: {
         GeoHazardTID: geoHazard,
         DtObsTime: undefined,
-        ObsLocation: {
-        },
+        ObsLocation: {},
         Attachments: []
-      },
+      }
     };
     return draft;
   }
@@ -267,20 +294,20 @@ export class RegistrationService {
   private getAutosyncChangeTrigger() {
     const networkOrTimerTrigger$ = merge(
       this.getNetworkOnlineObservable().pipe(map(() => 'network status online trigger')),
-      timer(SYNC_TIMER_TRIGGER_MS, SYNC_TIMER_TRIGGER_MS).pipe(map(() => 'timer trigger')));
+      timer(SYNC_TIMER_TRIGGER_MS, SYNC_TIMER_TRIGGER_MS).pipe(map(() => 'timer trigger'))
+    );
     return this.getRegistrationsToSyncObservable(false).pipe(
       map((records) => records.length > 0),
       filter((hasRecords) => hasRecords),
-      switchMap(() => networkOrTimerTrigger$));
+      switchMap(() => networkOrTimerTrigger$)
+    );
   }
 
   private resetProgressAndSyncItems(ignoreVersionCheck = false): (src: Observable<IRegistration[]>) => Observable<IRegistration[]> {
     return (src: Observable<IRegistration[]>) =>
       src.pipe(
         // Reset sync status
-        concatMap((records) => from(
-          this.progressService.resetSyncProgress(records.map((r) => r.id))
-        ).pipe(map(() => records))),
+        concatMap((records) => from(this.progressService.resetSyncProgress(records.map((r) => r.id))).pipe(map(() => records))),
 
         // Innsending skjer langt inni her
         this.flattenRegistrationsToSync(ignoreVersionCheck),
@@ -292,7 +319,8 @@ export class RegistrationService {
           this.loggerService.warn('Could not sync registrations', error);
           return of([]);
         }),
-        tap(() => this.progressService.resetSyncProgress()));
+        tap(() => this.progressService.resetSyncProgress())
+      );
   }
 
   /***
@@ -300,24 +328,25 @@ export class RegistrationService {
    */
   public hasAnyDataToShowInRegistrationTypes(reg: IRegistration, registrationTid: RegistrationTid): Observable<boolean> {
     const model = this.getRegistrationEditOrViewModel(reg);
-    return of(isObservationModelEmptyForRegistrationTid(model, registrationTid)).pipe((switchMap((isEmpty) => {
-      if(!isEmpty) {
-        return of(true);
-      }
-      return this.hasAnyAttachmentsForRegistrationTid$(reg, registrationTid).pipe(take(1));
-    })));
+    return of(isObservationModelEmptyForRegistrationTid(model, registrationTid)).pipe(
+      switchMap((isEmpty) => {
+        if (!isEmpty) {
+          return of(true);
+        }
+        return this.hasAnyAttachmentsForRegistrationTid$(reg, registrationTid).pipe(take(1));
+      })
+    );
   }
 
   private getRegistrationEditOrViewModel(reg: IRegistration): RegistrationEditModel | RegistrationViewModel {
-    if(reg.syncStatus === SyncStatus.InSync && reg.response) {
+    if (reg.syncStatus === SyncStatus.InSync && reg.response) {
       return reg.response;
     }
     return reg.request;
   }
 
-  hasAnyAttachmentsForRegistrationTid$(reg: IRegistration, registrationTid: RegistrationTid): Observable<boolean>{
-    return this.getAllAttachmentsForRegistrationTid$(reg.id, registrationTid).
-      pipe(map((attachments) => attachments.length > 0));
+  hasAnyAttachmentsForRegistrationTid$(reg: IRegistration, registrationTid: RegistrationTid): Observable<boolean> {
+    return this.getAllAttachmentsForRegistrationTid$(reg.id, registrationTid).pipe(map((attachments) => attachments.length > 0));
   }
 
   hasAnyAttachmentsForRegistrationTid(reg: IRegistration, registrationTid: RegistrationTid): Promise<boolean> {
@@ -326,9 +355,11 @@ export class RegistrationService {
 
   getRegistrationTypesWithAnyData(reg: IRegistration): Observable<IRegistrationType[]> {
     return this.getRegistrationTypesForGeoHazard(reg.geoHazard).pipe(
-      switchMap((regTypes) => regTypes.length > 0 ? forkJoin(regTypes.map((regType) => this.hasAnyDataToShowInRegistrationTypes(reg, regType.registrationTid)
-        .pipe(map((anyData) => ({  anyData, regType }))))) : of([])),
-      map((result) => result.filter((r) => r.anyData).map((r) => r.regType)));
+      switchMap((regTypes) =>
+        regTypes.length > 0 ? forkJoin(regTypes.map((regType) => this.hasAnyDataToShowInRegistrationTypes(reg, regType.registrationTid).pipe(map((anyData) => ({ anyData, regType }))))) : of([])
+      ),
+      map((result) => result.filter((r) => r.anyData).map((r) => r.regType))
+    );
   }
 
   public getSummaryForRegistrationTidById$(id: string, registrationTid: RegistrationTid): Observable<Summary[]> {
@@ -347,14 +378,13 @@ export class RegistrationService {
       //   return provider.generateSummary(reg);
       // }
       // TODO: Implement all providers to get summaries generated client side before synchronized to API...
-      return this.fallbackSummaryProvider.generateSummary(reg, registrationTid).pipe(tap((genericSummary) =>
-        this.loggerService.debug('Generic fallback summary', genericSummary)));
+      return this.fallbackSummaryProvider.generateSummary(reg, registrationTid).pipe(tap((genericSummary) => this.loggerService.debug('Generic fallback summary', genericSummary)));
     }
     return addIfEmpty ? this.generateEmptySummary(registrationTid).pipe(map((s) => [s])) : of([]);
   }
 
   public getSummaryForRegistrationTid(reg: IRegistration, registrationTid: RegistrationTid, addIfEmpty = true): Observable<Summary[]> {
-    if(reg.changedRegistrationTid === registrationTid && reg.syncStatus !== SyncStatus.InSync) {
+    if (reg.changedRegistrationTid === registrationTid && reg.syncStatus !== SyncStatus.InSync) {
       return this.getDraftSummary(reg, registrationTid, addIfEmpty);
     }
     return this.getResponseSummaryForRegistrationTid(reg, registrationTid, addIfEmpty);
@@ -362,12 +392,14 @@ export class RegistrationService {
 
   public getRegistrationName(registrationTid: RegistrationTid): Observable<string> {
     return this.kdvService.getKdvRepositoryByKeyObservable('RegistrationKDV').pipe(
-      map((kdvElements) => kdvElements.find((kdv) => kdv.Id === registrationTid)), map((val) => val ? val.Name : ''));
+      map((kdvElements) => kdvElements.find((kdv) => kdv.Id === registrationTid)),
+      map((val) => (val ? val.Name : ''))
+    );
   }
 
   private getResponseSummaryForRegistrationTid(reg: IRegistration, registrationTid: RegistrationTid, addIfEmpty = true): Observable<Summary[]> {
     if (reg && reg.response && reg.response.Summaries && reg.response.Summaries.length > 0) {
-      const summary = reg.response.Summaries.filter(x => x.RegistrationTID === registrationTid);
+      const summary = reg.response.Summaries.filter((x) => x.RegistrationTID === registrationTid);
       if (summary) {
         return of(summary);
       }
@@ -376,32 +408,38 @@ export class RegistrationService {
   }
 
   private generateEmptySummary(registrationTid: RegistrationTid): Observable<Summary> {
-    return this.getRegistrationName(registrationTid).pipe(map((registrationName) => ({
-      RegistrationTID: registrationTid,
-      RegistrationName: registrationName,
-      Summaries: []
-    })));
+    return this.getRegistrationName(registrationTid).pipe(
+      map((registrationName) => ({
+        RegistrationTID: registrationTid,
+        RegistrationName: registrationName,
+        Summaries: []
+      }))
+    );
   }
 
   public getRegistrationTypesForGeoHazard(geoHazard: GeoHazard): Observable<IRegistrationType[]> {
     const registrationTidsForGeoHazard = getRegistrationTidsForGeoHazard(geoHazard);
 
-    const flatViewrepository$ = this.kdvService.getViewRepositoryByKeyObservable('RegistrationTypesV')
-      .pipe(
-        map((val) => this.parseViewRepositoryType(val[`${geoHazard}`])),
-        map((result) => this.flattenRegistrationTypes(result)),
-        map((result) => result.filter((val) => registrationTidsForGeoHazard.indexOf(val.registrationTid) >= 0))
-      );
+    const flatViewrepository$ = this.kdvService.getViewRepositoryByKeyObservable('RegistrationTypesV').pipe(
+      map((val) => this.parseViewRepositoryType(val[`${geoHazard}`])),
+      map((result) => this.flattenRegistrationTypes(result)),
+      map((result) => result.filter((val) => registrationTidsForGeoHazard.indexOf(val.registrationTid) >= 0))
+    );
 
-    return of(registrationTidsForGeoHazard).pipe(switchMap((registrationTids) =>
-      flatViewrepository$.pipe(
-        map((vr) => registrationTids.map((registrationTid) => vr.find((v) => v.registrationTid === registrationTid)),
-          filter((result) => !!result)
-        ))));
+    return of(registrationTidsForGeoHazard).pipe(
+      switchMap((registrationTids) =>
+        flatViewrepository$.pipe(
+          map(
+            (vr) => registrationTids.map((registrationTid) => vr.find((v) => v.registrationTid === registrationTid)),
+            filter((result) => !!result)
+          )
+        )
+      )
+    );
   }
 
   private flattenRegistrationTypes(types: IRegistrationType[]) {
-    const arr = types.map((t) => (t.subTypes && t.subTypes.length > 0) ? t.subTypes : [t]);
+    const arr = types.map((t) => (t.subTypes && t.subTypes.length > 0 ? t.subTypes : [t]));
     return arr.reduce((a, b) => a.concat(b), []);
   }
 
@@ -414,7 +452,7 @@ export class RegistrationService {
         registrationTid: v['Id'],
         name: v['Name'],
         sortOrder: v['SortOrder'],
-        subTypes: this.parseViewRepositoryType(v['SubTypes']),
+        subTypes: this.parseViewRepositoryType(v['SubTypes'])
       };
       return result;
     });
@@ -424,40 +462,46 @@ export class RegistrationService {
     return combineLatest([this.getRegistrationDbCollectionForAppMode(), this.getRegistrationById(id)]).pipe(
       take(1),
       tap(([collection, reg]) => {
-        if(!collection) {
+        if (!collection) {
           this.loggerService.warn('No db collection found for appMode when saveRollbackState');
         }
-        if(!reg) {
+        if (!reg) {
           this.loggerService.warn('No registration found by id when saveRollbackState: ', id);
         }
       }),
-      switchMap(([collection, reg]) =>
-        (reg && collection) ? from(collection.upsertLocal(`undo_state_${id}`, { reg })) : of({})
-      ));
+      switchMap(([collection, reg]) => (reg && collection ? from(collection.upsertLocal(`undo_state_${id}`, { reg })) : of({})))
+    );
   }
 
   public saveRollbackState(id: string): void {
-    this.saveRollbackState$(id).subscribe(() => null, (err) => {
-      this.loggerService.warn('Could not save rollback state', err);
-    });
+    this.saveRollbackState$(id).subscribe(
+      () => null,
+      (err) => {
+        this.loggerService.warn('Could not save rollback state', err);
+      }
+    );
   }
 
   /**
    * Rollback registration to last known undo state (as observable)
    */
-  public rollbackChanges$(id: string): Observable<boolean>  {
+  public rollbackChanges$(id: string): Observable<boolean> {
     return this.getRegistrationDbCollectionForAppMode().pipe(
       tap((collection) => {
-        if(!collection) {
+        if (!collection) {
           this.loggerService.warn('No db collection found for appMode when saveRollbackState');
         }
       }),
-      switchMap((collection) => collection ? from(collection.getLocal(`undo_state_${id}`)).pipe(map((doc) => doc ?  doc.get('reg') : undefined)): of(undefined)),
-      switchMap((reg: IRegistration) => reg ?
-        this.saveRegistrationToOfflineStorage(reg).pipe(
-          switchMap(() => this.newAttachmentService.removeAttachmentsForRegistration$(id)),
-          map(() => true))
-        : of(false)));
+      switchMap((collection) => (collection ? from(collection.getLocal(`undo_state_${id}`)).pipe(map((doc) => (doc ? doc.get('reg') : undefined))) : of(undefined))),
+      switchMap((reg: IRegistration) =>
+        reg
+          ? this.saveRegistrationToOfflineStorage(reg).pipe(
+              switchMap(() => this.newAttachmentService.removeAttachments$(id)),
+              map(() => true)
+            )
+          : of(false)
+      )
+    );
   }
 
   /**
@@ -472,14 +516,12 @@ export class RegistrationService {
   }
 
   public getAllAttachmentsForRegistration$(id: string): Observable<ExistingOrNewAttachment[]> {
-    return combineLatest([
-      this.getRegistrationByIdShared$(id).pipe(map((reg) => getAllAttachments(reg))),
-      this.newAttachmentService.getUploadedAttachments(id)])
-      .pipe(
-        map(([existingAttachments, newAttachments]) => [
-          ...existingAttachments.map((a) => ({ type: 'existing' as ExistingAttachmentType, attachment: a })),
-          ...newAttachments.map((a) => ({ type: 'new' as NewAttachmentType, attachment: a }))
-        ]));
+    return combineLatest([this.getRegistrationByIdShared$(id).pipe(map((reg) => getAllAttachments(reg))), this.newAttachmentService.getAttachments(id)]).pipe(
+      map(([existingAttachments, newAttachments]) => [
+        ...existingAttachments.map((a) => ({ type: 'existing' as ExistingAttachmentType, attachment: a })),
+        ...newAttachments.map((a) => ({ type: 'new' as NewAttachmentType, attachment: a }))
+      ])
+    );
   }
 
   public getExistingAttachmentsForRegistrationTid$(id: string, registrationTid: RegistrationTid): Observable<AttachmentViewModel[]> {
@@ -487,31 +529,30 @@ export class RegistrationService {
   }
 
   public getNewAttachmentsForRegistrationTid$(id: string, registrationTid: RegistrationTid): Observable<AttachmentUploadEditModel[]> {
-    return this.newAttachmentService.getUploadedAttachments(id).pipe(
-      map((attachments: AttachmentUploadEditModel[]) => attachments.filter((a) => a.RegistrationTID === registrationTid)));
+    return this.newAttachmentService.getAttachments(id).pipe(map((attachments: AttachmentUploadEditModel[]) => attachments.filter((a) => a.RegistrationTID === registrationTid)));
   }
 
   public getAllAttachmentsForRegistrationTid$(id: string, registrationTid: RegistrationTid): Observable<ExistingOrNewAttachment[]> {
-    return combineLatest([
-      this.getExistingAttachmentsForRegistrationTid$(id, registrationTid),
-      this.getNewAttachmentsForRegistrationTid$(id, registrationTid)])
-      .pipe(
-        map(([existingAttachments, newAttachments]) => [
-          ...existingAttachments.map((a) => ({ type: 'existing' as ExistingAttachmentType, attachment: a })),
-          ...newAttachments.map((a) => ({ type: 'new' as NewAttachmentType, attachment: a }))
-        ]));
+    return combineLatest([this.getExistingAttachmentsForRegistrationTid$(id, registrationTid), this.getNewAttachmentsForRegistrationTid$(id, registrationTid)]).pipe(
+      map(([existingAttachments, newAttachments]) => [
+        ...existingAttachments.map((a) => ({ type: 'existing' as ExistingAttachmentType, attachment: a })),
+        ...newAttachments.map((a) => ({ type: 'new' as NewAttachmentType, attachment: a }))
+      ])
+    );
   }
 
   private getRegistrationOfflineDocumentById(id: string): Observable<RxRegistrationDocument> {
     return this.getRegistrationDbCollectionForAppMode().pipe(
       switchMap((dbCollection) => dbCollection.findByIds$([id])),
-      map((result) => result.get(id)));
+      map((result) => result.get(id))
+    );
   }
 
   private getRegistrationObservable(): Observable<IRegistration[]> {
     return this.getRegistrationDbCollectionForAppMode().pipe(
       switchMap((dbCollection) => dbCollection.find().$.pipe(map((docs) => docs.map((doc) => doc.toJSON())))),
-      distinctUntilChanged((a, b) => deepEqual(a, b)));
+      distinctUntilChanged((a, b) => deepEqual(a, b))
+    );
   }
 
   private getRegistrationsDbCollection(appMode: AppMode): RxRegistrationCollection {
@@ -532,20 +573,23 @@ export class RegistrationService {
 
   private filterWhenProgressIsAllreadyRunning() {
     return (src: Observable<IRegistration[]>) =>
-      src.pipe(withLatestFrom(this.progressService.registrationSyncProgress$),
+      src.pipe(
+        withLatestFrom(this.progressService.registrationSyncProgress$),
         filter(([, syncProgress]) => !syncProgress.inProgress),
-        map(([records]) => records));
+        map(([records]) => records)
+      );
   }
 
   private getRegistrationsToSyncObservable(includeThrottle = false) {
     return this.registrationStorage$.pipe(
       switchMap((records) =>
-        records.length > 0 ?
-          from(Promise.all(records.map((reg) => this.shouldSync(reg, includeThrottle).then((shouldSync) => ({ reg, shouldSync })))))
-          // forkJoin(records.map((reg) => this.shouldSync(reg, includeThrottle).pipe(map((shouldSync) => ({ reg, shouldSync })))))
-          : of([])
+        records.length > 0
+          ? from(Promise.all(records.map((reg) => this.shouldSync(reg, includeThrottle).then((shouldSync) => ({ reg, shouldSync })))))
+          : // forkJoin(records.map((reg) => this.shouldSync(reg, includeThrottle).pipe(map((shouldSync) => ({ reg, shouldSync })))))
+            of([])
       ),
-      map((result) => result.filter((result) => result.shouldSync).map((result) => result.reg)));
+      map((result) => result.filter((result) => result.shouldSync).map((result) => result.reg))
+    );
   }
 
   public async isEmpty(reg: IRegistration): Promise<boolean> {
@@ -596,40 +640,46 @@ export class RegistrationService {
 
   private flattenRegistrationsToSync(ignoreVersionCheck: boolean) {
     return (src: Observable<IRegistration[]>) =>
-      src.pipe(mergeMap((rows) =>
-        concat(rows.map((row) => (this.syncRecord(row, ignoreVersionCheck)))),
-      ), mergeMap((r) => r));
+      src.pipe(
+        mergeMap((rows) => concat(rows.map((row) => this.syncRecord(row, ignoreVersionCheck)))),
+        mergeMap((r) => r)
+      );
   }
 
   private syncRecord(item: IRegistration, ignoreVersionCheck: boolean): Observable<ItemSyncCompleteStatus<IRegistration>> {
     return this.offlineRegistrationSyncService.syncItem(item, ignoreVersionCheck).pipe(
-      catchError((err) => of(({ item, success: false, error: err }))),
-      tap((result) => this.loggerService.log('Record sync complete', result)));
+      catchError((err) => of({ item, success: false, error: err })),
+      tap((result) => this.loggerService.log('Record sync complete', result))
+    );
   }
 
-  private mapItemSyncCompleteStatusToRegistration(): (src: Observable<ItemSyncCompleteStatus<IRegistration>>) =>
-  Observable<IRegistration>  {
+  private mapItemSyncCompleteStatusToRegistration(): (src: Observable<ItemSyncCompleteStatus<IRegistration>>) => Observable<IRegistration> {
     return (src: Observable<ItemSyncCompleteStatus<IRegistration>>) =>
-      src.pipe(map((r: ItemSyncCompleteStatus<IRegistration>) => ({
-        ...r.item,
-        lastSync: moment().unix(),
-        syncStatus: r.success ? SyncStatus.InSync : (r.statusCode === 0 ? SyncStatus.Sync : SyncStatus.Draft),
-        request: r.success ? cloneDeep(r.item.response) : cloneDeep(r.item.request),
-        syncStatusCode: r.statusCode,
-        syncError: r.error,
-      })));
+      src.pipe(
+        map((r: ItemSyncCompleteStatus<IRegistration>) => ({
+          ...r.item,
+          lastSync: moment().unix(),
+          syncStatus: r.success ? SyncStatus.InSync : r.statusCode === 0 ? SyncStatus.Sync : SyncStatus.Draft,
+          request: r.success ? cloneDeep(r.item.response) : cloneDeep(r.item.request),
+          syncStatusCode: r.statusCode,
+          syncError: r.error
+        }))
+      );
   }
 
-  private updateRowAndReturnItem(): (src: Observable<ItemSyncCompleteStatus<IRegistration>>) =>
-    Observable<IRegistration> {
+  private updateRowAndReturnItem(): (src: Observable<ItemSyncCompleteStatus<IRegistration>>) => Observable<IRegistration> {
     return (src: Observable<ItemSyncCompleteStatus<IRegistration>>) =>
-      src.pipe(this.mapItemSyncCompleteStatusToRegistration(),
+      src.pipe(
+        this.mapItemSyncCompleteStatusToRegistration(),
         switchMap((item: IRegistration) =>
-          this.saveRegistrationToOfflineStorage(item)
-            .pipe(catchError((err) => {
+          this.saveRegistrationToOfflineStorage(item).pipe(
+            catchError((err) => {
               this.loggerService.error('Could not update record in offline storage', err);
               return of([]);
-            }), map(() => item)))
+            }),
+            map(() => item)
+          )
+        )
       );
   }
 }

--- a/src/app/modules/registration/components/add-picture-item/add-picture-item.component.ts
+++ b/src/app/modules/registration/components/add-picture-item/add-picture-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, Input, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { ActionSheetController, Platform, ToastController } from '@ionic/angular';
 import { Camera, CameraOptions, PictureSourceType } from '@ionic-native/camera/ngx';
@@ -16,7 +16,6 @@ import { forkJoin, of } from 'rxjs';
 import { catchError, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 
-// const DATA_URL_TAG = 'data:image/jpeg;base64,';
 const DEBUG_TAG = 'AddPictureItemComponent';
 const MIME_TYPE = 'image/jpeg';
 
@@ -34,7 +33,6 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
   @Input() registrationId: string;
   @Input() registrationTid: RegistrationTid;
   @Input() geoHazard: GeoHazard;
-  @Output() imagesChange = new EventEmitter();
   @Input() title = 'REGISTRATION.ADD_IMAGES';
   @Input() pictureCommentText = 'REGISTRATION.IMAGE_DESCRIPTION';
   @Input() pictureCommentPlaceholder = 'REGISTRATION.IMAGE_DESCRIPTION_PLACEHOLDER';
@@ -67,7 +65,9 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
     this.newAttachmentService
       .getAttachments(this.registrationId)
       .pipe(
-        map((attachments) => attachments.filter((a) => a.RegistrationTID === this.registrationTid && a.type === this.attachmentType && a.ref === this.ref)),
+        map((attachments) =>
+          attachments.filter((a) => a.RegistrationTID === this.registrationTid && a.type === this.attachmentType && a.ref === this.ref)
+        ),
         switchMap((attachments) =>
           attachments.length === 0
             ? of([])
@@ -97,7 +97,12 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
       await Promise.resolve(this.onBeforeAdd());
     }
     const translations = await this.translateService
-      .get(['REGISTRATION.GENERAL_COMMENT.ADD_PICTURE', 'REGISTRATION.GENERAL_COMMENT.TAKE_NEW_PHOTO', 'REGISTRATION.GENERAL_COMMENT.CHOOSE_FROM_LIBRARY', 'DIALOGS.CANCEL'])
+      .get([
+        'REGISTRATION.GENERAL_COMMENT.ADD_PICTURE',
+        'REGISTRATION.GENERAL_COMMENT.TAKE_NEW_PHOTO',
+        'REGISTRATION.GENERAL_COMMENT.CHOOSE_FROM_LIBRARY',
+        'DIALOGS.CANCEL'
+      ])
       .toPromise();
     const actionSheet = await this.actionSheetController.create({
       header: translations['REGISTRATION.GENERAL_COMMENT.ADD_PICTURE'],
@@ -128,8 +133,6 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
       const options: CameraOptions = {
         quality: settings.images.quality,
         destinationType: this.camera.DestinationType.FILE_URI,
-        // NOTE: Base64 encode. If API supports upload image blob later,
-        // this should be changed to FILE_URL and uploaded separatly
         sourceType: sourceType,
         encodingType: this.camera.EncodingType.JPEG,
         mediaType: this.camera.MediaType.PICTURE,
@@ -140,22 +143,17 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
         // NOTE: saveToPhotoAlbum=true causes a bug in latest cordova cameraplugin
       };
       const imageUrl = await this.camera.getPicture(options);
-      if (await !this.validateImage(imageUrl)) {
-        this.showErrorToast();
+      if (!(await this.validateImage(imageUrl))) {
+        this.showErrorToast('REGISTRATION.INVALID_IMAGE'); //TODO: Vis bedre feilmelding
         return true;
       }
 
       this.logger.debug(`Got image url from camera plugin: ${imageUrl}`, DEBUG_TAG);
-      // const permanentUrl = await this.moveImageToPermanentStorage(imageUrl);
-      // this.logger.debug(
-      //   `Image moved to permanent image url: ${permanentUrl}`,
-      //   DEBUG_TAG
-      // );
       const arrayBuffer = await this.getArrayBuffer(imageUrl);
-      this.addImage(new Blob([arrayBuffer]), MIME_TYPE);
+      await this.addImage(new Blob([arrayBuffer]), MIME_TYPE);
     } catch (err) {
       this.logger.log('User could not add image, most likely no access or invalid image', err, LogLevel.Warning, DEBUG_TAG);
-      this.showErrorToast();
+      this.showErrorToast('Could not save image. Do you have enough space?'); //TODO: Vis bedre feilmelding og på flere språk
     }
     return true;
   }
@@ -180,8 +178,8 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
     return false;
   }
 
-  showErrorToast() {
-    this.translateService.get('REGISTRATION.INVALID_IMAGE').subscribe(async (translation) => {
+  showErrorToast(messageKey: string) {
+    this.translateService.get(messageKey).subscribe(async (translation) => {
       const toast = await this.toastController.create({
         message: translation,
         mode: 'md',
@@ -191,80 +189,25 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
     });
   }
 
-  // private async moveImageToPermanentStorage(src: string): Promise<string> {
-  //   const entry = await this.file.resolveLocalFilesystemUrl(src);
-  //   const rootDir = await this.file.resolveDirectoryUrl(
-  //     this.file.dataDirectory
-  //   );
-  //   const obsImgFolder = await this.file.getDirectory(rootDir, 'obsimages', {
-  //     create: true
-  //   });
-  //   const newSrc = await this.moveFile(entry, obsImgFolder);
-  //   return newSrc;
-  // }
-
-  // private moveFile(file: Entry, directory: DirectoryEntry): Promise<string> {
-  //   const newName = `${utils.uuid()}.jpg`;
-  //   return new Promise((resolve, reject) =>
-  //     file.moveTo(
-  //       directory,
-  //       newName,
-  //       (entry) => resolve(entry.toURL()),
-  //       (err) => reject(err)
-  //     )
-  //   );
-  // }
-
-  // private async deleteFile(src: string) {
-  //   try {
-  //     const entry = await this.file.resolveLocalFilesystemUrl(src);
-  //     await new Promise<void>((resolve, reject) =>
-  //       entry.remove(resolve, reject)
-  //     );
-  //   } catch (err) {
-  //     this.logger.log(
-  //       'Could not delete image',
-  //       err,
-  //       LogLevel.Warning,
-  //       DEBUG_TAG
-  //     );
-  //   }
-  // }
-
   private async addDummyImage() {
     const dummyImage = await DataUrlHelper.getDataUrlFromSrcUrl('/assets/images/dummyregobsimage.jpeg');
     const blob = DataUrlHelper.convertDataURIToBinary(dummyImage);
-    this.addImage(new Blob([blob]), 'image/jpeg');
+    await this.addImage(new Blob([blob]), 'image/jpeg');
   }
 
-  addImage(data: Blob, mimeType: string) {
-    // this.images.push({
-    //   PictureImageBase64: dataUrl,
-    //   RegistrationTID: this.registrationTid
-    // });
-    // TODO: Use new attachment service instead
-    // this.imagesChange.emit(this.images);
-    this.newAttachmentService.addAttachment(this.registrationId, data, mimeType, this.geoHazard, this.registrationTid, this.attachmentType, this.ref);
+  async addImage(data: Blob, mimeType: string) {
+    await this.newAttachmentService.addAttachment(
+      this.registrationId,
+      data,
+      mimeType,
+      this.geoHazard,
+      this.registrationTid,
+      this.attachmentType,
+      this.ref
+    );
   }
 
   removeImage(image: AttachmentUploadEditModel) {
     this.newAttachmentService.removeAttachment(this.registrationId, image.id);
-    // const index = this.images.indexOf(image);
-    // if (index >= 0) {
-    //   const imgSrc = image.PictureImageBase64;
-    //   this.images.splice(index, 1);
-    //   this.imagesChange.emit(this.images);
-    //   if (!this.isBase64Image(imgSrc)) {
-    //     this.deleteFile(imgSrc);
-    //   }
-    // }
-  }
-
-  // isBase64Image(img: string) {
-  //   return img && img.startsWith('data:image');
-  // }
-
-  convertFileSrc(fileUrl: string) {
-    return this.domSanitizer.bypassSecurityTrustUrl(this.webView.convertFileSrc(fileUrl));
   }
 }

--- a/src/app/modules/registration/components/add-picture-item/add-picture-item.component.ts
+++ b/src/app/modules/registration/components/add-picture-item/add-picture-item.component.ts
@@ -1,27 +1,18 @@
 import { Component, OnInit, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import {
-  ActionSheetController,
-  Platform,
-  ToastController
-} from '@ionic/angular';
-import {
-  Camera,
-  CameraOptions,
-  PictureSourceType
-} from '@ionic-native/camera/ngx';
+import { ActionSheetController, Platform, ToastController } from '@ionic/angular';
+import { Camera, CameraOptions, PictureSourceType } from '@ionic-native/camera/ngx';
 import { settings } from '../../../../../settings';
 import { AttachmentType, AttachmentUploadEditModel, RegistrationTid } from 'src/app/modules/common-registration/registration.models';
 import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
 import { DataUrlHelper } from '../../../../core/helpers/data-url.helper';
 import { WebView } from '@ionic-native/ionic-webview/ngx';
 import { DomSanitizer } from '@angular/platform-browser';
-import { File, FileEntry, IFile } from '@ionic-native/file/ngx';
+import { File } from '@ionic-native/file/ngx';
 import { LoggingService } from '../../../shared/services/logging/logging.service';
 import { LogLevel } from '../../../shared/services/logging/log-level.model';
-import * as utils from '@nano-sql/core/lib/utilities';
 import { GeoHazard } from '@varsom-regobs-common/core';
-import { forkJoin, from, Observable, of } from 'rxjs';
+import { forkJoin, of } from 'rxjs';
 import { catchError, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 
@@ -46,8 +37,7 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
   @Output() imagesChange = new EventEmitter();
   @Input() title = 'REGISTRATION.ADD_IMAGES';
   @Input() pictureCommentText = 'REGISTRATION.IMAGE_DESCRIPTION';
-  @Input() pictureCommentPlaceholder =
-    'REGISTRATION.IMAGE_DESCRIPTION_PLACEHOLDER';
+  @Input() pictureCommentPlaceholder = 'REGISTRATION.IMAGE_DESCRIPTION_PLACEHOLDER';
   @Input() icon = 'camera';
   @Input() showIcon = true;
   @Input() iconColor = 'dark';
@@ -68,26 +58,38 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
     private domSanitizer: DomSanitizer,
     private actionSheetController: ActionSheetController,
     private newAttachmentService: NewAttachmentService,
-    private cdr: ChangeDetectorRef,
+    private cdr: ChangeDetectorRef
   ) {
     super();
   }
 
   ngOnInit() {
-    this.newAttachmentService.getUploadedAttachments(this.registrationId)
+    this.newAttachmentService
+      .getAttachments(this.registrationId)
       .pipe(
-          map((attachments) => attachments.filter((a) => (a.RegistrationTID === this.registrationTid && a.type === this.attachmentType && a.ref === this.ref))), 
-          switchMap((attachments) => attachments.length === 0 ? of([]) : forkJoin([...attachments.map((a) => 
-            this.newAttachmentService.getBlob(this.registrationId, a.id).pipe(take(1), map((blob) => ({ ...a, blob })), catchError((err) => { 
-                  this.logger.error(err,  DEBUG_TAG, 'Could not get blob from attachment');
-                  return of(({ ...a, blob: undefined }));
-            })
-          ))])),
-          takeUntil(this.ngDestroy$)
-      ).subscribe((result) => {
+        map((attachments) => attachments.filter((a) => a.RegistrationTID === this.registrationTid && a.type === this.attachmentType && a.ref === this.ref)),
+        switchMap((attachments) =>
+          attachments.length === 0
+            ? of([])
+            : forkJoin([
+                ...attachments.map((a) =>
+                  this.newAttachmentService.getBlob(this.registrationId, a.id).pipe(
+                    take(1),
+                    map((blob) => ({ ...a, blob })),
+                    catchError((err) => {
+                      this.logger.error(err, DEBUG_TAG, 'Could not get blob from attachment');
+                      return of({ ...a, blob: undefined });
+                    })
+                  )
+                )
+              ])
+        ),
+        takeUntil(this.ngDestroy$)
+      )
+      .subscribe((result) => {
         this.attachments = result;
         this.cdr.detectChanges();
-      })
+      });
   }
 
   async addClick() {
@@ -95,12 +97,7 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
       await Promise.resolve(this.onBeforeAdd());
     }
     const translations = await this.translateService
-      .get([
-        'REGISTRATION.GENERAL_COMMENT.ADD_PICTURE',
-        'REGISTRATION.GENERAL_COMMENT.TAKE_NEW_PHOTO',
-        'REGISTRATION.GENERAL_COMMENT.CHOOSE_FROM_LIBRARY',
-        'DIALOGS.CANCEL'
-      ])
+      .get(['REGISTRATION.GENERAL_COMMENT.ADD_PICTURE', 'REGISTRATION.GENERAL_COMMENT.TAKE_NEW_PHOTO', 'REGISTRATION.GENERAL_COMMENT.CHOOSE_FROM_LIBRARY', 'DIALOGS.CANCEL'])
       .toPromise();
     const actionSheet = await this.actionSheetController.create({
       header: translations['REGISTRATION.GENERAL_COMMENT.ADD_PICTURE'],
@@ -110,10 +107,8 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
           handler: () => this.getPicture(this.camera.PictureSourceType.CAMERA)
         },
         {
-          text:
-            translations['REGISTRATION.GENERAL_COMMENT.CHOOSE_FROM_LIBRARY'],
-          handler: () =>
-            this.getPicture(this.camera.PictureSourceType.PHOTOLIBRARY)
+          text: translations['REGISTRATION.GENERAL_COMMENT.CHOOSE_FROM_LIBRARY'],
+          handler: () => this.getPicture(this.camera.PictureSourceType.PHOTOLIBRARY)
         },
         {
           text: translations['DIALOGS.CANCEL'],
@@ -141,7 +136,7 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
         targetHeight: settings.images.size,
         targetWidth: settings.images.size,
         correctOrientation: true,
-        saveToPhotoAlbum: sourceType === PictureSourceType.CAMERA,
+        saveToPhotoAlbum: sourceType === PictureSourceType.CAMERA
         // NOTE: saveToPhotoAlbum=true causes a bug in latest cordova cameraplugin
       };
       const imageUrl = await this.camera.getPicture(options);
@@ -150,10 +145,7 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
         return true;
       }
 
-      this.logger.debug(
-        `Got image url from camera plugin: ${imageUrl}`,
-        DEBUG_TAG
-      );
+      this.logger.debug(`Got image url from camera plugin: ${imageUrl}`, DEBUG_TAG);
       // const permanentUrl = await this.moveImageToPermanentStorage(imageUrl);
       // this.logger.debug(
       //   `Image moved to permanent image url: ${permanentUrl}`,
@@ -162,12 +154,7 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
       const arrayBuffer = await this.getArrayBuffer(imageUrl);
       this.addImage(new Blob([arrayBuffer]), MIME_TYPE);
     } catch (err) {
-      this.logger.log(
-        'User could not add image, most likely no access or invalid image',
-        err,
-        LogLevel.Warning,
-        DEBUG_TAG
-      );
+      this.logger.log('User could not add image, most likely no access or invalid image', err, LogLevel.Warning, DEBUG_TAG);
       this.showErrorToast();
     }
     return true;
@@ -194,16 +181,14 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
   }
 
   showErrorToast() {
-    this.translateService
-      .get('REGISTRATION.INVALID_IMAGE')
-      .subscribe(async (translation) => {
-        const toast = await this.toastController.create({
-          message: translation,
-          mode: 'md',
-          duration: 4000
-        });
-        toast.present();
+    this.translateService.get('REGISTRATION.INVALID_IMAGE').subscribe(async (translation) => {
+      const toast = await this.toastController.create({
+        message: translation,
+        mode: 'md',
+        duration: 4000
       });
+      toast.present();
+    });
   }
 
   // private async moveImageToPermanentStorage(src: string): Promise<string> {
@@ -247,22 +232,19 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
   // }
 
   private async addDummyImage() {
-    const dummyImage = await DataUrlHelper.getDataUrlFromSrcUrl(
-      '/assets/images/dummyregobsimage.jpeg'
-    );
+    const dummyImage = await DataUrlHelper.getDataUrlFromSrcUrl('/assets/images/dummyregobsimage.jpeg');
     const blob = DataUrlHelper.convertDataURIToBinary(dummyImage);
     this.addImage(new Blob([blob]), 'image/jpeg');
   }
 
   addImage(data: Blob, mimeType: string) {
     // this.images.push({
-    //   PictureImageBase64: dataUrl, 
+    //   PictureImageBase64: dataUrl,
     //   RegistrationTID: this.registrationTid
     // });
     // TODO: Use new attachment service instead
     // this.imagesChange.emit(this.images);
-    this.newAttachmentService.addAttachment(this.registrationId, data, mimeType, this.geoHazard, this.registrationTid, this.attachmentType,
-       this.ref);
+    this.newAttachmentService.addAttachment(this.registrationId, data, mimeType, this.geoHazard, this.registrationTid, this.attachmentType, this.ref);
   }
 
   removeImage(image: AttachmentUploadEditModel) {
@@ -283,8 +265,6 @@ export class AddPictureItemComponent extends NgDestoryBase implements OnInit {
   // }
 
   convertFileSrc(fileUrl: string) {
-    return this.domSanitizer.bypassSecurityTrustUrl(
-      this.webView.convertFileSrc(fileUrl)
-    );
+    return this.domSanitizer.bypassSecurityTrustUrl(this.webView.convertFileSrc(fileUrl));
   }
 }

--- a/src/app/modules/registration/pages/base-page-service.ts
+++ b/src/app/modules/registration/pages/base-page-service.ts
@@ -41,50 +41,21 @@ export class BasePageService {
     private ngZone: NgZone,
     private alertController: AlertController,
     private translateService: TranslateService,
-    private loggingService: LoggingService,
+    private loggingService: LoggingService
   ) {}
 
-  async confirmLeave(
-    registration: IRegistration,
-    registrationTid: RegistrationTid,
-    onReset?: () => void
-  ) {
-    const leaveText = await this.translateService
-      .get('REGISTRATION.REQUIRED_FIELDS_MISSING')
-      .toPromise();
-    return this.createResetDialog(
-      leaveText,
-      registration,
-      registrationTid,
-      onReset
-    );
+  async confirmLeave(registration: IRegistration, registrationTid: RegistrationTid, onReset?: () => void) {
+    const leaveText = await this.translateService.get('REGISTRATION.REQUIRED_FIELDS_MISSING').toPromise();
+    return this.createResetDialog(leaveText, registration, registrationTid, onReset);
   }
 
-  async confirmReset(
-    registration: IRegistration,
-    registrationTid: RegistrationTid,
-    onReset?: () => void
-  ) {
-    const leaveText = await this.translateService
-      .get('REGISTRATION.CONFIRM_RESET')
-      .toPromise();
-    return this.createResetDialog(
-      leaveText,
-      registration,
-      registrationTid,
-      onReset
-    );
+  async confirmReset(registration: IRegistration, registrationTid: RegistrationTid, onReset?: () => void) {
+    const leaveText = await this.translateService.get('REGISTRATION.CONFIRM_RESET').toPromise();
+    return this.createResetDialog(leaveText, registration, registrationTid, onReset);
   }
 
-  private async createResetDialog(
-    message: string,
-    registration: IRegistration,
-    registrationTid: RegistrationTid,
-    onReset?: () => void
-  ) {
-    const translations = await this.translateService
-      .get(['DIALOGS.CANCEL', 'DIALOGS.YES'])
-      .toPromise();
+  private async createResetDialog(message: string, registration: IRegistration, registrationTid: RegistrationTid, onReset?: () => void) {
+    const translations = await this.translateService.get(['DIALOGS.CANCEL', 'DIALOGS.YES']).toPromise();
     const alert = await this.alertController.create({
       message,
       buttons: [
@@ -106,17 +77,11 @@ export class BasePageService {
     return reset;
   }
 
-  async reset(
-    registration: IRegistration,
-    registrationTid: RegistrationTid,
-    onReset?: () => void
-  ) {
+  async reset(registration: IRegistration, registrationTid: RegistrationTid, onReset?: () => void) {
     this.Zone.run(() => {
       if (registrationTid) {
-        registration.request[
-          getPropertyName(registrationTid)
-        ] = this.getDefaultValue(registrationTid);
-        this.resetImages(registration, registrationTid);
+        registration.request[getPropertyName(registrationTid)] = this.getDefaultValue(registrationTid);
+        this.resetImages(registration);
       }
       if (onReset) {
         onReset();
@@ -125,10 +90,7 @@ export class BasePageService {
     await this.registrationService.saveRegistrationAsync(registration);
   }
 
-  createDefaultProps(
-    registration: IRegistration,
-    registrationTid: RegistrationTid
-  ) {
+  createDefaultProps(registration: IRegistration, registrationTid: RegistrationTid) {
     const propName = getPropertyName(registrationTid);
     if (!registration.request[propName]) {
       // Init to new object if null
@@ -144,12 +106,17 @@ export class BasePageService {
     }
   }
 
-  resetImages(registration: IRegistration, registrationTid: RegistrationTid) {
-    this.newAttachmentService.getUploadedAttachments(registration.id).pipe(switchMap((attachments) => 
-      forkJoin(attachments.map((a) => this.newAttachmentService.removeAttachment(registration.id, a.id))))).subscribe(() => {
-        this.loggingService.debug('Reset images complete', DEBUG_TAG);
-      }, (error) => {
-        this.loggingService.error(error, DEBUG_TAG, 'Could not reset images');
-      });
+  resetImages(registration: IRegistration) {
+    this.newAttachmentService
+      .getAttachments(registration.id)
+      .pipe(switchMap((attachments) => forkJoin(attachments.map((a) => this.newAttachmentService.removeAttachment(registration.id, a.id)))))
+      .subscribe(
+        () => {
+          this.loggingService.debug('Reset images complete', DEBUG_TAG);
+        },
+        (error) => {
+          this.loggingService.error(error, DEBUG_TAG, 'Could not reset images');
+        }
+      );
   }
 }

--- a/src/app/modules/registration/pages/danger-obs/danger-obs.page.html
+++ b/src/app/modules/registration/pages/danger-obs/danger-obs.page.html
@@ -29,7 +29,7 @@
           {{ 'REGISTRATION.ADD_IMAGES' | translate}}
         </ion-label>
       </ion-list-header>
-      <app-add-picture-item (imagesChange)="save()"
+      <app-add-picture-item
         [registrationTid]="registrationTid" [geoHazard]="registration.geoHazard" [registrationId]="registration.id"></app-add-picture-item>
     </ion-list>
   </app-registration-content-wrapper>


### PR DESCRIPTION
- [x] Oppdaget at hvis vi sletter ett og ett bilde til vi ikke har flere bilder igjen, så blir selve "registrerings-mappa" liggende igjen for alltid, selv om vi sletter registreringa. Jeg ser om jeg kan sjekke dette når vi sletter enkeltbilder.
- [x] NB! På min tlf. går det supertreigt å legge til bilder nå. Det gjorde det ikke da vi begynte å teste på tirsdag. Tar flere sekunder fra jeg trykker på bilde-knappen til jeg får opp menyen om jeg skal velge fra album eller bruke kameraet. I intern-test-versjonen kommer menyen opp med en gang. Dette bør vi sjekke. Det er onBeforeAdd() i AddPictureItemComponent.addClick() som bruker lang tid, og det virker som onBeforeAdd() trigger en saveRegistration() i RegistrationService (fra common-koden). Har det vært noen endringer i dette kallet nå nylig?
**Trenger vi egentlig å lagre registreringa før man legger til bilder?** 