### PR TITLE
RO-1588: Byttet platform fra cordova til hybrid slik at riktig implementasjon av NewAttachmentService ble brukt

### DIFF
--- a/src/app/app.providers.ts
+++ b/src/app/app.providers.ts
@@ -204,7 +204,7 @@ export const APP_PROVIDERS = [
   // Custom native/web providers
   {
     provide: BackgroundGeolocationService,
-    useClass: window.hasOwnProperty('cordova') ? BackgroundGeolocationNativeService : BackgroundGeolocationWebService
+    useClass: window.hasOwnProperty('hybrid') ? BackgroundGeolocationNativeService : BackgroundGeolocationWebService
   },
   {
     provide: BackgroundDownloadService,

--- a/src/app/core/services/shortcut/shortcut.service.ts
+++ b/src/app/core/services/shortcut/shortcut.service.ts
@@ -22,7 +22,7 @@ export class ShortcutService {
 
   init() {
     const w = <any>window;
-    if (this.platform.is('cordova') && this.platform.is('android') && w.plugins && w.plugins.Shortcuts) {
+    if (this.platform.is('hybrid') && this.platform.is('android') && w.plugins && w.plugins.Shortcuts) {
       this.initAndroidShortcusts();
       return;
     }

--- a/src/app/modules/auth/factories/auth-factory.ts
+++ b/src/app/modules/auth/factories/auth-factory.ts
@@ -20,7 +20,7 @@ export const authFactory = (
   const authService = new RegobsAuthServiceOverride(browser, storage, requestor);
   userSettingService.appMode$.subscribe((appMode: AppMode) => {
     authService.authConfig = settings.authConfig[appMode];
-    if (!platform.is('cordova')) {
+    if (!platform.is('hybrid')) {
       const url = `${window.location.origin}/${AUTH_CALLBACK_PATH}`;
       authService.authConfig.redirect_url = url;
       authService.authConfig.end_session_redirect_url = url;

--- a/src/app/modules/common-registration/registration.module.ts
+++ b/src/app/modules/common-registration/registration.module.ts
@@ -92,7 +92,7 @@ export class RegistrationModule {
         },
         {
           provide: NewAttachmentService,
-          useClass: window.hasOwnProperty('cordova') ? FileAttachmentService : OfflineDbNewAttachmentService
+          useClass: window.hasOwnProperty('hybrid') ? FileAttachmentService : OfflineDbNewAttachmentService
         },
         TranslateService
       ]


### PR DESCRIPTION
Det feilet etter registreringa var sendt inn i RegobsApiSyncCallbackService.removeAllNewAttachments() fordi man brukte feil versjon av OfflineDbNewAttachmentService, som er for web.
Så det er egentlig bare endringen i RegistrationModule som er relevant her. 
Jeg tok uansett et søk på tilsvarende platformsjekker (søkte på 'cordova') i applikasjonen og erstattet alle disse med 'hybrid', da jeg regner med at det er tryggere.
https://ionicframework.com/docs/angular/platform
Denne feilen dukket opp da jeg flettet feature/add-common-project og develop siste gang, fordi develop dro med seg Capacitor, og Cordova-kjøremiljøet er ikke i bruk lengre.