### PR TITLE
Håndtering av konflikt under innsending av observasjoner

### DIFF
--- a/src/app/core/services/draft/draft-to-registration.service.ts
+++ b/src/app/core/services/draft/draft-to-registration.service.ts
@@ -2,7 +2,6 @@ import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Platform } from '@ionic/angular';
 import { combineLatest, exhaustMap, filter, firstValueFrom, from, interval, map, Observable, startWith, Subject, throttleTime, withLatestFrom } from 'rxjs';
-import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
 import { SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';

--- a/src/app/modules/common-registration/models/sync-status.enum.ts
+++ b/src/app/modules/common-registration/models/sync-status.enum.ts
@@ -16,5 +16,10 @@ export enum SyncStatus {
    * Registration is not changed locally. Same version exists on server
    * @deprecated In the future we won't save any registrations locally, so this status will disappear
    */
-  InSync = 'in-sync'
+  InSync = 'in-sync',
+
+  /**
+   * Same as Sync but will ignore version check in API an overwrite earlier versions
+   */
+  SyncAndIgnoreVersionCheck = 'sync-and-ignore-version-check'
 }

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.html
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.html
@@ -4,45 +4,48 @@
       {{'REGISTRATION.FAILED.TITLE' | translate}}
     </ion-label>
   </ion-list-header>
-  <ion-item>
-    <ion-label class="ion-text-wrap" *ngIf="networkError">
-      {{'REGISTRATION.FAILED.SUBTITLE' | translate}}
-    </ion-label>
-    <!-- TODO: Handle attachment error? -->
-    <ion-label class="ion-text-wrap" *ngIf="unknownError">
-      {{'REGISTRATION.FAILED.PROBLEM' | translate}}
-    </ion-label>
-    <ion-label class="ion-text-wrap" *ngIf="registrationError">
-      {{'REGISTRATION.FAILED.PROBLEM' | translate}}
-      <ng-container *ngIf="draft.error.message">
-        :<div class="error-message">
-          {{ draft.error.message }}
-        </div>
-      </ng-container>
-    </ion-label>
-    <ion-label class="ion-text-wrap" *ngIf="serverError">
-      {{'REGISTRATION.FAILED.PROBLEM' | translate}}. {{'REGISTRATION.FAILED.LOGGED' | translate}}
-      <!-- Ta skjermbilde og
-      <app-external-link src="http://www.regobs.no/Home/About">kontakt oss</app-external-link>
-      , så hjelper du oss med å finne en løsning.  -->
-      {{'REGISTRATION.FAILED.PROBLEM_HELP_TEXT' | translate}}
-    </ion-label>
-  </ion-item>
-  <ion-item *ngIf="registrationError || serverError || unknownError">
-    <ion-label class="ion-text-wrap">
-      {{'REGISTRATION.FAILED.REFERENCE' | translate}} ID: {{ draft.uuid }}
-    </ion-label>
-  </ion-item>
-  <ion-item (click)="sendEmail()">
-    <ion-icon slot="start" name="mail"></ion-icon>
-    <ion-label class="ion-text-wrap">
-      {{'REGISTRATION.FAILED.SEND_EMAIL' | translate}}
-    </ion-label>
-  </ion-item>
-  <ion-item (click)="openForEdit()">
-    <ion-icon slot="start" name="create"></ion-icon>
-    <ion-label class="ion-text-wrap">
-      {{'REGISTRATION.FAILED.EDIT_OBSERVATION' | translate}}
-    </ion-label>
-  </ion-item>
+  <app-version-conflict *ngIf="conflictError" [draft]="draft"></app-version-conflict>
+  <ng-container *ngIf="!conflictError">
+    <ion-item>
+      <ion-label class="ion-text-wrap" *ngIf="networkError">
+        {{'REGISTRATION.FAILED.SUBTITLE' | translate}} //TODO: Endre språknøkkel?
+      </ion-label>
+      <!-- TODO: Handle attachment error? -->
+      <ion-label class="ion-text-wrap" *ngIf="unknownError">
+        {{'REGISTRATION.FAILED.PROBLEM' | translate}}
+      </ion-label>
+      <ion-label class="ion-text-wrap" *ngIf="registrationError">
+        {{'REGISTRATION.FAILED.PROBLEM' | translate}}
+        <ng-container *ngIf="draft.error.message">
+          :<div class="error-message">
+            {{ draft.error.message }}
+          </div>
+        </ng-container>
+      </ion-label>
+      <ion-label class="ion-text-wrap" *ngIf="serverError">
+        {{'REGISTRATION.FAILED.PROBLEM' | translate}}. {{'REGISTRATION.FAILED.LOGGED' | translate}}
+        <!-- Ta skjermbilde og
+        <app-external-link src="http://www.regobs.no/Home/About">kontakt oss</app-external-link>
+        , så hjelper du oss med å finne en løsning.  -->
+        {{'REGISTRATION.FAILED.PROBLEM_HELP_TEXT' | translate}}
+      </ion-label>
+    </ion-item>
+    <ion-item *ngIf="registrationError || serverError || unknownError">
+      <ion-label class="ion-text-wrap">
+        {{'REGISTRATION.FAILED.REFERENCE' | translate}} ID: {{ draft.uuid }}
+      </ion-label>
+    </ion-item>
+    <ion-item (click)="sendEmail()">
+      <ion-icon slot="start" name="mail"></ion-icon>
+      <ion-label class="ion-text-wrap">
+        {{'REGISTRATION.FAILED.SEND_EMAIL' | translate}}
+      </ion-label>
+    </ion-item>
+    <ion-item (click)="openForEdit()">
+      <ion-icon slot="start" name="create"></ion-icon>
+      <ion-label class="ion-text-wrap">
+        {{'REGISTRATION.FAILED.EDIT_OBSERVATION' | translate}}
+      </ion-label>
+    </ion-item>
+  </ng-container>
 </ion-list>

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.ts
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.ts
@@ -31,6 +31,10 @@ export class FailedRegistrationComponent {
     return this.draft.error.code === RegistrationDraftErrorCode.NoNetworkOrTimedOut;
   }
 
+  get conflictError() {
+    return this.draft.error.code === RegistrationDraftErrorCode.ConflictError;
+  }
+
   get registrationError() {
     return this.draft.error.code === RegistrationDraftErrorCode.RegistrationError;
   }

--- a/src/app/modules/registration/components/send-button/send-button.component.ts
+++ b/src/app/modules/registration/components/send-button/send-button.component.ts
@@ -1,16 +1,13 @@
 import { Component, OnInit, Input, NgZone, OnDestroy, ChangeDetectionStrategy, ChangeDetectorRef, OnChanges, SimpleChanges } from '@angular/core';
 import { AlertController, NavController } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
-import { SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { takeUntil } from 'rxjs/operators';
 import { RegobsAuthService } from '../../../auth/services/regobs-auth.service';
 import { Subject } from 'rxjs';
 import { SmartChanges } from 'src/app/core/helpers/simple-changes.helper';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
-import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
-
-const DEBUG_TAG = 'app-send-button';
+import { DraftToRegistrationService } from 'src/app/core/services/draft/draft-to-registration.service';
 
 @Component({
   selector: 'app-send-button',
@@ -40,7 +37,7 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
     private regobsAuthService: RegobsAuthService,
     private cdr: ChangeDetectorRef,
     private ngZone: NgZone,
-    private loggingService: LoggingService
+    private draftToRegistrationService: DraftToRegistrationService
   ) {}
 
   ngOnInit(): void {
@@ -82,19 +79,7 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
           return;
         }
 
-        const { error, ...draftToUpdate } = this.draft;
-        if (error) {
-          this.loggingService.debug('Draft had error, will remove error when saving to retry upload', DEBUG_TAG, {
-            uuid: draftToUpdate.uuid,
-            error
-          });
-        }
-
-        // Mark draft as ready to submit
-        this.draftService.save({
-          ...draftToUpdate,
-          syncStatus: SyncStatus.Sync,
-        });
+        this.draftToRegistrationService.markDraftAsReadyToSubmit(this.draft);
 
         // Navigate to my observations
         this.navController.navigateRoot('my-observations');

--- a/src/app/modules/registration/components/version-conflict/version-conflict.component.html
+++ b/src/app/modules/registration/components/version-conflict/version-conflict.component.html
@@ -1,0 +1,17 @@
+<ion-list lines="full">
+  <ion-item>
+    <ion-label class="ion-text-wrap" [innerHTML]="'REGISTRATION.FAILED.CONFLICT' | translate"></ion-label>
+  </ion-item>
+  <ion-item (click)="abandon()">
+    <ion-icon slot="start" name="refresh"></ion-icon>
+    <ion-label class="ion-text-wrap">
+      {{'REGISTRATION.FAILED.ABANDON' | translate}}
+    </ion-label>
+  </ion-item>
+  <ion-item (click)="overwrite()">
+    <ion-icon slot="start" name="warning"></ion-icon>
+    <ion-label class="ion-text-wrap">
+      {{'REGISTRATION.FAILED.OVERWRITE' | translate}}
+    </ion-label>
+  </ion-item>
+</ion-list>

--- a/src/app/modules/registration/components/version-conflict/version-conflict.component.ts
+++ b/src/app/modules/registration/components/version-conflict/version-conflict.component.ts
@@ -1,0 +1,45 @@
+import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+import { NavController } from '@ionic/angular';
+import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
+import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
+import { DraftToRegistrationService } from 'src/app/core/services/draft/draft-to-registration.service';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+
+const DEBUG_TAG = 'VersionConflictComponent';
+
+/**
+ * Visible on the overview page for a draft if you got a version conflict when you submitted the draft.
+ * Shows the error message and let you overwrite the remote version or abandon your changes
+ */
+@Component({
+  selector: 'app-version-conflict',
+  templateUrl: './version-conflict.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class VersionConflictComponent {
+
+  @Input() draft: RegistrationDraft;
+
+  constructor(
+    private draftToRegistrationService: DraftToRegistrationService,
+    private draftRepository: DraftRepositoryService,
+    private logger: LoggingService,
+    private navController: NavController)
+  {}
+
+  overwrite(): void {
+    this.logger.debug(`Trying to overwrite remote version of draft ${this.draft.uuid}`, DEBUG_TAG);
+    this.draftToRegistrationService.markDraftAsReadyToSubmit(this.draft, true);
+    this.navigateToMyObservations(); //so we can see that the draft happily submits
+  }
+
+  abandon(): void {
+    this.logger.debug(`Draft ${this.draft.uuid} abandoned`, DEBUG_TAG);
+    this.draftRepository.delete(this.draft.uuid);
+    this.navigateToMyObservations(); //so we can find the new version
+  }
+
+  navigateToMyObservations(): void {
+    this.navController.navigateRoot('my-observations');
+  }
+}

--- a/src/app/modules/registration/pages/overview/overview.module.ts
+++ b/src/app/modules/registration/pages/overview/overview.module.ts
@@ -6,6 +6,7 @@ import { SummaryItemComponent } from '../../components/summary-item/summary-item
 import { SharedComponentsModule } from '../../shared-components.module';
 import { FailedRegistrationComponent } from '../../components/failed-registration/failed-registration.component';
 import { SaveAsDraftRouteGuard } from '../save-as-draft.guard';
+import { VersionConflictComponent } from '../../components/version-conflict/version-conflict.component';
 
 const routes: Routes = [
   {
@@ -21,7 +22,8 @@ const routes: Routes = [
     OverviewPage,
     SendButtonComponent,
     SummaryItemComponent,
-    FailedRegistrationComponent
+    FailedRegistrationComponent,
+    VersionConflictComponent
   ]
 })
 export class OverviewPageModule {}

--- a/src/app/modules/registration/pages/overview/overview.page.html
+++ b/src/app/modules/registration/pages/overview/overview.page.html
@@ -12,7 +12,7 @@
   <ion-content>
     <!-- Error info if posting the registration failed -->
     <app-failed-registration
-      *ngIf="draft.error && draft.syncStatus === RegistrationStatus.Sync"
+      *ngIf="draft.error && draftHasStatusSync(draft)"
       [draft]="draft"
     ></app-failed-registration>
 
@@ -26,7 +26,7 @@
 
       <!-- "Summary" items for each form -->
       <app-summary-item
-        [readonly]="draft.syncStatus === RegistrationStatus.Sync"
+        [readonly]="draftHasStatusSync(draft)"
         *ngFor="let item of summaryItems$ | async; trackBy: trackByFunction"
         [item]="item"
       ></app-summary-item>

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -15,7 +15,6 @@ import { DraftRepositoryService } from 'src/app/core/services/draft/draft-reposi
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class OverviewPage implements OnInit {
-  RegistrationStatus = SyncStatus;
   summaryItems$: Observable<Array<ISummaryItem>>;
   draft$: Observable<RegistrationDraft>;
 
@@ -31,6 +30,10 @@ export class OverviewPage implements OnInit {
     this.draft$ = this.draftService.getDraft$(uuid);
     this.summaryItems$ = this.summaryItemService.getSummaryItems$(uuid);
     this.userGroupService.updateUserGroups();
+  }
+
+  draftHasStatusSync(draft: RegistrationDraft): boolean {
+    return draft?.syncStatus === SyncStatus.Sync || draft?.syncStatus === SyncStatus.SyncAndIgnoreVersionCheck;
   }
 
   trackByFunction(index: number, item: ISummaryItem) {

--- a/src/app/pages/my-observations/components/sync-item/sync-item.component.ts
+++ b/src/app/pages/my-observations/components/sync-item/sync-item.component.ts
@@ -11,7 +11,8 @@ export class SyncItemComponent {
   @Input() draft: RegistrationDraft;
 
   get loading() {
-    return this.draft.syncStatus === SyncStatus.Sync && this.draft.error == null;
+    return (this.draft.syncStatus === SyncStatus.Sync || this.draft.syncStatus === SyncStatus.SyncAndIgnoreVersionCheck)
+    && this.draft.error == null;
   }
 
   get isDraft() {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -328,7 +328,10 @@
       "REFERENCE": "Reference",
       "SEND_EMAIL": "Send to us by email",
       "SUBTITLE": "Missing network or submission took too long. We'll try again after a while and hope that the network has improved.",
-      "TITLE": "Submission failed"
+      "TITLE": "Submission failed",
+      "CONFLICT": "A new version was saved while you worked.<br/>Would you like to cancel your work and load the new version or submit your version and overwrite?",
+      "ABANDON": "Cancel my work",
+      "OVERWRITE": "Submit and overwrite"
     },
     "GENERAL_COMMENT": {
       "ADD_NOTES_HEADER": "Notes for observation",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -328,7 +328,10 @@
       "REFERENCE": "Referanse",
       "SEND_EMAIL": "Send til oss på e-post",
       "SUBTITLE": "Mangler nettverk eller innsending tok for lang tid. Vi prøver igjen etter en stund og håper at nettet har bedret seg.",
-      "TITLE": "Innsending feilet"
+      "TITLE": "Innsending feilet",
+      "CONFLICT": "Mens du jobbet har observasjonen blitt endret et annet sted.<br/>Vil du forkaste dine endringer eller vil du sende inn og overskrive endringene som ble gjort et annet sted?",
+      "ABANDON": "Forkast mine endringer",
+      "OVERWRITE": "Send inn og overskriv"
     },
     "GENERAL_COMMENT": {
       "ADD_NOTES_HEADER": "Notat fra observasjonen",
@@ -399,7 +402,7 @@
       "TITLE": "Observasjon"
     },
     "REQUIRED_FIELDS_MISSING": "Ugyldig skjema. Vil du nullstille skjemaet og gå tilbake?",
-    "RESEND": "Prøv å send på nytt",
+    "RESEND": "Prøv å sende på nytt",
     "RESET": "Nullstill denne siden",
     "SAVED_DESCRIPTION": "Disse er under innsending og blir synkronisert når du har nettverk.",
     "SAVED_ON_PHONE": "Lagret på telefonen",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -315,7 +315,10 @@
       "REFERENCE": "Referanse",
       "SEND_EMAIL": "Send til oss på e-post",
       "SUBTITLE": "Manglar nettverk eller innsending tok for lang tid. Vi prøvar igjen om ei stund og håper nettverket har betra seg. ",
-      "TITLE": "Innsendinga misslykkast"
+      "TITLE": "Innsendinga misslykkast",
+      "CONFLICT": "Mens du jobba har observasjonen blitt endra ein annan plass.<br/>Vil du forkaste dine endringar eller vil du sende inn og overskrive endringene som blei gjort den andre plassen?",
+      "ABANDON": "Forkast mine endringar",
+      "OVERWRITE": "Send inn og overskriv"
     },
     "GENERAL_COMMENT": {
       "ADD_NOTES_HEADER": "Notat frå observasjonen",


### PR DESCRIPTION
Førsteutkast på konfliktløsning.
Skissene i Figma la opp til en litt for enkel måte å løse dette på, synes jeg. Vi trenger for eksempel å håndtere at man ikke får sendt inn med en gang man prøver. 
Så jeg har heller tatt utgangspunkt i feilhåndteringa vi har på innsending fra før.
Skulle ha laget tester på dette men rakk ikke.

- [x] Ser nå at når vi redirecter til "my-observations", så scroller den ikke alltid til toppen. Det kan være litt dumt, for da ser vi ikke status på kladdene. (dette er fikset i https://github.com/NVE/regObs4/pull/232)

Kunne kanskje vært lurt å ha noe tydeligere markering av at noe har feilet, så man skjønner at man må velge kladden som feilet og gjøre noe?
Har forsøkt å gjenbruke noe av "send-på-nytt"-koden som lå på innsendingsknappen.
Tenker at det ikke er nødvendig å sjekke om man er innlogget når man prøver å sende på nytt, men det kan jo feile selvfølgelig. Ville tro at http-interceptoren ordner med dette om det trengs, men har ikke testet det.
Føl fri til å gjøre om og få dette bedre!