### PR TITLE
Always show reset form button

### DIFF
--- a/src/app/modules/registration/components/registration-content-wrapper/registration-content-wrapper.component.html
+++ b/src/app/modules/registration/components/registration-content-wrapper/registration-content-wrapper.component.html
@@ -6,10 +6,15 @@
   </ion-row>
   <ion-row>
     <ion-col class="ion-no-padding">
-      <app-help-text [registrationTid]="registrationTid" [geoHazard]="draft.registration.GeoHazardTID"></app-help-text>
+      <app-help-text
+        [registrationTid]="registrationTid"
+        [geoHazard]="draft.registration.GeoHazardTID"
+      ></app-help-text>
       <app-navigation-buttons [draft]="draft"></app-navigation-buttons>
-      <app-save-and-go-back-button [draft]="draft" [registrationTid]="registrationTid"
-        (reset)="emitReset()"></app-save-and-go-back-button>
+      <app-save-and-go-back-button
+        [draft]="draft"
+        (reset)="emitReset()"
+      ></app-save-and-go-back-button>
     </ion-col>
   </ion-row>
 </ion-grid>

--- a/src/app/modules/registration/components/save-and-go-back-button/save-and-go-back-button.component.html
+++ b/src/app/modules/registration/components/save-and-go-back-button/save-and-go-back-button.component.html
@@ -7,7 +7,7 @@
       </ion-button>
     </ion-col>
   </ion-row>
-  <ion-row class="reset-button-row" *ngIf="hasData">
+  <ion-row class="reset-button-row">
     <ion-col class="ion-text-center">
       <ion-button class="reset-button" (click)="doReset()" color="dark" size="small" fill="clear">
         <svg-icon src="/assets/icon/reset.svg"></svg-icon>

--- a/src/app/modules/registration/components/save-and-go-back-button/save-and-go-back-button.component.ts
+++ b/src/app/modules/registration/components/save-and-go-back-button/save-and-go-back-button.component.ts
@@ -1,9 +1,6 @@
-import { Component, OnInit, Input, Output, EventEmitter, OnChanges, SimpleChanges, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { NavController } from '@ionic/angular';
-import { RegistrationTid } from 'src/app/modules/common-registration/registration.models';
-import { SmartChanges } from 'src/app/core/helpers/simple-changes.helper';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
-import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
 
 @Component({
   selector: 'app-save-and-go-back-button',
@@ -11,35 +8,13 @@ import { DraftRepositoryService } from 'src/app/core/services/draft/draft-reposi
   styleUrls: ['./save-and-go-back-button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SaveAndGoBackButtonComponent implements OnInit, OnChanges {
+export class SaveAndGoBackButtonComponent {
   @Input() draft: RegistrationDraft;
-  @Input() registrationTid: RegistrationTid;
   @Output() reset = new EventEmitter();
-
-  hasData = false;
 
   constructor(
     private navContoller: NavController,
-    private draftService: DraftRepositoryService,
-    private cdr: ChangeDetectorRef,
   ) {}
-
-  ngOnChanges(changes: SimpleChanges & SmartChanges<this>): void {
-    if(changes && changes.registration && !changes.registration.isFirstChange()) {
-      this.setHasData();
-    }
-  }
-
-  ngOnInit() {
-    this.setHasData();
-  }
-
-  private async setHasData(): Promise<void> {
-    if (this.draft != null && this.registrationTid != null) {
-      await this.draftService.isDraftEmptyForRegistrationType(this.draft, this.registrationTid);
-      this.cdr.markForCheck();
-    }
-  }
 
   async goBack() {
     this.navContoller.navigateBack('registration/edit/' + this.draft.uuid);

--- a/src/app/modules/registration/pages/base.page.ts
+++ b/src/app/modules/registration/pages/base.page.ts
@@ -124,9 +124,10 @@ export abstract class BasePage extends NgDestoryBase {
   }
 
   /**
-   * Reset the registration if the user confirms
+   * Reset the registration if the user confirms.
+   * @returns {boolean} true if the user wants to reset
    */
-  async reset() {
+  async reset(): Promise<boolean> {
     const pleaseReset = await this.basePageService.confirmDelete();
     if (pleaseReset) {
       await this.delete();
@@ -134,6 +135,8 @@ export abstract class BasePage extends NgDestoryBase {
       // Create a new empty form / registration
       this.draft = createEmptyRegistration(this.draft, this.registrationTid);
     }
+
+    return pleaseReset;
   }
 
   /**

--- a/src/app/modules/registration/pages/base.page.ts
+++ b/src/app/modules/registration/pages/base.page.ts
@@ -124,12 +124,15 @@ export abstract class BasePage extends NgDestoryBase {
   }
 
   /**
-   * Delete the registration if the user confirms
+   * Reset the registration if the user confirms
    */
   async reset() {
     const pleaseReset = await this.basePageService.confirmDelete();
     if (pleaseReset) {
       await this.delete();
+
+      // Create a new empty form / registration
+      this.draft = createEmptyRegistration(this.draft, this.registrationTid);
     }
   }
 

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -9,6 +9,7 @@ import { SetAvalanchePositionPage } from '../../set-avalanche-position/set-avala
 import moment from 'moment';
 import { SelectOption } from '../../../../shared/components/input/select/select-option.model';
 import { AvalancheObsEditModel, IncidentEditModel } from 'src/app/modules/common-regobs-api';
+import { createEmptyRegistration } from 'src/app/modules/common-registration/registration.helpers';
 
 
 /**
@@ -95,6 +96,12 @@ export class AvalancheObsPage extends BasePage {
     // There is an issue when setting max date that when changing hour, the minutes is still max minutes.
     // Workaround is to set minutes to 59.
     return moment().minutes(59).toISOString(true);
+  }
+
+  async reset() {
+    await super.reset();
+    // Also create new empty incident form
+    this.draft = createEmptyRegistration(this.draft, RegistrationTid.Incident);
   }
 
   protected async delete() {

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -99,9 +99,12 @@ export class AvalancheObsPage extends BasePage {
   }
 
   async reset() {
-    await super.reset();
-    // Also create new empty incident form
-    this.draft = createEmptyRegistration(this.draft, RegistrationTid.Incident);
+    const pleaseReset = await super.reset();
+    if (pleaseReset) {
+      // Also create new empty incident form
+      this.draft = createEmptyRegistration(this.draft, RegistrationTid.Incident);
+    }
+    return pleaseReset;
   }
 
   protected async delete() {


### PR DESCRIPTION
- Fører til at vi alltid viser "Tilbakestill skjema" i bunnen av alle registrerings-skjema
- Under reset, initialiserer nye tomme skjema etter de gamle slettes, for å unngå at viewet kræsjer etter reset