### PR TITLE
Fix change group bug

### DIFF
--- a/src/app/modules/registration/pages/group/group.page.html
+++ b/src/app/modules/registration/pages/group/group.page.html
@@ -18,7 +18,11 @@
           {{"REGISTRATION.GROUP.SUBTITLE" | translate}}
         </ion-label>
       </ion-list-header>
-      <ion-radio-group *ngIf="groups.length > 1" [(ngModel)]="draft.registration.ObserverGroupID">
+      <ion-radio-group
+        *ngIf="groups.length > 1"
+        [ngModel]="draft.registration.ObserverGroupID"
+        (ngModelChange)="groupChanged($event)"
+      >
         <ion-item *ngFor="let group of groups">
           <ion-radio mode="md" slot="start" [value]="group.Id"></ion-radio>
           <ion-label>{{group.Name}}</ion-label>

--- a/src/app/modules/registration/pages/group/group.page.ts
+++ b/src/app/modules/registration/pages/group/group.page.ts
@@ -49,9 +49,6 @@ export class GroupPage extends BasePage {
     }
 
     return pleaseReset;
-    // this.ngZone.run(() => {
-    //   this.draft.registration.ObserverGroupID = undefined;
-    // });
   }
 
   groupChanged(ObserverGroupID: RegistrationEditModel['ObserverGroupID']) {

--- a/src/app/modules/registration/pages/group/group.page.ts
+++ b/src/app/modules/registration/pages/group/group.page.ts
@@ -1,6 +1,6 @@
 import { Component, NgZone } from '@angular/core';
 import { UserGroupService } from '../../../../core/services/user-group/user-group.service';
-import { ObserverGroupDto } from 'src/app/modules/common-regobs-api/models';
+import { ObserverGroupDto, RegistrationEditModel } from 'src/app/modules/common-regobs-api/models';
 import { BasePage } from '../base.page';
 import { BasePageService } from '../base-page-service';
 import { ActivatedRoute } from '@angular/router';
@@ -41,19 +41,36 @@ export class GroupPage extends BasePage {
     });
   }
 
-  onReset(): void {
-    this.ngZone.run(() => {
-      this.draft.registration.ObserverGroupID = undefined;
-    });
+  async reset() {
+    const pleaseReset = await super.reset();
+
+    if (pleaseReset) {
+      this.groupChanged(null);
+    }
+
+    return pleaseReset;
+    // this.ngZone.run(() => {
+    //   this.draft.registration.ObserverGroupID = undefined;
+    // });
+  }
+
+  groupChanged(ObserverGroupID: RegistrationEditModel['ObserverGroupID']) {
+    this.draft = {
+      ...this.draft,
+      registration: {
+        ...this.draft.registration,
+        ObserverGroupID
+      }
+    };
   }
 
   checkedChanged(event: CustomEvent): void {
     const checkBox = (<any>event.target) as IonCheckbox;
+    let ObserverGroupID: RegistrationEditModel['ObserverGroupID'] = null;
     if (checkBox.checked) {
-      this.draft.registration.ObserverGroupID = this.firstGroup.Id;
-    } else {
-      this.draft.registration.ObserverGroupID = undefined;
+      ObserverGroupID = this.firstGroup.Id;
     }
+    this.groupChanged(ObserverGroupID);
   }
 
   isEmpty(): Promise<boolean> {


### PR DESCRIPTION
Fikser en feil grunnet `[(ngModel)]="draft.registration.ObserverGroupID"`. Når vi endrer direkte på `draft.registration` virker ikke `distinctUntilChanged`-sjekken i `summary-items.service.ts`. Vi endrer da direkte på objektet som `previous` i sjekkene peker til.