### PR TITLE
RO-1593: Update base view registration after navigating from sub view ++

### DIFF
--- a/src/app/modules/registration/pages/base.page.ts
+++ b/src/app/modules/registration/pages/base.page.ts
@@ -28,7 +28,11 @@ export abstract class BasePage extends NgDestoryBase {
       .pipe(
         take(1),
         map((reg) => {
-          this.basePageService.createDefaultProps(reg, this.registrationTid);
+          // Seems like this class is also used by the top level summary view,
+          // where we don't have a registrationTid.
+          if (this.registrationTid != null) {
+            this.basePageService.createDefaultProps(reg, this.registrationTid);
+          }
           return reg;
         }),
         tap((reg) => {

--- a/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.html
+++ b/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.html
@@ -48,7 +48,7 @@
           {{'REGISTRATION.SNOW.SNOW_PROFILE.PREVIEW' | translate}}
         </ion-label>
       </ion-list-header>
-      <ion-item [disabled]="isEmpty()" (click)="openPreview()">
+      <ion-item [disabled]="noLayersInSnowProfile()" (click)="openPreview()">
         <ion-icon name="eye" color="dark" slot="start"></ion-icon>
         <ion-label>{{'REGISTRATION.SNOW.SNOW_PROFILE.PREVIEW_ITEM' | translate }}</ion-label>
       </ion-item>

--- a/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.ts
+++ b/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.ts
@@ -59,12 +59,16 @@ export class SnowProfilePage extends BasePage {
     super(RegistrationTid.SnowProfile2, basePageService, activatedRoute);
   }
 
+  noLayersInSnowProfile(): boolean {
+    return isEmpty(this.registration.request.SnowProfile2);
+  }
+
+  private noTestsIncludedInSnowProfile(): boolean {
+    return !(this.registration.request.CompressionTest || []).some((ct) => ct.IncludeInSnowProfile === true);
+  }
+
   isEmpty() {
-    const isEmptyResult =
-     isEmpty(this.registration.request.SnowProfile2) &&
-      !(this.registration.request.CompressionTest || []).some(
-        (ct) => ct.IncludeInSnowProfile === true
-      );
+    const isEmptyResult = this.noLayersInSnowProfile() && this.noTestsIncludedInSnowProfile();
     return Promise.resolve(isEmptyResult);
   }
 


### PR DESCRIPTION
Fikser:

  - Underskjema lagres
  - Kan trigge snøprofil-preview når man har lagt til et lag
  - Hindre at "undefined" legges til på registration request

Todo:

  - Snøprofilplott preview feiler - sjekk hva plot server forventer
 
