### PR TITLE
RO-1532: Nå fjerner vi overvannshøyde hvis overvann før boring ikke er valgt

### DIFF
--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.ts
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.ts
@@ -48,7 +48,7 @@ export class IceThicknessPage extends BasePage {
 
   onBeforeLeave() {
     if (this.registration) {
-      if (this.iceHeightBefore === undefined) {
+      if (this.iceHeightBefore !== true) {
         this.registration.request.IceThickness.IceHeightBefore = undefined;
       } else if (this.registration.request.IceThickness.IceHeightBefore > 0) {
         this.registration.request.IceThickness.IceHeightBefore =


### PR DESCRIPTION
Hvordan teste:

1. Registrer istykkelse
2. Velg ja på overvann og sett f.eks 2 cm på overvannets tykkelse (feltet som dukker opp når man skriver Ja), 
3. Velg nei på overvann
4. Gå tilbake til min observasjon
5. Velg istykkelse
6. Det skal nå ikke være noe felt for overvannets tykkelse. Feilen var at dette feltet ble hengende igjen med verdien du satte.
