### PR TITLE
RO-1615: Fikset feil ved sletting av lokale filer på tlf. etter innsending som gjorde at registrering hang igjen med feilmarkering

### DIFF
--- a/src/app/modules/common-registration/services/add-new-attachment/file-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/file-attachment.service.ts
@@ -79,7 +79,11 @@ export default class FileAttachmentService implements NewAttachmentService {
 
   async removeAttachments(registrationId: string): Promise<void> {
     const path = await this.getRootPath();
-    await this.file.removeDir(`${path}/`, registrationId);
+    if (await this.directoryForRegistrationExists(registrationId)) {
+      await this.file.removeRecursively(`${path}/`, registrationId);
+    } else {
+      this.loggingService.debug(`Tried to remove ${path}/${registrationId}, but didn't find it`, DEBUG_TAG);
+    }
     this.attachmentsChanged.next();
   }
 
@@ -101,7 +105,7 @@ export default class FileAttachmentService implements NewAttachmentService {
 
   /**
    * Get root directory folder path
-   * @returns directory path as string
+   * @returns directory path as string (without trailing /)
    */
   private async getRootPath(): Promise<string> {
     const dataFolder = this.getDataDirectoryFileUrl();


### PR DESCRIPTION
Dette er et problem både på Android 10 og iOS 15.
Det var to feil som begge har med at appen prøver å slette bildemappa til registreringa etter at den er sendt inn.

1. Hvis du ikke hadde bilder i registreringa, hadde du heller ingen bildemappe, så da feilet det når vi prøvde å slette en mappe som ikke eksisterte. Feilmelding fra OS'et var NOT_FOUND_ERR.
2. Hvis du hadde bilder i registreringa, feilet det fordi bildemappa inneholdt filer. Dette ga INVALID_MODIFICATION_ERR fra OS'et. Ble løst ved å kjøre et eget kall for rekursiv sletting