### PR TITLE
Mine Observasjoner scroller nå autmatisk til toppen

### DIFF
--- a/src/app/pages/my-observations/my-observations.page.ts
+++ b/src/app/pages/my-observations/my-observations.page.ts
@@ -18,6 +18,10 @@ export class MyObservationsPage {
   draftIsEmpty = false;
   sentRegistrationsIsEmpty = false;
 
+  ionViewDidEnter() {
+    this.content.scrollToTop();
+  }
+
   async refresh(cancelPromise?: Promise<void>): Promise<void> {
     await this.sentListComponent.refresh(cancelPromise);
   }


### PR DESCRIPTION
Hvis du redigerer en observasjon du har sendt inn, risikerer du å ikke få med deg at innsendinga feiler, fordi Mine Observasjoner beholder fokus på observasjonskortet til observasjonen du endret.
Med denne fiksen vil alltid Mine Observasjoner scrolle til toppen, slik at evt. kladder som ikke er sendt inn vises.
Jeg vet ikke om dette er rett fiks; skjønner at det kan være irriterende å miste fokus på en observasjon også.