### PR TITLE
RO-1529: Fiks av at ruter mistet "rødmarkeringa" hvis man lukket siden og gikk inn igjen

### DIFF
--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -45,7 +45,7 @@ interface PackageTotals {
 export class OfflineMapPage extends NgDestoryBase {
   private readonly installedPackages$: Observable<Map<string, OfflineMapPackage>>;
   private installedPackages: Map<string, OfflineMapPackage> = new Map();
-  private failedPackageIds: string[] = []; //remember failed packages next time we open OfflineMapPage
+  private failedPackageIds: string[] = []; //remember failed packages until features are ready for styling
   private downloadAndUnzipProgress$: Observable<OfflineMapPackage[]>;
   packageTotals$: Observable<PackageTotals>;
   readonly allPackages$: Observable<OfflineMapPackage[]>;

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -45,7 +45,7 @@ interface PackageTotals {
 export class OfflineMapPage extends NgDestoryBase {
   private readonly installedPackages$: Observable<Map<string, OfflineMapPackage>>;
   private installedPackages: Map<string, OfflineMapPackage> = new Map();
-  private failedPackageIds: string[] = [];
+  private failedPackageIds: string[] = []; //remember failed packages next time we open OfflineMapPage
   private downloadAndUnzipProgress$: Observable<OfflineMapPackage[]>;
   packageTotals$: Observable<PackageTotals>;
   readonly allPackages$: Observable<OfflineMapPackage[]>;
@@ -181,7 +181,6 @@ export class OfflineMapPage extends NgDestoryBase {
       let style = defaultTileStyle;
       if(!this.installedPackages.has(key)) {
         if (this.failedPackageIds.includes(key)) {
-          //we need to mark failed packages when we open modal again if packages failed in a previous session
           style = errorTileStyle;
         }
         this.setStyleForFeature(key, style);

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -4,7 +4,7 @@ import { OfflineMapPackage } from '../../core/services/offline-map/offline-map.m
 import { HelperService } from '../../core/services/helpers/helper.service';
 import { AlertController, ModalController } from '@ionic/angular';
 import { BehaviorSubject, combineLatest, firstValueFrom, from, Observable, Subject } from 'rxjs';
-import { debounceTime, filter, map, shareReplay, switchMap, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { debounceTime, filter, map, shareReplay, switchMap, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 import * as L from 'leaflet';
 import { HttpClient } from '@angular/common/http';
 import { OfflinePackageModalComponent } from './offline-package-modal/offline-package-modal.component';
@@ -45,6 +45,7 @@ interface PackageTotals {
 export class OfflineMapPage extends NgDestoryBase {
   private readonly installedPackages$: Observable<Map<string, OfflineMapPackage>>;
   private installedPackages: Map<string, OfflineMapPackage> = new Map();
+  private failedPackageIds: string[] = [];
   private downloadAndUnzipProgress$: Observable<OfflineMapPackage[]>;
   packageTotals$: Observable<PackageTotals>;
   readonly allPackages$: Observable<OfflineMapPackage[]>;
@@ -143,7 +144,11 @@ export class OfflineMapPage extends NgDestoryBase {
         this.setStyleForPackages();
       });
 
-    this.downloadAndUnzipProgress$.pipe(takeUntil(this.ngDestroy$)).subscribe((itemsWithProgress) => {
+    this.downloadAndUnzipProgress$.pipe(takeUntil(this.ngDestroy$)).pipe(
+      tap((itemsWithProgress) => {
+        this.failedPackageIds = itemsWithProgress.filter(item => item.error).map(item => item.name);
+      })
+    ).subscribe((itemsWithProgress) => {
       this.zone.runOutsideAngular(() => {
         for(const item of itemsWithProgress) {
           this.setStyleForProgressOrDownloadedPackage(item);
@@ -173,8 +178,13 @@ export class OfflineMapPage extends NgDestoryBase {
       this.setStyleForProgressOrDownloadedPackage(item);
     }
     for(const [key, ] of this.packagesOnServer) {
+      let style = defaultTileStyle;
       if(!this.installedPackages.has(key)) {
-        this.setStyleForFeature(key, defaultTileStyle);
+        if (this.failedPackageIds.includes(key)) {
+          //we need to mark failed packages when we open modal again if packages failed in a previous session
+          style = errorTileStyle;
+        }
+        this.setStyleForFeature(key, style);
       }
     }
   }


### PR DESCRIPTION
Nå husker vi hvilke pakker som har feilet i tidligere nedlastingssesjon, og markerer disse i kartet når vi åpner offlinekart-oversikten.
Det var tidligere forsøk på å løse dette, men rød-markeringa ble forsøkt satt før map'en som holdt på rutene ikke var ferdig oppbygd, derfor ble ikke ruta tegnet med rød bakgrunn.
Synes det er litt vanskelig å blande RXJS med tilstand i klassen slik vi har her; fant ikke noen bedre løsning. Hadde vært stilig å hatt en Observable som sa ifra når alle features var tegnet ferdig, slik at vi kunne vente med å sette stil til denne var klar.