### PR TITLE
Make it blatantly clear what's online-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6205,9 +6205,9 @@
       }
     },
     "@varsom-regobs-common/translations": {
-      "version": "1.0.184",
-      "resolved": "https://registry.npmjs.org/@varsom-regobs-common/translations/-/translations-1.0.184.tgz",
-      "integrity": "sha512-vzHdJwvBQy+0UaW9ukdk+kWoAHZ0NQ2KjYzKB5e+veRViSIcrHmJyIYh/rqpHvWLrNwGGuj80Y4JRIvjAU6EUQ=="
+      "version": "1.0.185",
+      "resolved": "https://registry.npmjs.org/@varsom-regobs-common/translations/-/translations-1.0.185.tgz",
+      "integrity": "sha512-MDg5m+xclNMKqi/eRf6Sp/2x0wxiCuPLsww5OwKfIvhA1UJ/NMStjsmUUnrnvimaOJnHw4YksfKaKFwkoscsCg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",

--- a/src/app/core/models/support-tile.model.ts
+++ b/src/app/core/models/support-tile.model.ts
@@ -8,4 +8,5 @@ export interface SupportTile {
   opacity: number;
   geoHazardId: GeoHazard;
   disableWhenEnabled?: string[];
+  availableOffline?: boolean;
 }

--- a/src/app/core/models/user-settings.model.ts
+++ b/src/app/core/models/user-settings.model.ts
@@ -22,4 +22,5 @@ export interface UserSetting {
   featureToggeGpsDebug: boolean;
   infoAboutObservationsRecievedTimestamp?: number;
   infoAboutSupportMapsRecievedTimestamp?: number;
+  infoAboutOfflineSupportMapsRecievedTimestamp?: number;
 }

--- a/src/app/core/models/user-settings.model.ts
+++ b/src/app/core/models/user-settings.model.ts
@@ -20,7 +20,7 @@ export interface UserSetting {
   consentForSendingAnalyticsDialogCompleted: boolean;
   featureToggleDeveloperMode: boolean;
   featureToggeGpsDebug: boolean;
-  infoAboutObservationsRecievedTimestamp?: number;
-  infoAboutSupportMapsRecievedTimestamp?: number;
-  infoAboutOfflineSupportMapsRecievedTimestamp?: number;
+  infoAboutObservationsRecievedTimestamps?: {[name: string]: number};
+  infoAboutSupportMapsRecievedTimestamps?: {[name: string]: number};
+  infoAboutOfflineSupportMapsRecievedTimestamps?: {[name: string]: number};
 }

--- a/src/app/modules/side-menu/components/support-tiles-menu/support-tiles-menu.component.html
+++ b/src/app/modules/side-menu/components/support-tiles-menu/support-tiles-menu.component.html
@@ -6,7 +6,7 @@
         {{'SUPPORT_MAP.' +supportTile.description | translate }}
       </ion-label>
       <ion-toggle [checked]="supportTile.enabled" [(ngModel)]="supportTile.enabled"
-        (ionChange)="onTileChanged(supportTile)" (click)="checkForInfoPopup(!supportTile.enabled)">
+        (ionChange)="onTileChanged(supportTile)" (click)="checkForInfoPopup(!supportTile.enabled, supportTile)">
       </ion-toggle>
     </ion-item>
     <div class="inner-list-panel" *ngIf="supportTile.enabled">

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -163,7 +163,8 @@ export const settings = {
           enabled: true,
           opacity: 0.5,
           geoHazardId: 10,
-          disableWhenEnabled: ['steepness']
+          disableWhenEnabled: ['steepness'],
+          availableOffline: true
         },
         {
           name: 'steepness',
@@ -173,7 +174,8 @@ export const settings = {
           enabled: false,
           opacity: 0.5,
           geoHazardId: 10,
-          disableWhenEnabled: ['steepness-outlet']
+          disableWhenEnabled: ['steepness-outlet'],
+          availableOffline: false
         },
         {
           name: 'clayzones',
@@ -182,7 +184,8 @@ export const settings = {
             'https://gis2.nve.no/arcgis/rest/services/wmts/Kvikkleire_Jordskred/MapServer/tile/{z}/{y}/{x}',
           enabled: true,
           opacity: 0.5,
-          geoHazardId: 20
+          geoHazardId: 20,
+          availableOffline: false
         },
         {
           name: 'floodzoones',
@@ -191,7 +194,8 @@ export const settings = {
             'https://gis3.nve.no/arcgis/rest/services/wmts/Flomsoner1/MapServer/tile/{z}/{y}/{x}',
           enabled: true,
           opacity: 0.5,
-          geoHazardId: 60
+          geoHazardId: 60,
+          availableOffline: false
         },
         {
           name: 'weakenedice',
@@ -200,7 +204,8 @@ export const settings = {
             'https://gis3.nve.no/arcgis/rest/services/wmts/SvekketIs/MapServer/tile/{z}/{y}/{x}',
           enabled: true,
           opacity: 0.5,
-          geoHazardId: 70
+          geoHazardId: 70,
+          availableOffline: true
         }
       ],
       supportTilesBounds: [


### PR DESCRIPTION
This change throws up a popup every time the user activates
an online-only support map. It also rebases some of the
popup code, since it started to have quite a bit of copied
code.