### PR TITLE
Fix/ro 1640 fix logout error loop

### DIFF
--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -80,6 +80,7 @@ export class ApiInterceptor implements HttpInterceptor {
     request: HttpRequest<unknown>
   ): Observable<HttpRequest<unknown>> {
     return this.regobsAuthService.loggedInUser$.pipe(
+      take(1),
       catchError((err) => {
         this.loggerService.debug(
           'Could not get valid token',

--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -1,4 +1,4 @@
-import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, map, switchMap, take, tap } from 'rxjs/operators';
 import {
   HttpRequest,
   HttpInterceptor,

--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -80,6 +80,9 @@ export class ApiInterceptor implements HttpInterceptor {
     request: HttpRequest<unknown>
   ): Observable<HttpRequest<unknown>> {
     return this.regobsAuthService.loggedInUser$.pipe(
+      // We do not want this do be a long lived observable,
+      // we want it to complete after we get the first loggedInUser.
+      // take(1) makes the observable complete after getting the first loggedInUser.
       take(1),
       catchError((err) => {
         this.loggerService.debug(

--- a/src/app/modules/auth/services/regobs-auth-service-override.ts
+++ b/src/app/modules/auth/services/regobs-auth-service-override.ts
@@ -35,11 +35,18 @@ export class RegobsAuthServiceOverride extends AuthService {
   /**
    * Refresh token. If refresh fails, you can just try again.
    * Will only remove cached tokens if refresh token is expired
+   *
+   * @throws {Error} if no token is defined
    */
   public async refreshToken() {
-    await super.requestTokenRefresh().catch((error) => {
+    try {
+      await super.requestTokenRefresh();
+    } catch (error) {
+      if (error?.message?.toLowerCase().indexOf('no token defined') > -1) {
+        throw error;
+      }
       this.clearTokensIfRefreshTokenIsExpired(error);
-    });
+    }
   }
 
   private async clearTokensIfRefreshTokenIsExpired(error: unknown) {


### PR DESCRIPTION
Denne bugen var mindre enn den så ut som i utgangspunktet, det var kun i samme økt som du hadde logget inn at dette ville være et problem. Men mulig det også kunne blitt problemer andre steder i koden der `lastValueFrom` eventuelt blir brukt for å vente på svar fra sikrede api-kall.

Problemet var relatert til at `lastValueFrom` ble brukt for å vente på svar fra `/Account/GetObserver` i denne koden:

```typescript
private async checkAndSetNickIfNickIsNull(): Promise<ObserverResponseDto> {
    try {
      const user = await lastValueFrom(this.accountService.AccountGetObserver());
      if (user && user.Nick != null && user.Nick != '') {
        return;
      }
      const nick = await this.showSetNickDialog();
      await lastValueFrom(this.accountService.AccountUpdateObserver({ Nick: nick }));
    } catch (err) {
      this.logger.error(err, DEBUG_TAG, 'Could not save nick');
    }
  }
```

Siden dette er et sikret api-kall ble det lagt på token via `addAuthHeader` i `ApiInterceptor.ts`. [`lastValueFrom` krever at observablen completer før noe returneres](https://rxjs.dev/api/index/function/lastValueFrom). For å legge på tokenet blir det lyttet på `loggedInUser$` i `addAuthHeader`, men `loggedInUser$` er langlevende og completer aldri. Dermed ble aldri requesten completed og `lastValueFrom` fullførte aldri. Da ble requesten hengende videre i økta, og etter vi hadde logget ut prøvde den igjen å kalle `/Account/GetObserver`. Ved å legge til `take(1)` sørger vi for at observablen vil completes.

Denne PRen fikser også at vi ikke kommer inn i evige loops hvis token ikke finnes og `handleResponseError` i api-interceptoren kalles for å legge på token. Ved å kaste en exception hvis token ikke finnes hopper den ut i første forsøk.