### PR TITLE
RO-1695: Nå får vi med oss at alle skjema er endret i skjemaoversikten

### DIFF
--- a/src/app/modules/registration/services/summary-item.service.spec.ts
+++ b/src/app/modules/registration/services/summary-item.service.spec.ts
@@ -1,12 +1,42 @@
-// import { TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
+import { SyncStatus } from '../../common-registration/registration.models';
 
-// import { SummaryItemService } from './summary-item.service';
+import { draftHasNotChanged } from './summary-item.service';
 
-// describe('SummaryItemService', () => {
-//   beforeEach(() => TestBed.configureTestingModule({}));
+describe('SummaryItemService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
 
-//   it('should be created', () => {
-//     const service: SummaryItemService = TestBed.get(SummaryItemService);
-//     expect(service).toBeTruthy();
-//   });
-// });
+  it('draftHasNotChanged should detect changes in comment schema', async () => {
+
+    const draftV1: RegistrationDraft = {
+      uuid: 'draft',
+      syncStatus: SyncStatus.Draft,
+      registration: {
+        GeoHazardTID: 10,
+        DtObsTime: 'obsTime',
+        GeneralObservation: {
+          Comment: 'version 1'
+        }
+      }
+    };
+
+    const draftV1Copy: RegistrationDraft = {
+      ...draftV1
+    };
+
+    const draftV2: RegistrationDraft = {
+      ...draftV1,
+      registration: {
+        ...draftV1.registration,
+        GeneralObservation: {
+          Comment: 'version 2'
+        }
+      }
+    };
+
+    expect(draftHasNotChanged(draftV1, draftV1Copy)).toBeTrue();
+    expect(draftHasNotChanged(draftV1, draftV2)).toBeFalse();
+  });
+
+});

--- a/src/app/modules/registration/services/summary-item.service.spec.ts
+++ b/src/app/modules/registration/services/summary-item.service.spec.ts
@@ -1,13 +1,11 @@
-import { TestBed } from '@angular/core/testing';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { SyncStatus } from '../../common-registration/registration.models';
 
 import { draftHasNotChanged } from './summary-item.service';
 
 describe('SummaryItemService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
 
-  it('draftHasNotChanged should detect changes in comment schema', async () => {
+  it('draftHasNotChanged should detect changes in comment schema', () => {
 
     const draftV1: RegistrationDraft = {
       uuid: 'draft',
@@ -35,8 +33,28 @@ describe('SummaryItemService', () => {
       }
     };
 
+    const draftV3: RegistrationDraft = {
+      ...draftV1,
+      registration: {
+        ...draftV1.registration,
+        GeneralObservation: undefined
+      }
+    };
+
+    const draftV4: RegistrationDraft = {
+      ...draftV3,
+      registration: {
+        ...draftV1.registration,
+        WeatherObservation: {
+          AirTemperature: 42
+        }
+      }
+    };
+
     expect(draftHasNotChanged(draftV1, draftV1Copy)).toBeTrue();
     expect(draftHasNotChanged(draftV1, draftV2)).toBeFalse();
+    expect(draftHasNotChanged(draftV1, draftV3)).toBeFalse();
+    expect(draftHasNotChanged(draftV1, draftV4)).toBeFalse(); //same number of schemas, but schemas are different
   });
 
 });

--- a/src/app/modules/registration/services/summary-item.service.ts
+++ b/src/app/modules/registration/services/summary-item.service.ts
@@ -12,11 +12,17 @@ import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
 import { combineLatest, distinctUntilChanged, from, map, Observable, switchMap } from 'rxjs';
 import deepEqual from 'fast-deep-equal';
-import { getAllAttachmentsFromEditModel, getRegistrationsWithData, isObservationModelEmptyForRegistrationTid } from '../../common-registration/registration.helpers';
+import { getAllAttachmentsFromEditModel, getRegistationPropertyForModel, getRegistrationsWithData, isObservationModelEmptyForRegistrationTid } from '../../common-registration/registration.helpers';
 import { attachmentsComparator } from 'src/app/core/helpers/attachment-comparator';
 import { NewAttachmentService } from '../../common-registration/registration.services';
 
-function draftHasNotChanged(previous: RegistrationDraft, current: RegistrationDraft) {
+/**
+ *
+ * @param previous
+ * @param current
+ * @returns
+ */
+export function draftHasNotChanged(previous: RegistrationDraft, current: RegistrationDraft) {
   // Check if draft time has changed
   if (previous.registration.DtObsTime !== current.registration.DtObsTime) {
     return false;
@@ -41,9 +47,13 @@ function draftHasNotChanged(previous: RegistrationDraft, current: RegistrationDr
   }
 
   // Check if we have any changed forms
-  const anyTidsChanged = curTids.some((curTid, i) => curTid !== preTids[i]);
-  if (anyTidsChanged) {
-    return false;
+  const allTidsThatMayHaveChanged = [...preTids, ...curTids].filter((v, i, a) => a.indexOf(v) === i);
+  for (const tid of allTidsThatMayHaveChanged) {
+    const previousRegistration = getRegistationPropertyForModel(previous.registration, tid);
+    const currentRegistration = getRegistationPropertyForModel(current.registration, tid);
+    if (!deepEqual(previousRegistration, currentRegistration)) {
+      return false;
+    }
   }
 
   const preExistingAttachments = getAllAttachmentsFromEditModel(previous.registration);

--- a/src/app/modules/registration/services/summary-item.service.ts
+++ b/src/app/modules/registration/services/summary-item.service.ts
@@ -47,8 +47,7 @@ export function draftHasNotChanged(previous: RegistrationDraft, current: Registr
   }
 
   // Check if we have any changed forms
-  const allTidsThatMayHaveChanged = [...preTids, ...curTids].filter((v, i, a) => a.indexOf(v) === i);
-  for (const tid of allTidsThatMayHaveChanged) {
+  for (const tid of curTids) {
     const previousRegistration = getRegistationPropertyForModel(previous.registration, tid);
     const currentRegistration = getRegistationPropertyForModel(current.registration, tid);
     if (!deepEqual(previousRegistration, currentRegistration)) {


### PR DESCRIPTION
Nå kjører vi en deepEquals på alle skjema for å fange opp endringer. Sikkert ikke nødvendig i og med at vi bare viser data fra enkelte skjemaer i oversikten, men da slipper vi å spesialbehandle enkeltskjema seinere.