### PR TITLE
Set zoom level from package root tile

### DIFF
--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
@@ -40,7 +40,7 @@ export class OfflinePackageModalComponent implements OnInit {
       tap(() => this.cdr.detectChanges() ));
     this.tileLayer = new L.GeoJSON(this.feature);
     
-    // Set zoom layer from package bounds
+    // Set center from package bounds
     const { lat, lng } = this.tileLayer.getBounds().getCenter();
     this.center = [lat, lng];
 


### PR DESCRIPTION
Vi kan bruke zoom-nivået til root-flisa når vi setter kartutsnittet på detaljsida.
Fikser forhåpentligvis feilen.