### PR TITLE
RO-1541: Håndere feil under utpakking på en smartere måte

### DIFF
--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -429,13 +429,12 @@ export class OfflineMapService {
     if (isDownloading) {
       messageKey = 'OFFLINE_MAP.DOWNLOAD_ERROR_MESSAGE';
     } else if (this.availableDiskspace?.available > 300000000) {
+      //we have more than 300MB available
       messageKey = 'OFFLINE_MAP.UNZIP_ERROR_MESSAGE_GENERIC';
     } else {
       messageKey = 'OFFLINE_MAP.UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT';
     }
-    const translations = await this.translateService
-      .get([messageKey, 'ALERT.OK'])
-      .toPromise();
+    const translations = await firstValueFrom(this.translateService.get([messageKey, 'ALERT.OK']));
     const alert = await this.alertController.create({
       message: translations[messageKey],
       buttons: [

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -237,7 +237,8 @@
       "DOWNLOADING_PART_X_OF_Y": "Downloading part {{n}} of {{totalParts}}",
       "UNZIP_PART_X_OF_Y": "Unzipping part {{n}} of {{totalParts}}"
     },
-    "UNZIP_ERROR_MESSAGE": "Could not save map package to disk. Are you sure there is enough disk space?"
+    "UNZIP_ERROR_MESSAGE_GENERIC": "Could not save map package to disk. Please try again",
+    "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Could not save map package to disk. Are you sure there is enough disk space?"
   },
   "PERMISSION": {
     "LOCATION_DENIED_HEADER": "Permission to location denied",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -237,7 +237,8 @@
       "DOWNLOADING_PART_X_OF_Y": "Laster ned {{n}} av {{totalParts}}",
       "UNZIP_PART_X_OF_Y": "Pakker ut {{n}} av {{totalParts}}"
     },
-    "UNZIP_ERROR_MESSAGE": "Klarte ikke lagre kartpakke på disk. Er du sikker på at det er nok plass tilgjengelig?"
+    "UNZIP_ERROR_MESSAGE_GENERIC": "Klarte ikke lagre kartpakke på disk. Vennligst prøv igjen!",
+    "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Klarte ikke lagre kartpakke på disk. Er du sikker på at det er nok plass tilgjengelig?"
   },
   "PERMISSION": {
     "LOCATION_DENIED_HEADER": "Tilgang til posisjon nektet",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -204,7 +204,9 @@
       "DOWNLOADING_PART_X_OF_Y": "Laddar ner fil {{n}} av {{totalParts}}",
       "UNZIP_PART_X_OF_Y": "Packar upp fil {{n}} av {{totalParts}}"
     },
-    "UNZIP_ERROR_MESSAGE": "Lyckades ej spara kartpaketet till disk. Har du nog med diskutrymme?"
+    "UNZIP_ERROR_MESSAGE_GENERIC": "Lyckades ej spara kartpaketet till disk. Vänligen prøva igjen!",
+    "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Lyckades ej spara kartpaketet till disk. Har du nog med diskutrymme?"
+
   },
   "PERMISSION": {
     "LOCATION_DENIED_HEADER": "Tillstånd till plats nekas",


### PR DESCRIPTION
Hvis det feiler når vi prøver å skrive fila til disk, vil vi nå prøve fire ganger til før vi gir opp.
Om vi har mindre enn 300MB på telefonen, viser vi den gamle feilmeldinga om at du bør sjekke om du har nok plass.
Hvis vi har mer plass enn dette, viser vi en mer generell feilmelding.
Har også forsøkt å forenkle koden litt ved å splitte opp noen av de lange funksjonene.

Testet på Android (dog ikke med å fylle opp tlf, men med å trikse med 300MB-grensa).