### PR TITLE
RO 1609: Fjerning av registrering(er) når vi forlater et (ugyldig) skjema

### DIFF
--- a/src/app/modules/common-registration/helpers/registration.helper.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.ts
@@ -103,3 +103,30 @@ export function isArrayType(tid: RegistrationTid): boolean {
   );
 }
 
+/**
+ * Create an empty registration for given draft, if it does not exists
+ * @returns the draft with actual registration initialized
+ */
+export function createEmptyRegistration(draft: RegistrationDraft, registrationTid: RegistrationTid): RegistrationDraft {
+  const propName = getRegistrationName(registrationTid);
+  if (!draft.registration[propName]) {
+    return {
+      ...draft,
+      registration: {
+        ...draft.registration,
+        [propName]: getDefaultValue(registrationTid)
+      }
+    };
+  }
+  return draft;
+}
+
+function getDefaultValue(registrationTid: RegistrationTid) {
+  if (isArrayType(registrationTid)) {
+    return [];
+  } else {
+    return {};
+  }
+}
+
+

--- a/src/app/modules/registration/pages/base-page-service.ts
+++ b/src/app/modules/registration/pages/base-page-service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NgZone } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { RegistrationTid } from 'src/app/modules/common-registration/registration.models';
 import { getRegistrationName, isArrayType } from 'src/app/modules/common-registration/registration.helpers';
 import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
