### PR TITLE
RO-1470: Spør om lov før vi lagrer kartpakker på telefon

### DIFF
--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -28,11 +28,7 @@ const ROOT_MAP_DIR = 'maps';
 
 function arrayBufferToBase64(buffer: ArrayBuffer) {
   let binary = '';
-  const bytes = new Uint8Array(buffer);
-  const len = bytes.byteLength;
-  for (let i = 0; i < len; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
+  new Uint8Array(buffer).forEach((byte) => binary += String.fromCharCode(byte));
   return btoa(binary);
 }
 


### PR DESCRIPTION
Nå sjekker vi (og evt. spør) om lov til å lagre filer i Android før vi starter å laste ned kartpakke.
Det ble litt rotete fordi jeg også fikk med en masse lint-fiks, men den eneste endringen i funksjonalitet er bruk av funksjonen isPermissionToSaveFilesDenied().