### PR TITLE
RO-1475: Fiks for å kunne installere app på nytt på Android uten å avinstallere først

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ng": "ng",
     "generate-swagger-api-module": "ng-swagger-gen -c ng-swagger-gen.json",
     "start": "ionic serve",
-    "build": "ionic build",
+    "build": "npm run create-version-file && ionic build",
     "build:prod": "ng build --configuration production",
     "cap:sync": "jetify && cap sync",
     "test": "ng test --watch=false --browsers=\"ChromeHeadless\" --code-coverage",


### PR DESCRIPTION
Gnererer nå versjonnummer automatisk når vi kjører 
`npm run build`
for å kunne redeploye på Android uten å avinstallere først.

Takk til Jørgen for denne!
Den har den ulempen at vi da får endret manifest og plist.info, så man må passe på å ikke sjekke inn disse etterpå