### PR TITLE
Nå feiler vi hvis vi lagrer ufullstendige/ulovlige kladder

### DIFF
--- a/src/app/core/services/draft/draft-repository.service.spec.ts
+++ b/src/app/core/services/draft/draft-repository.service.spec.ts
@@ -69,7 +69,7 @@ describe('DraftRepositoryService', () => {
   });
 
   it('create() should return an empty draft', async () => {
-    const draft = await service.create(GeoHazard.Ice);
+    const draft = service.create(GeoHazard.Ice);
     expect(draft.uuid.length).toBeGreaterThan(0);
     expect(draft.syncStatus).toBe(SyncStatus.Draft);
     expect(draft.registration.GeoHazardTID).toBe(GeoHazard.Ice);
@@ -80,7 +80,7 @@ describe('DraftRepositoryService', () => {
   });
 
   it('save() should store a draft', async () => {
-    const draft = await service.create(GeoHazard.Snow);
+    const draft = service.create(GeoHazard.Snow);
     draft.registration.DtObsTime = '2022-02-13 08:00';
     draft.registration.SnowSurfaceObservation = {
       Comment: 'comment',
@@ -103,9 +103,9 @@ describe('DraftRepositoryService', () => {
   });
 
   it('newly saved drafts should be unique', async () => {
-    const draft = await service.create(GeoHazard.Snow);
+    const draft = service.create(GeoHazard.Snow);
     await service.save(draft);
-    const draft2 = await service.create(GeoHazard.Snow);
+    const draft2 = service.create(GeoHazard.Snow);
     await service.save(draft2);
     expect(database.store.size).toEqual(2);
     expect(database.store.has(`drafts.TEST.${draft.uuid}`)).toBeTrue();
@@ -113,7 +113,7 @@ describe('DraftRepositoryService', () => {
   });
 
   it('save of invalid drafts should fail', async () => {
-    const draft = await service.create(GeoHazard.Snow);
+    const draft = service.create(GeoHazard.Snow);
     draft.registration.GeoHazardTID = undefined;
     draft.registration.DtObsTime = undefined;
     service.save(draft)
@@ -124,14 +124,14 @@ describe('DraftRepositoryService', () => {
   });
 
   it('we can change a registration, save it and load the changed registration', async () => {
-    const irrelevantDraft1 = await service.create(GeoHazard.Snow);
+    const irrelevantDraft1 = service.create(GeoHazard.Snow);
     await service.save(irrelevantDraft1);
 
-    const draft = await service.create(GeoHazard.Ice);
+    const draft = service.create(GeoHazard.Ice);
     draft.registration.GeneralObservation = { Comment: 'v.1' };
     await service.save(draft);
 
-    const irrelevantDraft2 = await service.create(GeoHazard.Soil);
+    const irrelevantDraft2 = service.create(GeoHazard.Soil);
     await service.save(irrelevantDraft2);
 
     //verify that the comment was saved and we can load it
@@ -150,7 +150,7 @@ describe('DraftRepositoryService', () => {
   });
 
   it('we get notified when registrations are saved', async () => {
-    const draft = await service.create(GeoHazard.Ice);
+    const draft = service.create(GeoHazard.Ice);
     draft.registration.GeneralObservation = { Comment: 'v.1' };
 
     await service.save(draft);
@@ -176,7 +176,7 @@ describe('DraftRepositoryService', () => {
   });
 
   it('we can use drafts$ as a stream when registrations are saved', async () => {
-    const draft = await service.create(GeoHazard.Ice);
+    const draft = service.create(GeoHazard.Ice);
     draft.registration.GeneralObservation = { Comment: 'v.1' };
 
     let i = 0;
@@ -214,7 +214,7 @@ describe('DraftRepositoryService', () => {
   });
 
   it('delete works', async () => {
-    const draft = await service.create(GeoHazard.Ice);
+    const draft = service.create(GeoHazard.Ice);
     await service.save(draft);
 
     expect(database.store.size).toBe(1);
@@ -233,10 +233,10 @@ describe('DraftRepositoryService', () => {
 
   it('we do not mix data from different environments', fakeAsync(async () => {
     //save 2 drafts in test environment
-    const draft1inTest = await service.create(GeoHazard.Ice);
+    const draft1inTest = service.create(GeoHazard.Ice);
     await service.save(draft1inTest);
 
-    const draft2inTest = await service.create(GeoHazard.Ice);
+    const draft2inTest = service.create(GeoHazard.Ice);
     await service.save(draft2inTest);
 
     userSettingService.saveUserSettings({
@@ -248,7 +248,7 @@ describe('DraftRepositoryService', () => {
     expect(draftChanges.length).toBe(0); //no drafts in demo yet
 
     //save a draft in demo environment
-    const draft1inDemo = await service.create(GeoHazard.Ice);
+    const draft1inDemo = service.create(GeoHazard.Ice);
     await service.save(draft1inDemo);
 
     //drafts in test database not available in demo environment
@@ -283,7 +283,7 @@ describe('DraftRepositoryService', () => {
 
   it('drafts$ returns a draft only when it is available, and completes if it is deleted', fakeAsync(async () => {
     let draft: RegistrationDraft = {
-      ...await service.create(GeoHazard.Ice),
+      ...service.create(GeoHazard.Ice),
       uuid: 'test'
     };
 

--- a/src/app/core/services/draft/draft-repository.service.spec.ts
+++ b/src/app/core/services/draft/draft-repository.service.spec.ts
@@ -1,9 +1,9 @@
 import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import { AppMode, GeoHazard, LangKey } from 'src/app/modules/common-core/models';
+import { AppMode, GeoHazard } from 'src/app/modules/common-core/models';
 import { SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { DraftRepositoryService } from './draft-repository.service';
 import { TestLoggingService } from 'src/app/modules/shared/services/logging/test-logging.service';
-import { firstValueFrom, Observable, ReplaySubject, take } from 'rxjs';
+import { firstValueFrom, Observable, ReplaySubject } from 'rxjs';
 import { DatabaseService } from '../database/database.service';
 import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
 import { RegistrationDraft } from './draft-model';
@@ -65,7 +65,7 @@ describe('DraftRepositoryService', () => {
     userSettingService.saveUserSettings({
       ...await firstValueFrom(userSettingService.userSetting$),
       appMode: AppMode.Test,
-    })
+    });
   });
 
   it('create() should return an empty draft', async () => {
@@ -110,6 +110,17 @@ describe('DraftRepositoryService', () => {
     expect(database.store.size).toEqual(2);
     expect(database.store.has(`drafts.TEST.${draft.uuid}`)).toBeTrue();
     expect(database.store.has(`drafts.TEST.${draft2.uuid}`)).toBeTrue();
+  });
+
+  it('save of invalid drafts should fail', async () => {
+    const draft = await service.create(GeoHazard.Snow);
+    draft.registration.GeoHazardTID = undefined;
+    draft.registration.DtObsTime = undefined;
+    service.save(draft)
+      .then(() => fail('save of invalid drafts should fail'))
+      .catch((err) => {
+        expect(err.message).toEqual(`Save of invalid draft failed. UUID: '${draft.uuid}'. Cause: missing GeoHazardTID`);
+      });
   });
 
   it('we can change a registration, save it and load the changed registration', async () => {
@@ -231,7 +242,7 @@ describe('DraftRepositoryService', () => {
     userSettingService.saveUserSettings({
       ...await firstValueFrom(userSettingService.userSetting$),
       appMode: AppMode.Demo,
-    })
+    });
 
     const draftChanges = await firstValueFrom(service.drafts$);
     expect(draftChanges.length).toBe(0); //no drafts in demo yet
@@ -251,7 +262,7 @@ describe('DraftRepositoryService', () => {
     userSettingService.saveUserSettings({
       ...await firstValueFrom(userSettingService.userSetting$),
       appMode: AppMode.Test,
-    })
+    });
 
     tick(1);
 


### PR DESCRIPTION
Er i tvil om hvor nyttig denne er. Lurer både på hvor mye vi skal validere. 
Denne oppgaven ble laget fordi vi hadde opplevd å få ufullstendige kladder i databasen, en kladd som ikke hadde noen felter, og en kladd som manglet registreringsobjektet, tror jeg.
Å lage tester på manglende uuid eller registrering har jeg ikke fått til, fordi kompilatoren klager så fort jeg prøver å lage kladder uten dette.
Jeg har bare laget engelske feilmeldinger som vil vises i konsollet, så har ikke tatt meg bryet med å oversette dem.
Hvis vi kan få ufullstendige kladder i databasen skyldes det antakelig feil i koden, og da tror jeg ikke vi trenger å vise noen feilmelding til bruker.