### PR TITLE
Handle draft delete in overview page

### DIFF
--- a/src/app/core/services/draft/draft-repository.service.spec.ts
+++ b/src/app/core/services/draft/draft-repository.service.spec.ts
@@ -266,6 +266,7 @@ describe('DraftRepositoryService', () => {
     };
 
     let i = 0;
+    let completed = false;
     const sub = service.getDraft$('test').subscribe({
       next: (d) => {
         if (i < 2) {
@@ -274,6 +275,9 @@ describe('DraftRepositoryService', () => {
           expect(d).toBeUndefined();
         }
         i += 1;
+      },
+      complete: () => {
+        completed = true;
       }
     });
 
@@ -289,13 +293,19 @@ describe('DraftRepositoryService', () => {
 
     tick(1);
 
+    // The observable should have emitted two times, two versions of the draft
+    expect(i).toBe(2);
+
     draft = null;
     await service.delete('test');
 
     flush();
 
-    // The observable should have emitted three times total, two drafts and undefined after it was deleted
-    expect(i).toBe(3);
+    // The observable should still only have emitted two times, two versions of the draft
+    expect(i).toBe(2);
+
+    // It should also have completed the observable when the draft was deleted
+    expect(completed).toBeTrue();
 
     // As we deleted the draft, the subscription should be closed
     expect(sub.closed).toBe(true);

--- a/src/app/core/services/draft/draft-repository.service.spec.ts
+++ b/src/app/core/services/draft/draft-repository.service.spec.ts
@@ -269,11 +269,7 @@ describe('DraftRepositoryService', () => {
     let completed = false;
     const sub = service.getDraft$('test').subscribe({
       next: (d) => {
-        if (i < 2) {
-          expect(d).toEqual({ ...draft, lastSavedTime: jasmine.any(Number) });
-        } else {
-          expect(d).toBeUndefined();
-        }
+        expect(d).toEqual({ ...draft, lastSavedTime: jasmine.any(Number) });
         i += 1;
       },
       complete: () => {

--- a/src/app/core/services/draft/draft-repository.service.ts
+++ b/src/app/core/services/draft/draft-repository.service.ts
@@ -51,7 +51,7 @@ export class DraftRepositoryService {
   /**
    * Returns an observable with draft changes for a single draft.
    * Does not emit until the specified draft is available in the database.
-   * If the draft is deleted after a subscription has been made, undefined is returned and the observable is completed.
+   * If the draft is deleted after a subscription has been made, the observable completes.
    */
   getDraft$(uuid: string): Observable<RegistrationDraft | undefined> {
     const gotDraft = new Subject<boolean>();
@@ -63,7 +63,7 @@ export class DraftRepositoryService {
         }
       }),
       skipUntil(gotDraft),
-      takeWhile(draft => draft != null, true)
+      takeWhile(draft => draft != null)
     );
   }
 

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -12,6 +12,7 @@ import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 import deepEqual from 'fast-deep-equal';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
+import { NavController } from '@ionic/angular';
 
 @Component({
   selector: 'app-overview',
@@ -33,7 +34,8 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
     private activatedRoute: ActivatedRoute,
     private summaryItemService: SummaryItemService,
     private userGroupService: UserGroupService,
-    private newAttachmentService: NewAttachmentService
+    private newAttachmentService: NewAttachmentService,
+    private navController: NavController,
   ) {
     super();
   }
@@ -66,9 +68,15 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
         distinctUntilChanged((a, b) => deepEqual(a, b)),
         takeUntil(this.ngDestroy$)
       )
-      .subscribe((summaryItems) => {
-        this.summaryItems = summaryItems;
-        this.cdr.detectChanges();
+      .subscribe({
+        next: (summaryItems) => {
+          this.summaryItems = summaryItems;
+          this.cdr.detectChanges();
+        },
+        complete: () => {
+          // Draft has been deleted / this registration does not exist any more, we should navigate to front page
+          this.navController.navigateRoot('');
+        }
       });
   }
 


### PR DESCRIPTION
Uten denne fiksen får vi en error på `overview.page.ts` når man sletter en draft.
Denne endringen fører til en `draft$`-observables ikke returnerer undefined når en draft slettes, men bare completer. Det er litt lettere å håndtere i koden.