### PR TITLE
RO 1623: Get position immediately on android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,9 +2541,9 @@
       "integrity": "sha512-7vmIGsO/qheb20xbaY9/ohLDD1BPEcp7EcX/LV6CFB3R0fMqPp43mg85Yy6WnC2nV5mR27xtzkcSEndRVsHshg=="
     },
     "@capacitor/geolocation": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-1.1.0.tgz",
-      "integrity": "sha512-YTUzIEGzbO502Eoe5LFCXcs7rVLIvtwcsWYfP/KECBsC29q746wUm5wQqr2EkFKi/ImLPdTmoXj4oXwwSgWyWA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-1.3.1.tgz",
+      "integrity": "sha512-3u9Hu4E0VBMa6r0d2t9MENDIR+bv5Tf144uPmb2Bl7XLQeFwvu4BSp2neNq39x58PvcROPMNX1BOTSGpQep+1Q=="
     },
     "@capacitor/ios": {
       "version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@capacitor/browser": "^1.0.3",
     "@capacitor/core": "^3.2.3",
     "@capacitor/filesystem": "^1.0.3",
-    "@capacitor/geolocation": "^1.1.0",
+    "@capacitor/geolocation": "^1.3.1",
     "@capacitor/ios": "^3.2.3",
     "@capacitor/splash-screen": "^1.1.2",
     "@capacitor/status-bar": "^1.0.3",

--- a/src/app/core/services/geo-position/geo-position.service.ts
+++ b/src/app/core/services/geo-position/geo-position.service.ts
@@ -52,6 +52,8 @@ export class GeoPositionService implements OnDestroy {
 
   // Subscriptions
   private watchPositionCallbackId: CallbackID = null;
+  private watchPositionRequestTime: number = null;
+  private watchPositionFirstCallbackReceived = false;
   private headingSubscription: Subscription;
 
   get currentPosition$(): Observable<Position> {
@@ -173,8 +175,9 @@ export class GeoPositionService implements OnDestroy {
   public async startTrackingComponent(
     name: string,
     forcePermissionDialog = false
-  ) {
+  ): Promise<void> {
     if (forcePermissionDialog) {
+      this.loggingService.debug(`startTrackingComponent: name = ${name}. Check permissions...`, DEBUG_TAG);
       const valid = await this.checkPermissions();
       if (!valid) {
         this.gpsPositionLog.next(
@@ -185,6 +188,7 @@ export class GeoPositionService implements OnDestroy {
         );
         return;
       }
+      this.loggingService.debug(`startTrackingComponent: name = ${name}. Permissions ok = ${valid}`, DEBUG_TAG);
     }
     this.trackingComponents.next([
       ...this.getTrackingComponentsExcludeByName(name),
@@ -219,6 +223,8 @@ export class GeoPositionService implements OnDestroy {
       const options:  ClearWatchOptions = { id : this.watchPositionCallbackId };
       Geolocation.clearWatch(options);
       this.watchPositionCallbackId = null;
+      this.watchPositionRequestTime = null;
+      this.watchPositionFirstCallbackReceived = null;
     }
   }
 
@@ -236,6 +242,13 @@ export class GeoPositionService implements OnDestroy {
         this.gpsPositionLog.next(this.createPositionError('Unknown error'));
       }
       if (position !== null) {
+        let delayInfo = '';
+        if (this.watchPositionFirstCallbackReceived === false) {
+          this.watchPositionFirstCallbackReceived = true;
+          const secondsSinceStartWatch = (Date.now() - this.watchPositionRequestTime) / 1000;
+          delayInfo = `. Delay since request: ${secondsSinceStartWatch}s`;
+        }
+        this.loggingService.debug(`Got position from device: Timestamp: ${new Date(position.timestamp).toLocaleTimeString()}, lat: ${position.coords?.latitude}, lon: ${position.coords?.longitude}${delayInfo}`, DEBUG_TAG);
         this.gpsPositionLog.next(this.createGpsPositionLogElement(position));
         if (this.isValidPosition(position)) {
           this.currentPosition.next(position);
@@ -244,8 +257,9 @@ export class GeoPositionService implements OnDestroy {
     };
     this.addStatusToGpsPositionLog('StartGpsTracking');
     this.stopWatchingPosition(); //we need to stop current watch of position if any
+    this.watchPositionRequestTime = Date.now();
     this.watchPositionCallbackId = await Geolocation.watchPosition(settings.gps.highAccuracyPositionOptions, watchPositionCallback);
-    this.loggingService.debug(`Start current GPS position watch subscription with callback ID: ${this.watchPositionCallbackId}`, DEBUG_TAG);
+    this.loggingService.debug(`Start GPS position subscription with callback ID: ${this.watchPositionCallbackId}, enableHighAccuracy = ${settings.gps.highAccuracyPositionOptions.enableHighAccuracy}, timeout = ${settings.gps.highAccuracyPositionOptions.timeout}, maximumAge = ${settings.gps.highAccuracyPositionOptions.maximumAge}`, DEBUG_TAG);
   }
 
   private isValidPosition(pos: Position): boolean {
@@ -270,7 +284,7 @@ export class GeoPositionService implements OnDestroy {
     // https://www.devhybrid.com/ionic-4-requesting-user-permissions/
     try {
       const currentPermissions = await Geolocation.checkPermissions();
-      this.loggingService.debug(`Geolocation (PermissionState) is ${currentPermissions?.location}`, DEBUG_TAG);
+      this.loggingService.debug(`Geolocation permissions: (fine)location is ${currentPermissions?.location}, courseLocation is ${currentPermissions.coarseLocation}`, DEBUG_TAG);
       const authorized = currentPermissions.location === 'granted';
       if (!authorized) {
         if (this.platform.is('ios')) {
@@ -279,7 +293,7 @@ export class GeoPositionService implements OnDestroy {
         }
         // location is not authorized, request new. This only works on Android
         const newPermissionsAfterRequest = await Geolocation.requestPermissions();
-        this.loggingService.debug(`Geolocation (PermissionState) after new request is ${newPermissionsAfterRequest?.location}`, DEBUG_TAG);
+        this.loggingService.debug(`Geolocation permissions after new request is: (fine)location is ${newPermissionsAfterRequest?.location}, courseLocation is ${newPermissionsAfterRequest.coarseLocation}`, DEBUG_TAG);
         if (newPermissionsAfterRequest?.location === 'denied') {
           await this.showPermissionDeniedError();
           return false;

--- a/src/app/core/services/geo-position/geo-position.service.ts
+++ b/src/app/core/services/geo-position/geo-position.service.ts
@@ -248,7 +248,7 @@ export class GeoPositionService implements OnDestroy {
           const secondsSinceStartWatch = (Date.now() - this.watchPositionRequestTime) / 1000;
           delayInfo = `. Delay since request: ${secondsSinceStartWatch}s`;
         }
-        this.loggingService.debug(`Got position from device: Timestamp: ${new Date(position.timestamp).toLocaleTimeString()}, lat: ${position.coords?.latitude}, lon: ${position.coords?.longitude}${delayInfo}`, DEBUG_TAG);
+        this.loggingService.debug(`Got position from device: Timestamp: ${new Date(position.timestamp).toLocaleTimeString()}, accuracy: ${position.coords?.accuracy}${delayInfo}`, DEBUG_TAG);
         this.gpsPositionLog.next(this.createGpsPositionLogElement(position));
         if (this.isValidPosition(position)) {
           this.currentPosition.next(position);

--- a/src/app/modules/gps-debug/components/gps-debug/gps-debug.component.html
+++ b/src/app/modules/gps-debug/components/gps-debug/gps-debug.component.html
@@ -12,7 +12,7 @@
         <span *ngIf="item.pos else NoPosition">&nbsp;
           {{ item.pos.coords.latitude | number:'.5' }}&deg;{{'MAP_CENTER_INFO.NORTH_SHORT'|translate}},
           {{ item.pos.coords.longitude | number:'.5' }}&deg;{{'MAP_CENTER_INFO.EAST_SHORT'|translate}},
-          {{ item.pos.coords.accuracy }}
+          {{ item.pos.coords.accuracy | number: '1.0-0'}}m
         </span>
       </span>
       <span *ngIf="item.status === 'PositionError'">

--- a/src/app/modules/gps-debug/components/gps-debug/gps-debug.component.ts
+++ b/src/app/modules/gps-debug/components/gps-debug/gps-debug.component.ts
@@ -102,7 +102,10 @@ export class GpsDebugComponent implements OnInit, OnDestroy {
   }
 
   timestampToString(timestamp: number) {
-    return moment.unix(timestamp).local().format('dd.MM HH:mm:ss.SSS');
+    const isMillis = timestamp > 99999999999; //sometimes we get timestamp in seconds instead of millis
+    const timestampInMillis = isMillis ? timestamp : timestamp * 1000;
+    const result = new Date(timestampInMillis).toLocaleString();
+    return result;
   }
 
   getErrorCodeOrMessage(err: PositionError) {

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -573,7 +573,10 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
         filter(([, active]) => active),
         takeUntil(this.ngDestroy$)
       )
-      .subscribe(() => this.redrawMap());
+      .subscribe(() => {
+        this.loggingService.debug('InvalidateSizeMapTimer: Trigger redraw of map', DEBUG_TAG);
+        this.redrawMap();
+      });
   }
 
   redrawMap() {

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -573,10 +573,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
         filter(([, active]) => active),
         takeUntil(this.ngDestroy$)
       )
-      .subscribe(() => {
-        this.loggingService.debug('InvalidateSizeMapTimer: Trigger redraw of map', DEBUG_TAG);
-        this.redrawMap();
-      });
+      .subscribe(() => this.redrawMap());
   }
 
   redrawMap() {

--- a/src/settings.model.ts
+++ b/src/settings.model.ts
@@ -88,7 +88,6 @@ export interface ISettings {
   services: any;
   db: any;
   map: IMapSettings;
-  gps: any;
   dateFormats: any;
   kdvElements: any;
   helpTexts: any;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -300,8 +300,8 @@ export const settings: ISettings = {
   gps: {
     highAccuracyPositionOptions: {
       enableHighAccuracy: true,
-      timeout: 20 * 1000, // 20 sec
-      maximumAge: Infinity // Start with latest cached value
+      timeout: 20 * 1000, //get notified with new position data at least each 20 sec
+      maximumAge: 0 //we do not accept cached positions, ask for GPS position immediately
     }
   },
   dateFormats: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -300,7 +300,7 @@ export const settings: ISettings = {
   gps: {
     highAccuracyPositionOptions: {
       enableHighAccuracy: true,
-      timeout: 20 * 1000, //get notified with new position data at least each 20 sec
+      timeout: 1000, //get notified with new position data at least each 1 sec
       maximumAge: 0 //we do not accept cached positions, ask for GPS position immediately
     }
   },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -297,13 +297,6 @@ export const settings: ISettings = {
     flyToOnGpsZoom: 13,
     maxClusterRadius: 60 // 30,
   },
-  gps: {
-    highAccuracyPositionOptions: {
-      enableHighAccuracy: true,
-      timeout: 1000, //get notified with new position data at least each 1 sec
-      maximumAge: 0 //we do not accept cached positions, ask for GPS position immediately
-    }
-  },
   dateFormats: {
     angular: {
       date: 'dd.MM.yyyy',


### PR DESCRIPTION
Denne fiksen er forsøk på å få "fersk" GPS-posisjon så fort vi ber om det (når appen aktiveres f.eks.).
Har nå satt timeout til 1 sekund etter tips fra @jorgkv , og det så ut til å gjøre susen. Har også satt maximumAge til 0. Jeg skjønner ikke helt bakgrunnen for at maximumAge var satt til Infinity, men mulig at dette funket bra i tidligere versjoner av Android. Jeg synes ikke det er logisk at endring av timeout skulle ha noe å si for hvor raskt vi får posisjon første gang, men greit nok. Da blir funksjonaliteten mer lik den vi har på iPhone, som rapporterer posisjon ganske ofte (rundt 1 gang / sek?).
Her er dokumentasjon: https://capacitorjs.com/docs/apis/geolocation#positionoptions

NB! Siden de "gamle" innstillingene for posisjonering funka best på iOS, kjører vi kun de nye instillingene på Android. Vi har ikke bruk for å lagre innstillingene, da de aldri endres under kjøring, så vi hardkoder dem nå i GeoPositionService.

Har også:
- oppgradert geolocation-plugin for å få med meg et par fikser som er relevant for Android.
- fikset en feil i GPS-debug-komponenten, som viste helt rare tidspunkter
- laget bedre og mer logging av posisjonsdata