### PR TITLE
Vise også nedlastede pakker i lista

### DIFF
--- a/src/app/core/services/helpers/helper.service.ts
+++ b/src/app/core/services/helpers/helper.service.ts
@@ -35,7 +35,7 @@ export class HelperService {
     );
   }
 
-  humanReadableByteSize(bytes: number, si = true) {
+  humanReadableByteSize(bytes: number, fractionDigits = 1, si = true) {
     const thresh = si ? 1000 : 1024;
     if (Math.abs(bytes) < thresh) {
       return bytes + ' B';
@@ -48,6 +48,6 @@ export class HelperService {
       bytes /= thresh;
       ++u;
     } while (Math.abs(bytes) >= thresh && u < units.length - 1);
-    return bytes.toFixed(1) + ' ' + units[u];
+    return bytes.toFixed(fractionDigits) + ' ' + units[u];
   }
 }

--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -26,20 +26,18 @@
 <ion-footer>
   <ion-list>
     <ion-item *ngIf="packageTotals$ | async as packageTotals" (click)="expanded = !expanded" lines="full">
-      <ion-label class="package-count">{{ 'OFFLINE_MAP.PACKAGE_COUNT' | translate:{packageCount: packageTotals.numPackages} }}</ion-label>
-      <ion-label>
-        <span class="packages-size">{{ packageTotals.spaceUsed }}</span>&nbsp; 
-        <span class="space-available">({{ 'OFFLINE_MAP.SPACE_AVAILABLE' | translate:{spaceAvailable: getSpaceAvailable()} }})</span>
-      </ion-label>
+      <ion-label *ngIf="packageTotals.numPackages === 1" class="package-count">{{ 'OFFLINE_MAP.PACKAGE_COUNT_SINGLE' | translate:{packageCount: packageTotals.numPackages} }}</ion-label>
+      <ion-label *ngIf="packageTotals.numPackages !== 1" class="package-count">{{ 'OFFLINE_MAP.PACKAGE_COUNT_MULTIPLE' | translate:{packageCount: packageTotals.numPackages} }}</ion-label>
+      <ion-label class="packages-size">{{ packageTotals.spaceUsed }}</ion-label>
+      <ion-label class="space-available">({{ 'OFFLINE_MAP.SPACE_AVAILABLE' | translate:{spaceAvailable: getSpaceAvailable()} }})</ion-label>
       <ion-icon *ngIf="packageTotals.numPackages > 0" slot="end" [name]="expanded ? 'chevron-down-circle' : 'chevron-up-circle'" class="expand-icon"></ion-icon>
     </ion-item>
     <div class="footer">
-      <ng-container *ngIf="expanded && downloadAndUnzipProgress$ | async as items">
+      <ng-container *ngIf="expanded && allPackages$ | async as items">
         <ion-item (click)="showPackageModalForPackage(item)" *ngFor="let item of items" lines="full">
           <ion-label>{{ item.name }}</ion-label>
           <ion-label>{{ humanReadableByteSize(item.size) }}</ion-label>
-          <ion-label *ngIf="isDownloading(item)">
-            ({{getPercentage(item) +'%' }})</ion-label>
+          <ion-label>{{ formatProgressIfDownloading(item) }}</ion-label>
           <ion-icon slot="end" *ngIf="item.error" name="warning-outline"></ion-icon>
           <ion-icon slot="end" *ngIf="!(item.error)" (click)="cancelOrDelete(item, $event)" name="trash-outline"></ion-icon>
         </ion-item>

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -45,9 +45,9 @@ interface PackageTotals {
 export class OfflineMapPage extends NgDestoryBase {
   private readonly installedPackages$: Observable<Map<string, OfflineMapPackage>>;
   private installedPackages: Map<string, OfflineMapPackage> = new Map();
-  downloadAndUnzipProgress$: Observable<OfflineMapPackage[]>;
+  private downloadAndUnzipProgress$: Observable<OfflineMapPackage[]>;
   packageTotals$: Observable<PackageTotals>;
-  private readonly allPackages$: Observable<OfflineMapPackage[]>;
+  readonly allPackages$: Observable<OfflineMapPackage[]>;
   private packagesOnServer$: Observable<Map<string, CompoundPackage>>;
   private packagesOnServer: Map<string, CompoundPackage> = new Map();
   showTileCard = true;
@@ -237,21 +237,25 @@ export class OfflineMapPage extends NgDestoryBase {
   }
 
   showPackageModalForPackage(map: OfflineMapPackage) {
-    const feature = this.featureMap.get(map.compoundPackageMetadata.getName());
-    if(feature) {
+    const feature = this.featureMap.get(map.name);
+    if (feature) {
       this.showPackageModal(feature.feature);
     }
   }
 
-  humanReadableByteSize(bytes: number): string {
+  humanReadableByteSize(bytes: number, fractionDigits = 0): string {
     if (isNaN(bytes)) {
       return '';
     }
-    return this.helperService.humanReadableByteSize(bytes, true);
+    return this.helperService.humanReadableByteSize(bytes, fractionDigits, true);
   }
 
-  getPercentage(map: OfflineMapPackage): number {
-    return Math.round((map.progress ? map.progress.percentage : 0) * 100);
+  formatProgressIfDownloading(map: OfflineMapPackage): string {
+    if (map.downloadStart && !map.downloadComplete) {
+      const value = Math.round((map.progress ? map.progress.percentage : 0) * 100);
+      return `(${value}%)`;
+    }
+    return '';
   }
 
   async cancelOrDelete(map: OfflineMapPackage, event: Event) {
@@ -281,15 +285,11 @@ export class OfflineMapPage extends NgDestoryBase {
     }
   }
 
-  isDownloading(map: OfflineMapPackage): boolean {
-    return map.downloadStart && !map.downloadComplete;
-  }
-
   isDownloaded(map: OfflineMapPackage): boolean {
     return !!map.downloadComplete;
   }
 
   getSpaceAvailable(): string {
-    return this.humanReadableByteSize(this.offlineMapService.availableDiskspace?.available);
+    return this.humanReadableByteSize(this.offlineMapService.availableDiskspace?.available, 0);
   }
 }

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -261,18 +261,17 @@ export class OfflineMapPage extends NgDestoryBase {
   async cancelOrDelete(map: OfflineMapPackage, event: Event) {
     event.stopPropagation();
     if (this.isDownloaded(map)) {
-      const toTranslate = ['DIALOGS.ARE_YOU_SURE', 'DIALOGS.CANCEL', 'DIALOGS.OK'];
+      const toTranslate = ['OFFLINE_MAP.DELETE_PACKAGE_CONFIRM', 'DIALOGS.CANCEL', 'DIALOGS.DELETE'];
       const translations = await firstValueFrom(this.translateService.get(toTranslate));
       const alert = await this.alertController.create({
-        header: translations['DIALOGS.ARE_YOU_SURE'],
-        message: translations['DIALOGS.ARE_YOU_SURE'],
+        message: translations['OFFLINE_MAP.DELETE_PACKAGE_CONFIRM'],
         buttons: [
           {
             text: translations['DIALOGS.CANCEL'],
             role: 'cancel'
           },
           {
-            text: translations['DIALOGS.OK'],
+            text: translations['DIALOGS.DELETE'],
             handler: () => {
               this.offlineMapService.removeMapPackageByName(map.name);
             }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -240,7 +240,8 @@
       "UNZIP_PART_X_OF_Y": "Unzipping part {{n}} of {{totalParts}}"
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Could not save map package to disk. Please try again",
-    "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Could not save map package to disk. Are you sure there is enough disk space?"
+    "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Could not save map package to disk. Are you sure there is enough disk space?",
+    "DELETE_PACKAGE_CONFIRM": "Delete this map package?"
   },
   "PERMISSION": {
     "LOCATION_DENIED_HEADER": "Permission to location denied",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -219,7 +219,8 @@
   "OFFLINE_MAP": {
     "DISKSPACE_ERROR_MESSAGE": "Not enough disk space available to store offline map package. Please free up some disk space and try again.",
     "DOWNLOAD_ERROR_MESSAGE": "Could not download map package. Make sure you have a stable internet connection.",
-    "PACKAGE_COUNT": "{{packageCount}} map packages",
+    "PACKAGE_COUNT_SINGLE": "{{packageCount}} package",
+    "PACKAGE_COUNT_MULTIPLE": "{{packageCount}} packages",
     "SPACE_AVAILABLE": "{{spaceAvailable}} free",
     "MAP_PACKAGE_DETAILS_PAGE": {
       "CANCEL_DOWNLOAD_BUTTON": "Cancel download",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -240,7 +240,8 @@
       "UNZIP_PART_X_OF_Y": "Pakker ut {{n}} av {{totalParts}}"
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Klarte ikke lagre kartpakke på disk. Vennligst prøv igjen!",
-    "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Klarte ikke lagre kartpakke på disk. Er du sikker på at det er nok plass tilgjengelig?"
+    "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Klarte ikke lagre kartpakke på disk. Er du sikker på at det er nok plass tilgjengelig?",
+    "DELETE_PACKAGE_CONFIRM": "Vil du slette denne kartpakka?"
   },
   "PERMISSION": {
     "LOCATION_DENIED_HEADER": "Tilgang til posisjon nektet",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -219,7 +219,8 @@
   "OFFLINE_MAP": {
     "DISKSPACE_ERROR_MESSAGE": "Beklager, du har ikke nok plass tilgjengelig på telefonen til å lagre kartpakken. Vennligst frigjør plass og prøv på nytt.",
     "DOWNLOAD_ERROR_MESSAGE": "Klarte ikke laste ned kartpakke. Pass på at du har stabil og god internett-kobling.",
-    "PACKAGE_COUNT": "{{packageCount}} kartpakker",
+    "PACKAGE_COUNT_SINGLE": "{{packageCount}} pakke",
+    "PACKAGE_COUNT_MULTIPLE": "{{packageCount}} pakker",
     "SPACE_AVAILABLE": "{{spaceAvailable}} ledig",
     "MAP_PACKAGE_DETAILS_PAGE": {
       "CANCEL_DOWNLOAD_BUTTON": "Avbryt nedlasting",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -224,8 +224,16 @@
     "OFFLINE_MAP_PAGE_TITLE": "Offlinekart",
     "STATUS": {
       "DOWNLOADING_PART_X_OF_Y": "Laster ned {{n}} av {{totalParts}}",
-      "UNZIP_PART_X_OF_Y": "Pakker ut {{n}} av {{totalParts}}"
-    }
+      "UNZIP_PART_X_OF_Y": "Pakkar ut {{n}} av {{totalParts}}"
+    },
+    "SPACE_AVAILABLE": "{{spaceAvailable}} ledig",
+    "DELETE_PACKAGE_CONFIRM": "Vil du slette denne kartpakka?",
+    "DISKSPACE_ERROR_MESSAGE": "Beklagar, du har ikkje nok plass tilgjengeleg på telefonen til å lagre kartpakka. Frigjer plass og prøv på nytt.",
+    "DOWNLOAD_ERROR_MESSAGE": "Klarte ikkje laste ned kartpakke. Pass på at du har ei stabil og god internett-kobling.",
+    "PACKAGE_COUNT_MULTIPLE": "{{packageCount}} pakkar",
+    "PACKAGE_COUNT_SINGLE": "{{packageCount}} pakke",
+    "UNZIP_ERROR_MESSAGE_GENERIC": "Klarte ikkje lagre kartpakka på disk. Ver vennleg og prøv igjen!",
+    "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Klarte ikkje lagre kartpakka på disk. Er du sikker på at det er nok plass tilgjengeleg?"
   },
   "PERMISSION": {
     "LOCATION_DENIED_HEADER": "Tilgang til posisjon nekta.",


### PR DESCRIPTION
Nå viser vi alle kartpakker som er på telefonen, i tillegg til de du laster ned eller har lagt i kø.
Har også jobbet litt med å redusere plass i "liste-overskriften" for å få plass til hele teksten på små skjermer.
Løsningen ble å bruke fire kolonner i stedet for tre, da jeg ikke fikk til å overstyre overflow: hidden. Synes det så greit ut likevel.
Har også fikset teksten i bekreftelses-popupen som kommer opp hvis du prøver å slette en nedlasta kartpakke. Denne var nok ikke helt ferdig.
Det forslaget som dukket opp på fredag om å vise "Trykk på en rute i kartet for å laste ned" i stedet for "0 Pakker 0 MB ### GB ledig" før man har lastet ned noe, forkastet jeg, fordi jeg mener det er viktigere å kunne se om man har plass. Vi har en egen Jira-oppgave på dette og har allerede et forslag på hvordan denne meldingen kan vises.