### PR TITLE
Do not save empty registrations

### DIFF
--- a/src/app/modules/registration/pages/base.page.ts
+++ b/src/app/modules/registration/pages/base.page.ts
@@ -111,8 +111,11 @@ export abstract class BasePage extends NgDestoryBase {
     await this.save();
   }
 
-  save() {
-    return this.basePageService.draftRepository.save({ ...this.draft, syncStatus: SyncStatus.Draft });
+  async save() {
+    if (await this.isEmpty()) {
+      await this.delete();
+    }
+    await this.basePageService.draftRepository.save({ ...this.draft, syncStatus: SyncStatus.Draft });
   }
 
   getSaveFunc() {

--- a/src/app/modules/registration/pages/set-time/set-time.page.ts
+++ b/src/app/modules/registration/pages/set-time/set-time.page.ts
@@ -4,7 +4,6 @@ import { NavController } from '@ionic/angular';
 import { BasePage } from '../base.page';
 import { BasePageService } from '../base-page-service';
 import { ActivatedRoute } from '@angular/router';
-import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 
 @Component({
   selector: 'app-set-time',
@@ -40,6 +39,10 @@ export class SetTimePage extends BasePage {
     // There is an issue when setting max date that when changing hour, the minutes is still max minutes.
     // Workaround is to set minutes to 59.
     return moment().minutes(59).toISOString(true);
+  }
+
+  async isEmpty(): Promise<boolean> {
+    return false;
   }
 
   confirm() {


### PR DESCRIPTION
Sletter tomme objekter på `draft.registration` før vi lagrer kladdene.
Bør hindre at vi prøver å sende inn tomme objekter til regobs-apiet, som takler sånne ting dårlig.