### PR TITLE
RO-1634: Justering av høyde fra GPS i kartsenter-info

### DIFF
--- a/src/app/modules/map/components/map-center-info/map-center-info.component.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy, ChangeDetectorRef, ViewChild, Eleme
 import { ToastController, Platform } from '@ionic/angular';
 import { Clipboard } from '@ionic-native/clipboard/ngx';
 import { TranslateService } from '@ngx-translate/core';
-import { combineLatest, firstValueFrom, of } from 'rxjs';
+import { combineLatest, firstValueFrom, Observable, of } from 'rxjs';
 import { catchError, takeUntil, timeout } from 'rxjs/operators';
 import { MapSearchService } from '../../services/map-search/map-search.service';
 import { MapService } from '../../services/map/map.service';
@@ -13,8 +13,10 @@ import { Position } from '@capacitor/geolocation';
 import { LocationName } from '../../services/map-search/location-name.model';
 import * as L from 'leaflet';
 import { ViewInfo } from '../../services/map-search/view-info.model';
-import { IMapView } from '../../services/map/map-view.interface';
+import { Capacitor } from '@capacitor/core';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 
+const DEBUG_TAG = 'MapCenterInfoComponent';
 const LOCATION_INFO_REQUEST_TIMEOUT = 10_000;
 let requestCounter = 0;
 
@@ -26,6 +28,8 @@ let requestCounter = 0;
 })
 export class MapCenterInfoComponent extends NgDestoryBase {
   private userPos: Position;  // Caches the gps position for distance and height diff computation
+  private lastUserPos: L.LatLng; //Remember last gps position to avoid adjusting altitude when device dont' move
+  private _userAltitude: number = null; // Cached user altitude from server fetched when we can't trust the GPS altitude
 
   // For accessing the info box element from parent views
   @ViewChild('infoBoxElement') private infoBoxElement: ElementRef;
@@ -50,9 +54,13 @@ export class MapCenterInfoComponent extends NgDestoryBase {
     }
   }
 
+  get userAltitude(): number {
+    return this._userAltitude || this.userPos?.coords?.altitude;
+  }
+
   get heightDifference(): number {
-    if (this.userPos?.coords?.altitude != null && this.elevation) {
-      return this.elevation - this.userPos.coords.altitude;
+    if (this.userAltitude != null && this.elevation != null) {
+      return this.elevation - this.userAltitude;
     }
   }
 
@@ -66,6 +74,7 @@ export class MapCenterInfoComponent extends NgDestoryBase {
     geoPositionService: GeoPositionService,
     private helperService: HelperService,
     private cdr: ChangeDetectorRef,
+    private loggingService: LoggingService
   ) {
     super();
 
@@ -78,6 +87,7 @@ export class MapCenterInfoComponent extends NgDestoryBase {
       .pipe(takeUntil(this.ngDestroy$))
       .subscribe(([newPos, followMode]) => {
         this.userPos = followMode ? null : newPos;
+        this.fixGpsPosHeight();
         this.cdr.markForCheck();
       });
 
@@ -88,31 +98,53 @@ export class MapCenterInfoComponent extends NgDestoryBase {
         this.location = null;
         this.elevation = null;
         this.steepness = null;
-        this.fetchNewLocationInfo(newMapView);
+        this.fetchNewLocationInfo(newMapView.center);
         this.cdr.markForCheck();
       });
+  }
+
+  private async fixGpsPosHeight(): Promise<void> {
+    if (Capacitor.getPlatform() !== 'ios' && this.userPos?.coords) {
+      const start = Date.now();
+      const latLng = new L.LatLng(this.userPos.coords.latitude, this.userPos.coords.longitude);
+      if (!this.lastUserPos || this.lastUserPos.distanceTo(latLng) > 5) {
+        this.lastUserPos = latLng;
+        const locationInfo = await firstValueFrom(this.getLocationInfo$(latLng));
+        if (locationInfo && locationInfo.elevation) {
+          this._userAltitude = locationInfo.elevation
+          this.cdr.markForCheck();        
+          this.loggingService.debug(`Device altitude ${this.userPos.coords.altitude} adjusted to ${locationInfo.elevation} in ${Date.now() - start}ms`, DEBUG_TAG);
+        } else {
+          this._userAltitude = null;
+          this.loggingService.debug(`Tried to adjust user position altitude, but got no response from server, keeping altitude from device: ${this.userPos.coords.altitude}, took ${Date.now() - start}ms`, DEBUG_TAG);
+        }  
+      } else {
+        this.loggingService.debug(`Distance to last user position is ${this.lastUserPos.distanceTo(latLng)}m. Skips adjustment of altitude when distance is < 5m`, DEBUG_TAG);
+      }
+    }
   }
 
   getHorizontalDifferenceText(value: number): string {
     return this.helperService.getDistanceText(value);
   }
 
-  private fetchNewLocationInfo(mapView: IMapView) {
-    this.loading = true;
-
-    const locationInfoRequest = this.mapSearchService
-      .getViewInfo(mapView)
+  private getLocationInfo$(latLng: L.LatLng): Observable<ViewInfo> {
+    return this.mapSearchService.getViewInfo(latLng)
       .pipe(
         timeout(LOCATION_INFO_REQUEST_TIMEOUT),
         catchError(() => of({} as ViewInfo)),
       );
+  }
+
+  private fetchNewLocationInfo(latLng: L.LatLng) {
+    this.loading = true;
 
     // Track request number, so we only update the view
     // after the last observable completes.
     requestCounter++;
     const requestIndex = requestCounter;
 
-    firstValueFrom(locationInfoRequest)
+    firstValueFrom(this.getLocationInfo$(latLng))
       .then(viewInfo => {
         if (requestIndex < requestCounter) return;
 

--- a/src/app/modules/map/services/map-search/map-search.service.ts
+++ b/src/app/modules/map/services/map-search/map-search.service.ts
@@ -146,8 +146,7 @@ export class MapSearchService {
       );
   }
 
-  getViewInfo(mapView: IMapView, geoHazard = GeoHazard.Soil): Observable<ViewInfo> {
-    const latLng = mapView.center;
+  getViewInfo(latLng: L.LatLng, geoHazard = GeoHazard.Soil): Observable<ViewInfo> {
     return this.geoCodeService
       .GeoCodeLocationInfo({
         latitude: latLng.lat,

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -264,7 +264,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
   private updateMapViewInfo(): void {
     const latLng = this.locationMarker.getLatLng();
     this.mapSearchService
-      .getViewInfo({ center: latLng, bounds: null, zoom: 0 }, this.geoHazard)
+      .getViewInfo(latLng, this.geoHazard)
       .subscribe(
         (val) => {
           this.ngZone.run(() => {


### PR DESCRIPTION
Nå henter vi høyde fra Regobs-API'et basert på brukerens posisjon. Denne funksjonen brukes bare på Android (pga. feil høyde fra GPS) og på web (får ikke høyde).
På iOS bruker vi høyden vi får fra GPS uten å røre den (som før).

Har også fikset en feil som gjorde at man ikke viste høydeforskjell hvis kartsenter er på havnivå.

Det er ganske mye logging her nå, som vi sikkert kan ta vekk, men tenkte det var greit å ha det i starten, i hvert fall for å teste PR'en.

