### PR TITLE
RO-1551: Fiks av at offline-kart vises i stedet for Geodata-kartet selv om man er online

### DIFF
--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -580,8 +580,8 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
 
 
     const createOpenTopoMap: CreateTileLayer = (options) => new L.TileLayer(settings.map.tiles.openTopoMapUrl, options);
-    const createArcGisOnlineMap: CreateTileLayer = (options) => new L.TileLayer(settings.map.tiles.arcGisOnlineTopoMapUrl);
-    const createGeoDataLandskapMap: CreateTileLayer = (options) => new L.TileLayer(settings.map.tiles.geoDataLandskapMapUrl);
+    const createArcGisOnlineMap: CreateTileLayer = (options) => new L.TileLayer(settings.map.tiles.arcGisOnlineTopoMapUrl, options);
+    const createGeoDataLandskapMap: CreateTileLayer = (options) => new L.TileLayer(settings.map.tiles.geoDataLandskapMapUrl, options);
     const createArGisOnlineMixMap: CreateTileLayer[] = [
       (options) => new RegObsTileLayer(
         settings.map.tiles.arcGisOnlineTopoMapUrl,


### PR DESCRIPTION
Tipper årsaken var at options ikke ble sendt med til kartlaget når vi valgte GeodataLandskap-kartet. 
Det funket i hvert fall bra i Android etter det.