@@ -7,6 +7,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { LoggingService } from '../../shared/services/logging/logging.service';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
+import { firstValueFrom } from 'rxjs';
 
 const DEBUG_TAG = 'BasePageService';
 @Injectable({
@@ -21,29 +22,29 @@ export class BasePageService {
   constructor(
     private draftRepositoryService: DraftRepositoryService,
     private newAttachmentService: NewAttachmentService,
-    private ngZone: NgZone,
     private alertController: AlertController,
     private translateService: TranslateService,
     private loggingService: LoggingService
   ) {}
 
-  async confirmLeave(draft: RegistrationDraft, registrationTid: RegistrationTid, onReset?: () => void) {
-    const leaveText = await this.translateService.get('REGISTRATION.REQUIRED_FIELDS_MISSING').toPromise();
-    return this.createResetDialog(leaveText, draft, registrationTid, onReset);
+  /**
+   * @returns true if operator confirms to leave an invalid registration form (and lose the data)
+   */
+  async confirmLeave(): Promise<boolean> {
+    const leaveText = await firstValueFrom(this.translateService.get('REGISTRATION.REQUIRED_FIELDS_MISSING'));
+    return this.askForResetConfirmation(leaveText);
   }
 
-  async confirmReset(draft: RegistrationDraft, registrationTid: RegistrationTid, onReset?: () => void) {
-    const leaveText = await this.translateService.get('REGISTRATION.CONFIRM_RESET').toPromise();
-    return this.createResetDialog(leaveText, draft, registrationTid, onReset);
+  /**
+   * @returns true if operator confirms to reset registration form
+   */
+  async confirmReset(): Promise<boolean> {
+    const leaveText = await firstValueFrom(this.translateService.get('REGISTRATION.CONFIRM_RESET'));
+    return this.askForResetConfirmation(leaveText);
   }
 
-  private async createResetDialog(
-    message: string,
-    draft: RegistrationDraft,
-    registrationTid: RegistrationTid,
-    onReset?: () => void
-  ) {
-    const translations = await this.translateService.get(['DIALOGS.CANCEL', 'DIALOGS.YES']).toPromise();
+  private async askForResetConfirmation(message: string): Promise<boolean> {
+    const translations = await firstValueFrom(this.translateService.get(['DIALOGS.CANCEL', 'DIALOGS.YES']));
     const alert = await this.alertController.create({
       message,
       buttons: [
@@ -59,31 +60,48 @@ export class BasePageService {
     await alert.present();
     const result = await alert.onDidDismiss();
     const reset: boolean = result.role !== 'cancel';
-    if (reset) {
-      await this.reset(draft, registrationTid, onReset);
-    }
     return reset;
   }
 
-  // TODO: Test how ng zone works here
-  async reset(draft: RegistrationDraft, registrationTid: RegistrationTid, onReset?: () => void) {
-    if (registrationTid) {
-      const draftReset: RegistrationDraft = {
+  /**
+   * Reset or delete the registrations with given registrationTids and save the draft.
+   * The attachments that belong to the registrations will be de removed.
+   * @param draft the draft the registrations belong to
+   * @param registrationTids type ID's of the registrations
+   * @param doDelete use this if you like to delete instead of reset
+   */
+  async reset(draft: RegistrationDraft, registrationTids: RegistrationTid[], doDelete = false) {
+    if (registrationTids?.length > 0) {
+      const draftCopy: RegistrationDraft = {
         ...draft,
         registration: {
           ...draft.registration,
-          [getRegistrationName(registrationTid)]: this.getDefaultValue(registrationTid)
         }
       };
 
-      await this.resetImages(draftReset);
-      await this.draftRepository.save(draftReset);
-    }
-    this.ngZone.run(() => {
-      if (onReset) {
-        onReset();
+      const attachments = await firstValueFrom(this.newAttachmentService.getAttachments(draft.uuid));
+
+      for (const registrationTid of registrationTids) {
+        const registrationName = getRegistrationName(registrationTid);
+        if (doDelete) {
+          delete draftCopy.registration[registrationName];
+        } else {
+          draftCopy.registration[registrationName] = this.getDefaultValue(registrationTid); //reset field
+        }
+        for (const attachment of attachments) {
+          if (attachment.RegistrationTID === registrationTid) {
+            try {
+              this.newAttachmentService.removeAttachment(draft.uuid, attachment.id);
+            } catch (error) {
+              this.loggingService.error(error, DEBUG_TAG,
+                `Remove image failed, attachmentId = ${attachment.id}, registration ID = ${draft.uuid}`);
+            }
+          }
+        }
       }
-    });
+
+      await this.draftRepository.save(draftCopy);
+    }
   }
 
   createDefaultProps(draft: RegistrationDraft, registrationTid: RegistrationTid): RegistrationDraft {
@@ -107,14 +125,5 @@ export class BasePageService {
       return {};
     }
   }
-
-  // TODO: Test if reset images works ok
-  async resetImages(draft: RegistrationDraft) {
-    try {
-      await this.newAttachmentService.removeAttachments(draft.uuid);
-      this.loggingService.debug('Reset images complete', DEBUG_TAG);
-    } catch (error) {
-      this.loggingService.error(error, DEBUG_TAG, 'Could not reset images');
-    }
-  }
 }
+

--- a/src/app/modules/registration/pages/base-page-service.ts
+++ b/src/app/modules/registration/pages/base-page-service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { RegistrationTid } from 'src/app/modules/common-registration/registration.models';
-import { getRegistrationName, isArrayType } from 'src/app/modules/common-registration/registration.helpers';
+import { getRegistrationName } from 'src/app/modules/common-registration/registration.helpers';
 import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
 import { AlertController } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
@@ -36,9 +36,9 @@ export class BasePageService {
   }
 
   /**
-   * @returns true if operator confirms to reset registration form
+   * @returns true if user confirms to delete registration form
    */
-  async confirmReset(): Promise<boolean> {
+  async confirmDelete(): Promise<boolean> {
     const leaveText = await firstValueFrom(this.translateService.get('REGISTRATION.CONFIRM_RESET'));
     return this.askForResetConfirmation(leaveText);
   }
@@ -64,13 +64,12 @@ export class BasePageService {
   }
 
   /**
-   * Reset or delete the registrations with given registrationTids and save the draft.
+   * Delete the registrations with given registrationTids and save the draft.
    * The attachments that belong to the registrations will be de removed.
    * @param draft the draft the registrations belong to
    * @param registrationTids type ID's of the registrations
-   * @param doDelete use this if you like to delete instead of reset
    */
-  async reset(draft: RegistrationDraft, registrationTids: RegistrationTid[], doDelete = false) {
+  async delete(draft: RegistrationDraft, registrationTids: RegistrationTid[]) {
     if (registrationTids?.length > 0) {
       const draftCopy: RegistrationDraft = {
         ...draft,
@@ -83,11 +82,7 @@ export class BasePageService {
 
       for (const registrationTid of registrationTids) {
         const registrationName = getRegistrationName(registrationTid);
-        if (doDelete) {
-          delete draftCopy.registration[registrationName];
-        } else {
-          draftCopy.registration[registrationName] = this.getDefaultValue(registrationTid); //reset field
-        }
+        delete draftCopy.registration[registrationName];
         for (const attachment of attachments) {
           if (attachment.RegistrationTID === registrationTid) {
             try {
@@ -104,26 +99,5 @@ export class BasePageService {
     }
   }
 
-  createDefaultProps(draft: RegistrationDraft, registrationTid: RegistrationTid): RegistrationDraft {
-    const propName = getRegistrationName(registrationTid);
-    if (!draft.registration[propName]) {
-      return {
-        ...draft,
-        registration: {
-          ...draft.registration,
-          [propName]: this.getDefaultValue(registrationTid)
-        }
-      };
-    }
-    return draft;
-  }
-
-  getDefaultValue(registrationTid: RegistrationTid) {
-    if (isArrayType(registrationTid)) {
-      return [];
-    } else {
-      return {};
-    }
-  }
 }
 

--- a/src/app/modules/registration/pages/base-page-service.ts
+++ b/src/app/modules/registration/pages/base-page-service.ts
@@ -64,12 +64,14 @@ export class BasePageService {
   }
 
   /**
-   * Delete the registrations with given registrationTids and save the draft.
+   * Delete the registrations with given registrationTids
    * The attachments that belong to the registrations will be de removed.
+   * You must save the returned draft yourself.
    * @param draft the draft the registrations belong to
    * @param registrationTids type ID's of the registrations
+   * @return the draft without the registrations
    */
-  async delete(draft: RegistrationDraft, registrationTids: RegistrationTid[]) {
+  async delete(draft: RegistrationDraft, registrationTids: RegistrationTid[]): Promise<RegistrationDraft> {
     if (registrationTids?.length > 0) {
       const draftCopy: RegistrationDraft = {
         ...draft,
@@ -95,8 +97,10 @@ export class BasePageService {
         }
       }
 
-      await this.draftRepository.save(draftCopy);
+      //await this.draftRepository.save(draftCopy);
+      return draftCopy;
     }
+    return draft;
   }
 
 }

--- a/src/app/modules/registration/pages/base-page.service.spec.ts
+++ b/src/app/modules/registration/pages/base-page.service.spec.ts
@@ -1,35 +1,61 @@
-import { RegistrationTid, SyncStatus } from 'src/app/modules/common-registration/registration.models';
+import { AttachmentUploadEditModel, RegistrationTid, SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
 import { BasePageService } from './base-page-service';
 import { LoggingService } from '../../shared/services/logging/logging.service';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { TestBed } from '@angular/core/testing';
-import { NgZone } from '@angular/core';
+import { of } from 'rxjs';
 
 describe('BasePageService', () => {
 
   let service: BasePageService;
-  let newAttachmentService: NewAttachmentService;
+  let newAttachmentService: jasmine.SpyObj<NewAttachmentService>;
   let loggerService: jasmine.SpyObj<LoggingService>;
-  let ngZone: jasmine.SpyObj<NgZone>;
 
   let draftRepository: {
     save: jasmine.Spy<DraftRepositoryService['save']>;
   };
 
-  const draft: RegistrationDraft = {
-    uuid: 'abc',
+  const avalancheObsDraft: RegistrationDraft = {
+    uuid: 'draft',
     syncStatus: SyncStatus.Draft,
     registration: {
       GeoHazardTID: 10,
       DtObsTime: 'obsTime',
       AvalancheObs: {
         DtAvalancheTime: 'avalancheTime',
-        FractureWidth: 23,
+        Comment: 'avalance obs comment'
+      },
+      Incident: {
+        Comment: 'incident comment'
       }
     }
   };
+
+  const attachments: AttachmentUploadEditModel[] = [
+    {
+      id: '1',
+      type: 'Attachment',
+      AttachmentId: 1,
+      RegistrationTID: RegistrationTid.Incident,
+    },{
+      id: '2',
+      type: 'Attachment',
+      AttachmentId: 2,
+      RegistrationTID: RegistrationTid.Incident,
+    },
+    {
+      id: '3',
+      type: 'Attachment',
+      AttachmentId: 3,
+      RegistrationTID: RegistrationTid.AvalancheObs,
+    },{
+      id: '4',
+      type: 'Attachment',
+      AttachmentId: 4,
+      RegistrationTID: RegistrationTid.DangerObs
+    }];
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
@@ -39,34 +65,67 @@ describe('BasePageService', () => {
     };
 
     loggerService = jasmine.createSpyObj('LoggingService', ['debug', 'error']);
-    newAttachmentService = jasmine.createSpyObj('NewAttachmentService', ['removeAttachments']);
-    ngZone = jasmine.createSpyObj('NgZone', ['run']);
+    newAttachmentService = jasmine.createSpyObj('NewAttachmentService', ['getAttachments', 'removeAttachment']);
 
     service = new BasePageService(
       draftRepository as unknown as DraftRepositoryService,
       newAttachmentService,
-      ngZone,
       null,
       null,
       loggerService
     );
   });
 
-  it('reset() should empty the registration', async () => {
-    
-    await service.reset(draft, RegistrationTid.AvalancheObs);
+  it('reset(doDelete) should delete the avalanche and incident registration', async () => {
+
     const expectedEmptyDraft: RegistrationDraft = {
-        uuid: 'abc',
-        syncStatus: SyncStatus.Draft,
-        registration: {
-          GeoHazardTID: 10,
-          DtObsTime: 'obsTime'
-          //No AvalancheObs anymore
-        }
-      };
+      uuid: 'draft',
+      syncStatus: SyncStatus.Draft,
+      registration: {
+        GeoHazardTID: 10,
+        DtObsTime: 'obsTime'
+        //No AvalancheObs or Incident anymore
+      }
+    };
+    newAttachmentService.getAttachments.and.returnValue(of(attachments));
+
+    await service.reset(avalancheObsDraft, [RegistrationTid.AvalancheObs, RegistrationTid.Incident], true);
     expect(draftRepository.save).toHaveBeenCalledTimes(1);
     expect(draftRepository.save.calls.allArgs()).toEqual([
       [{ ...expectedEmptyDraft }],
     ]);
+    expect(newAttachmentService.getAttachments).toHaveBeenCalledOnceWith('draft');
+    expect(newAttachmentService.removeAttachment).toHaveBeenCalledTimes(3);
+    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '1');
+    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '2');
+    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '3');
   });
+
+  //TODO: Denne feiler fordi jeg vet ikke hvordan jeg kan angi at AvalancheObs er tom uten å få trøbbel med Typescript
+  it('reset(clear) should only clear the avalanche and incident registration', async () => {
+
+    const expectedEmptyDraft: RegistrationDraft = {
+      uuid: 'draft',
+      syncStatus: SyncStatus.Draft,
+      registration: {
+        GeoHazardTID: 10,
+        DtObsTime: 'obsTime',
+        Incident: {}
+      }
+    };
+    expectedEmptyDraft['AvalancheObs'] = {};
+    newAttachmentService.getAttachments.and.returnValue(of(attachments));
+
+    await service.reset(avalancheObsDraft, [RegistrationTid.AvalancheObs, RegistrationTid.Incident]);
+    expect(draftRepository.save).toHaveBeenCalledTimes(1);
+    expect(draftRepository.save.calls.allArgs()).toEqual([
+      [{ ...expectedEmptyDraft }],
+    ]);
+    expect(newAttachmentService.getAttachments).toHaveBeenCalledOnceWith('draft');
+    expect(newAttachmentService.removeAttachment).toHaveBeenCalledTimes(3);
+    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '1');
+    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '2');
+    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '3');
+  });
+
 });

--- a/src/app/modules/registration/pages/base-page.service.spec.ts
+++ b/src/app/modules/registration/pages/base-page.service.spec.ts
@@ -1,0 +1,72 @@
+import { RegistrationTid, SyncStatus } from 'src/app/modules/common-registration/registration.models';
+import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
+import { BasePageService } from './base-page-service';
+import { LoggingService } from '../../shared/services/logging/logging.service';
+import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
+import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
+import { TestBed } from '@angular/core/testing';
+import { NgZone } from '@angular/core';
+
+describe('BasePageService', () => {
+
+  let service: BasePageService;
+  let newAttachmentService: NewAttachmentService;
+  let loggerService: jasmine.SpyObj<LoggingService>;
+  let ngZone: jasmine.SpyObj<NgZone>;
+
+  let draftRepository: {
+    save: jasmine.Spy<DraftRepositoryService['save']>;
+  };
+
+  const draft: RegistrationDraft = {
+    uuid: 'abc',
+    syncStatus: SyncStatus.Draft,
+    registration: {
+      GeoHazardTID: 10,
+      DtObsTime: 'obsTime',
+      AvalancheObs: {
+        DtAvalancheTime: 'avalancheTime',
+        FractureWidth: 23,
+      }
+    }
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+
+    draftRepository = {
+      save: jasmine.createSpy('DraftService.save')
+    };
+
+    loggerService = jasmine.createSpyObj('LoggingService', ['debug', 'error']);
+    newAttachmentService = jasmine.createSpyObj('NewAttachmentService', ['removeAttachments']);
+    ngZone = jasmine.createSpyObj('NgZone', ['run']);
+
+    service = new BasePageService(
+      draftRepository as unknown as DraftRepositoryService,
+      newAttachmentService,
+      ngZone,
+      null,
+      null,
+      loggerService
+    );
+  });
+
+  it('reset() should empty the registration', async () => {
+    
+    await service.reset(draft, RegistrationTid.AvalancheObs);
+    const expectedEmptyDraft: RegistrationDraft = {
+        uuid: 'abc',
+        syncStatus: SyncStatus.Draft,
+        registration: {
+          GeoHazardTID: 10,
+          DtObsTime: 'obsTime'
+          //No AvalancheObs anymore
+        }
+      };
+    expect(draftRepository.save).toHaveBeenCalledTimes(1);
+    expect(draftRepository.save.calls.allArgs()).toEqual([
+      [{ ...expectedEmptyDraft }],
+    ]);
+  });
+});

--- a/src/app/modules/registration/pages/base-page.service.spec.ts
+++ b/src/app/modules/registration/pages/base-page.service.spec.ts
@@ -88,12 +88,11 @@ describe('BasePageService', () => {
       }
     };
     newAttachmentService.getAttachments.and.returnValue(of(attachments));
+    const registrationTids = [RegistrationTid.AvalancheObs, RegistrationTid.Incident];
 
-    await service.delete(avalancheObsDraft, [RegistrationTid.AvalancheObs, RegistrationTid.Incident]);
-    expect(draftRepository.save).toHaveBeenCalledTimes(1);
-    expect(draftRepository.save.calls.allArgs()).toEqual([
-      [{ ...expectedEmptyDraft }],
-    ]);
+    const actualDraft = await service.delete(avalancheObsDraft, registrationTids);
+
+    expect(actualDraft).toEqual(expectedEmptyDraft);
     expect(newAttachmentService.getAttachments).toHaveBeenCalledOnceWith('draft');
     expect(newAttachmentService.removeAttachment).toHaveBeenCalledTimes(3);
     expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '1');

--- a/src/app/modules/registration/pages/base-page.service.spec.ts
+++ b/src/app/modules/registration/pages/base-page.service.spec.ts
@@ -76,7 +76,7 @@ describe('BasePageService', () => {
     );
   });
 
-  it('reset(doDelete) should delete the avalanche and incident registration', async () => {
+  it('delete should delete the avalanche and incident registration', async () => {
 
     const expectedEmptyDraft: RegistrationDraft = {
       uuid: 'draft',
@@ -89,34 +89,7 @@ describe('BasePageService', () => {
     };
     newAttachmentService.getAttachments.and.returnValue(of(attachments));
 
-    await service.reset(avalancheObsDraft, [RegistrationTid.AvalancheObs, RegistrationTid.Incident], true);
-    expect(draftRepository.save).toHaveBeenCalledTimes(1);
-    expect(draftRepository.save.calls.allArgs()).toEqual([
-      [{ ...expectedEmptyDraft }],
-    ]);
-    expect(newAttachmentService.getAttachments).toHaveBeenCalledOnceWith('draft');
-    expect(newAttachmentService.removeAttachment).toHaveBeenCalledTimes(3);
-    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '1');
-    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '2');
-    expect(newAttachmentService.removeAttachment).toHaveBeenCalledWith('draft', '3');
-  });
-
-  //TODO: Denne feiler fordi jeg vet ikke hvordan jeg kan angi at AvalancheObs er tom uten å få trøbbel med Typescript
-  it('reset(clear) should only clear the avalanche and incident registration', async () => {
-
-    const expectedEmptyDraft: RegistrationDraft = {
-      uuid: 'draft',
-      syncStatus: SyncStatus.Draft,
-      registration: {
-        GeoHazardTID: 10,
-        DtObsTime: 'obsTime',
-        Incident: {}
-      }
-    };
-    expectedEmptyDraft['AvalancheObs'] = {};
-    newAttachmentService.getAttachments.and.returnValue(of(attachments));
-
-    await service.reset(avalancheObsDraft, [RegistrationTid.AvalancheObs, RegistrationTid.Incident]);
+    await service.delete(avalancheObsDraft, [RegistrationTid.AvalancheObs, RegistrationTid.Incident]);
     expect(draftRepository.save).toHaveBeenCalledTimes(1);
     expect(draftRepository.save.calls.allArgs()).toEqual([
       [{ ...expectedEmptyDraft }],

--- a/src/app/modules/registration/pages/base.page.ts
+++ b/src/app/modules/registration/pages/base.page.ts
@@ -6,6 +6,7 @@ import { ActivatedRoute } from '@angular/router';
 import { take, takeUntil, map, switchMap, tap, skip } from 'rxjs/operators';
 import { NgDestoryBase } from '../../../core/helpers/observable-helper';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
+import { createEmptyRegistration } from '../../common-registration/registration.helpers';
 
 /**
  * Base page for a registration form, eg. danger sign
@@ -40,7 +41,7 @@ export abstract class BasePage extends NgDestoryBase {
         // Seems like this class is also used by the set datetime page,
         // where we don't have a registrationTid
         if (this.registrationTid != null) {
-          return this.basePageService.createDefaultProps(draft, this.registrationTid);
+          return createEmptyRegistration(draft, this.registrationTid);
         }
         return draft;
       }),
@@ -85,9 +86,9 @@ export abstract class BasePage extends NgDestoryBase {
     if (!isEmpty && !valid) {
       const pleaseLeave = await this.basePageService.confirmLeave();
       if (pleaseLeave) {
-        await this.doDelete();
+        await this.delete();
       } else {
-        return false; //operator wants to stay
+        return false; //user wants to stay
       }
     }
     return true;
@@ -120,26 +121,20 @@ export abstract class BasePage extends NgDestoryBase {
   }
 
   /**
-   * Clear all fields in the registration if the operator confirms
+   * Delete the registration if the user confirms
    */
   async reset() {
-    const pleaseReset = await this.basePageService.confirmReset();
+    const pleaseReset = await this.basePageService.confirmDelete();
     if (pleaseReset) {
-      await this.doReset();
+      await this.delete();
     }
   }
 
   /**
-   * Clear all fields in the registration(s) and save the draft
+   * Delete the registration behind the form and save the draft.
+   * You may override this if your form contains other data.
    */
-  protected async doReset() {
-    await this.basePageService.reset(this.draft, [this.registrationTid]);
-  }
-
-  /**
-   * Delete the registration(s) behind the form and save the draft
-   */
-  protected async doDelete() {
-    await this.basePageService.reset(this.draft, [this.registrationTid], true);
+  protected async delete() {
+    await this.basePageService.delete(this.draft, [this.registrationTid]);
   }
 }

--- a/src/app/modules/registration/pages/base.page.ts
+++ b/src/app/modules/registration/pages/base.page.ts
@@ -101,6 +101,9 @@ export abstract class BasePage extends NgDestoryBase {
     return of({});
   }
 
+  /**
+   * Save automatically when you leave the page. Will also run onBeforeLeave() hook if you have any
+   */
   async ionViewWillLeave() {
     if (this.onBeforeLeave) {
       await Promise.resolve(this.onBeforeLeave());
@@ -135,6 +138,6 @@ export abstract class BasePage extends NgDestoryBase {
    * You may override this if your form contains other data.
    */
   protected async delete() {
-    await this.basePageService.delete(this.draft, [this.registrationTid]);
+    this.draft = await this.basePageService.delete(this.draft, [this.registrationTid]);
   }
 }

--- a/src/app/modules/registration/pages/can-deactivate-route.guard.ts
+++ b/src/app/modules/registration/pages/can-deactivate-route.guard.ts
@@ -5,6 +5,6 @@ import { BasePage } from './base.page';
 @Injectable()
 export class CanDeactivateRouteGuard implements CanDeactivate<BasePage> {
   async canDeactivate(component: BasePage): Promise<boolean> {
-    return component.canLeave();
+    return await component.canLeave();
   }
 }

--- a/src/app/modules/registration/pages/danger-obs/danger-obs.page.ts
+++ b/src/app/modules/registration/pages/danger-obs/danger-obs.page.ts
@@ -13,7 +13,7 @@ import { KdvService } from 'src/app/modules/common-registration/registration.ser
 /**
  * Used to add or edit danger observations.
  * Contains a list of danger observations already registered.
- * You may click an observation open the specific observation in a form.
+ * You may click an observation to open the specific observation in a form.
  * Contains also a button to add new observations and a function to upload images.
  */
 @Component({

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -97,14 +97,9 @@ export class AvalancheObsPage extends BasePage {
     return moment().minutes(59).toISOString(true);
   }
 
-  protected async doReset() {
-    //clear both forms
-    await this.basePageService.reset(this.draft, [this.registrationTid, RegistrationTid.Incident], false);
-  }
-
-  protected async doDelete() {
+  protected async delete() {
     //delete both forms
-    await this.basePageService.reset(this.draft, [this.registrationTid, RegistrationTid.Incident], true);
+    await this.basePageService.delete(this.draft, [this.registrationTid, RegistrationTid.Incident]);
   }
 
   isValid() {

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -10,6 +10,11 @@ import moment from 'moment';
 import { SelectOption } from '../../../../shared/components/input/select/select-option.model';
 import { AvalancheObsEditModel, IncidentEditModel } from 'src/app/modules/common-regobs-api';
 
+
+/**
+ * Used to register both avalanche observations and incidents, so this page contains two forms.
+ * You can also upload images which will be attached to the avalanche observation.
+ */
 @Component({
   selector: 'app-avalanche-obs',
   templateUrl: './avalanche-obs.page.html',
@@ -92,13 +97,14 @@ export class AvalancheObsPage extends BasePage {
     return moment().minutes(59).toISOString(true);
   }
 
-  async onReset() {
-    this.showWarning = false;
-    // Also reset Incident when Avalanche obs is reset.
-    await this.basePageService.reset(
-      this.draft,
-      RegistrationTid.Incident
-    );
+  protected async doReset() {
+    //clear both forms
+    await this.basePageService.reset(this.draft, [this.registrationTid, RegistrationTid.Incident], false);
+  }
+
+  protected async doDelete() {
+    //delete both forms
+    await this.basePageService.reset(this.draft, [this.registrationTid, RegistrationTid.Incident], true);
   }
 
   isValid() {

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -99,7 +99,7 @@ export class AvalancheObsPage extends BasePage {
 
   protected async delete() {
     //delete both forms
-    await this.basePageService.delete(this.draft, [this.registrationTid, RegistrationTid.Incident]);
+    this.draft = await this.basePageService.delete(this.draft, [this.registrationTid, RegistrationTid.Incident]);
   }
 
   isValid() {


### PR DESCRIPTION
Forsøk på å fikse flere problemer som dukket opp hvis man hadde åpnet skjema for snøskredhendelse og lukket det igjen uten å lagre. Se https://nveprojects.atlassian.net/browse/RO-1609 for bakgrunnsinfo.
Denne PR'en har en løsning på disse punktene:
1. Jeg vet ikke om det er riktig, men mener at vi bør heller bør slette en registrering enn å nullstille den hvis vi ikke har noe data å sende inn for aktuell registrering. Dette løser problemet med obligatoriske felter i en registrering.
2. Nå sletter vi kun bilder som hører til registreringen(e) i skjemaet
3. Har forenklet måten å overstyre hvordan man sletter data i et skjema