### PR TITLE
PR-1528: Har oversatt hardkodet feilstatus som vises i popup'en for en kartpakke

### DIFF
--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -692,7 +692,8 @@ export class OfflineMapService {
       `Error downloading map ${metadata.name}`
     );
     metadata.error = error || new Error('Unknown error');
-    metadata.progress.description = 'Error';
+    const errorMessageKey = isDownloading ? 'OFFLINE_MAP.STATUS.DOWNLOAD_ERROR' : 'OFFLINE_MAP.STATUS.UNZIP_ERROR';
+    metadata.progress.description = await firstValueFrom(this.translateService.get(errorMessageKey));
     const unzipProgress = this.downloadAndUnzipProgress.value.filter(
       (p) => p.name !== metadata.name
     );

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -238,7 +238,9 @@
     "SPACE_AVAILABLE": "{{spaceAvailable}} free",
     "STATUS": {
       "DOWNLOADING_PART_X_OF_Y": "Downloading part {{n}} of {{totalParts}}",
-      "UNZIP_PART_X_OF_Y": "Unzipping part {{n}} of {{totalParts}}"
+      "UNZIP_PART_X_OF_Y": "Unzipping part {{n}} of {{totalParts}}",
+      "DOWNLOAD_ERROR": "Download error",
+      "UNZIP_ERROR": "Unzip error"
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Could not save map package to disk. Please try again",
     "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Could not save map package to disk. Are you sure there is enough disk space?"

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -238,7 +238,9 @@
     "SPACE_AVAILABLE": "{{spaceAvailable}} ledig",
     "STATUS": {
       "DOWNLOADING_PART_X_OF_Y": "Laster ned {{n}} av {{totalParts}}",
-      "UNZIP_PART_X_OF_Y": "Pakker ut {{n}} av {{totalParts}}"
+      "UNZIP_PART_X_OF_Y": "Pakker ut {{n}} av {{totalParts}}",
+      "DOWNLOAD_ERROR": "Nedlasting feilet",
+      "UNZIP_ERROR": "Utpakking feilet"
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Klarte ikke lagre kartpakke på disk. Vennligst prøv igjen!",
     "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Klarte ikke lagre kartpakke på disk. Er du sikker på at det er nok plass tilgjengelig?"

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -230,7 +230,9 @@
     "SPACE_AVAILABLE": "{{spaceAvailable}} ledig",
     "STATUS": {
       "DOWNLOADING_PART_X_OF_Y": "Lastar ned {{n}} av {{totalParts}}",
-      "UNZIP_PART_X_OF_Y": "Pakkar ut {{n}} av {{totalParts}}"
+      "UNZIP_PART_X_OF_Y": "Pakkar ut {{n}} av {{totalParts}}",
+      "DOWNLOAD_ERROR": "Nedlasting feilet",
+      "UNZIP_ERROR": "Utpakking feilet"
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Klarte ikkje å lagre kartpakka på disk. Ver vennleg og prøv igjen!",
     "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Klarte ikkje å lagre kartpakka på disk. Er du sikker på at det er nok plass tilgjengeleg?"

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -201,7 +201,9 @@
     "OFFLINE_MAP_PAGE_TITLE": "Offlinekartor",
     "STATUS": {
       "DOWNLOADING_PART_X_OF_Y": "Laddar ner fil {{n}} av {{totalParts}}",
-      "UNZIP_PART_X_OF_Y": "Packar upp fil {{n}} av {{totalParts}}"
+      "UNZIP_PART_X_OF_Y": "Packar upp fil {{n}} av {{totalParts}}",
+      "DOWNLOAD_ERROR": "Nedladdningen misslyckades",
+      "UNZIP_ERROR": "Uppackning av filer misslyckades"
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Lyckades ej spara kartpaketet till disk. Vänligen prøva igjen!",
     "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Lyckades ej spara kartpaketet till disk. Har du nog med diskutrymme?"


### PR DESCRIPTION
Det er denne statusen som nå er oversatt:
![image](https://user-images.githubusercontent.com/71138449/149772254-f7782713-9792-449b-b809-73ffb3bd0fb8.png)

Dette blir oversatt i servicen idet feilen skjer, så hvis du bytter språk etter at det feilet, får du ikke oversatt det på nytt. Tenkte det var godt nok.
