### PR TITLE
Aktiverer fransk språk igjen

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -272,7 +272,7 @@ export const settings = {
       { lang: 'sv', name: 'Svenska' },
       { lang: 'de', name: 'Deutsch' },
       { lang: 'sl', name: 'Slovenski' },
-      // { lang: 'fr', name: 'Français' }, //TODO: Ta inn denne når synkronisering av språk mot databasen er gjort
+      { lang: 'fr', name: 'Français' },
     ]
   }
 };


### PR DESCRIPTION
Vi har fått Octopus til å virke igjen og har rullet fransk i API'et ut til demo. Da kan vi gjøre det mulig å teste dette i appen