### PR TITLE
RO-1389: Forsøk på å legge offline-kart i eget kartlag underst

### DIFF
--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -280,34 +280,10 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     // zooming in/out etc.
     this.offlineMapService.packages$
       .pipe(takeUntil(this.ngDestroy$))
-      .subscribe((packages) => this.redrawOfflineLayers(packages));
+      .subscribe(() => this.redrawOfflineLayers());
   }
 
-  private findLayer(id : string): boolean {
-    this.layerGroup.eachLayer((layer) => {
-      if (layer instanceof L.TileLayer) {
-        const tileLayer: L.TileLayer = layer;
-        if (tileLayer.options.id === id) {
-          return true;
-        }
-      }
-    })
-    return false;
-  }
-
-  private redrawOfflineLayers(packages: OfflineMapPackage[]) {
-    packages[0].compoundPackageMetadata.getParts();
-    const layerType = 'statensKartverk'; //TODO: Fjern hardkoding
-    const layerId = `offline-${layerType}`; //TODO: Fjern hardkoding
-    if (!this.findLayer(layerId)) {
-      //create offline background layer first time
-      const options: IRegObsTileLayerOptions = {
-        id: layerId,
-        maxNativeZoom: 14 //TODO: Fjern hardkoding
-      }
-      const layer =  new RegObsOfflineAwareTileLayer(layerType, null, options, this.offlineMapService.offlineTilesRegistry, this.loggingService);
-      this.layerGroup.addLayer
-    }
+  private redrawOfflineLayers() {
     this.layerGroup.eachLayer((layer) => {
       if (layer instanceof RegObsOfflineAwareTileLayer) {
         layer.redraw();
@@ -377,7 +353,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     const options: IRegObsTileLayerOptions = {
       ...this.getTileLayerDefaultOptions(userSetting.useRetinaMap),
       id: layerId,
-      maxNativeZoom: 14 //TODO: Fjern hardkoding
+      maxNativeZoom: 14 //Tiles from level 14 will be scaled up if we go deeper. TODO: Fjern hardkoding
     }
     return  new RegObsOfflineAwareTileLayer(layerType, null, options, this.offlineMapService.offlineTilesRegistry, this.loggingService);
   }
@@ -389,7 +365,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       
       if (isAndroidOrIos(this.platform)) {
         const offlineTopoLayer = this.createOfflineTopoLayer(userSetting);
-        offlineTopoLayer.addTo(this.layerGroup);
+        offlineTopoLayer.addTo(this.layerGroup); //TODO: Passe på at laget havner underst?
       }
 
       const createTileLayerFactory = this.getTileLayerFactory(

--- a/src/app/modules/map/core/classes/regobs-tile-layer.ts
+++ b/src/app/modules/map/core/classes/regobs-tile-layer.ts
@@ -64,15 +64,13 @@ export class RegObsOfflineAwareTileLayer extends RegObsTileLayer {
   }
 
   /**
-   * @returns url to an offline tile if available, or else default online tile url
+   * @returns url to an offline tile if available
    */
   getTileUrl(coords: L.Coords): string {
     let url: string;
     const offlineMapUrl = this.offlineTilesRegistry.getUrl(this.mapType, coords.x, coords.y, coords.z);
     if (offlineMapUrl) {
       url = `${offlineMapUrl}/${coords.z}/${coords.x}/${coords.y}.png`;
-    } else {
-      url = super.getTileUrl(coords);
     }
     this.loggingService.debug('Tile url:', DEBUG_TAG, coords.x, coords.y, coords.z, url);
     return url;


### PR DESCRIPTION
Har testet på Android. Fungerer bra når vi er helt offline, da vises offline-kartet.
Nå risikerer vi heller ikke å ikke få noe kart, fordi offline-kartet vises også om vi velger Geodata-kartet.
Autoskalering av offline-kartet fungerer også bra, slik at fliser > nivå 14 forstørres i stedet for å gi feilmelding.
Det som ikke funker så bra er hvis vi har dårlig dekning. Da vil flisene i online-laget dekke over offline-laget inntil vi ryker på en timeout, og den virker altfor lang.
Forslag til løsninger på det siste mottas med takk!