### PR TITLE
RO:1692: Funksjon for å slette observasjoner som er sendt inn

### DIFF
--- a/src/app/core/services/draft/draft-repository.service.ts
+++ b/src/app/core/services/draft/draft-repository.service.ts
@@ -212,6 +212,28 @@ export class DraftRepositoryService {
   }
 
   /**
+  * Request to delete a registration from server
+  * The registration will be deleted from server next time we can reach the server
+  * Nothing will happen if we don't find it.
+  * @param uuid uuid of the registration you want to delete
+  * @throw error if the registration doesn't have a RegId (not submitted to server)
+  */
+  async deleteFromServer(uuid: string): Promise<void> {
+    const draft = await this.load(uuid);
+    if (draft) {
+      if (!draft.regId) {
+        throw new Error('Missing RegId. Are you sure this registration has been saved in Regobs earlier?');
+      }
+      const updatedDraft: RegistrationDraft = {
+        ...draft,
+        syncStatus: SyncStatus.DeleteRequested
+      };
+      this.logger.debug(`Draft ${uuid} requested for deletion from server`, DEBUG_TAG);
+      await this.save(updatedDraft);
+    }
+  }
+
+  /**
    * @returns a key for all drafts for given app mode
    */
   private createKeyForAllDrafts(appMode: AppMode): string {

--- a/src/app/modules/common-registration/models/sync-status.enum.ts
+++ b/src/app/modules/common-registration/models/sync-status.enum.ts
@@ -21,5 +21,10 @@ export enum SyncStatus {
   /**
    * Same as Sync but will ignore version check in API an overwrite earlier versions
    */
-  SyncAndIgnoreVersionCheck = 'sync-and-ignore-version-check'
+  SyncAndIgnoreVersionCheck = 'sync-and-ignore-version-check',
+
+  /**
+   * Registration is on its way to be deleted
+   */
+  DeleteRequested = 'delete-requested'
 }

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -66,6 +66,18 @@ export class SentListComponent implements OnInit, OnDestroy {
         this.isEmpty.next(false);
         this.changeDetectorRef.detectChanges();
       });
+
+    //remove deleted registrations from the list when we get notified
+    draftToRegService.deletedRegistrationIds$
+      .pipe(takeUntil(this.ngDestroy$))
+      .subscribe((deletedRegId) => {
+        const regsWithoutDeletedRegistration = this.loadedRegistrations
+          .filter(reg => reg.RegId !== deletedRegId);
+
+        this.loadedRegistrations = regsWithoutDeletedRegistration;
+        this.isEmpty.emit(this.loadedRegistrations.length === 0);
+        this.changeDetectorRef.detectChanges();
+      });
   }
 
   ngOnDestroy(): void {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -6,13 +6,15 @@
     "TITLE": "Varsom Abonner"
   },
   "ADD_MENU": {
-    "DRAFT_TITLE_SOIL": "Draft: Soil observation",
+    "DRAFT_TITLE_DIRT": "Draft: Soil observation",
     "DRAFT_TITLE_ICE": "Draft: Ice observation",
     "DRAFT_TITLE_SNOW": "Draft: Snow observation",
+    "DRAFT_TITLE_SOIL": "Draft: Soil observation",
     "DRAFT_TITLE_WATER": "Draft: Water observation",
-    "NEW_SOIL_OBSERVATION": "New soil observation",
+    "NEW_DIRT_OBSERVATION": "New soil observation",
     "NEW_ICE_OBSERVATION": "New ice observation",
     "NEW_SNOW_OBSERVATION": "New snow observation",
+    "NEW_SOIL_OBSERVATION": "New soil observation",
     "NEW_WATER_OBSERVATION": "New water observation"
   },
   "ALERT": {
@@ -100,7 +102,7 @@
     "LINE_1": "Use the warnings, data and maps at your own risk. Errors and omissions may be present.",
     "LINE_2": "A warning is a planning tool and may differ from the actual situation. Always make your own evaluation. Conditions may be complex and differ from the warning.",
     "LINE_3": "Data on Regobs is produced by the users and is available «as is». It may contain errors and omissions. NVE makes no warranties for errors, omissions and assessments produced by the users.",
-    "LINE_4": "When publishing images with observations in Regobs, you also accept reuse of these images (licensed under <a href='https://data.norge.no/nlod/en/'>NLOD</a>).",
+    "LINE_4": "When publishing images with observations in Regobs, you also accept reuse of these images (licensed under <a href='https://data.norge.no/nlod/no/'>NLOD</a>).",
     "LINE_5": "Read more in our <a href=\"{{legalUrl}}\" target=\"_blank\">Terms of Service</a>.",
     "OK": "Ok, I accept",
     "TERMS": "Data on Varsom Regobs is produced by the users of Regobs and is available as it is. The information may contain errors and omissions. NVE makes no guarantee for the quality or accuracy of the information which is found on Regobs and does not take responsibility for data which is incorrect or misleading. The number of stars besides a username (1-5) indicates the level of competence of the person providing observations. Without stars, competence is unknown or low."
@@ -210,6 +212,7 @@
   "OBSERVATION_LIST": {
     "ALL_OBSERVATIONS": "All observations",
     "FORMS": "Forms",
+    "GO_TO_OBSERVATION": "Go to observation",
     "IN_MAP_VIEW": "Observations in map view",
     "MAX_COUNT_REACHED_HEADER": "No more observations",
     "MAX_COUNT_REACHED_TEXT": "We show max {{ maxCount }} observations here. If you didn't find what you looked for you may try to zoom in or narrow the period you want to see observations from.",
@@ -292,8 +295,15 @@
       "RIGHT_HERE": "Right here",
       "TITLE": "Danger Sign"
     },
-    "DELETE": "Delete observation",
-    "DELETE_CONFIRM": "Are you sure?",
+    "DELETE": {
+      "BUTTON": {
+        "DELETE_FROM_REGOBS": "Delete from Regobs",
+        "CANCEL_CHANGES": "Cancel changes"
+      },
+      "DRAFT_CONFIRMATION": "This observation is not sent to Regobs yet. Do you want to delete it?",
+      "HEADER": "Delete observation",
+      "REGOBS_CONFIRMATION": "This observation is already in Regobs. Do you want to delete the observation for good from Regobs or cancel your latest changes?"
+    },
     "DIRT": {
       "LAND_SLIDE_OBS": {
         "AVAL_TRIGGER": "Landslide trigger",
@@ -320,17 +330,17 @@
       "SUBJECT": "Registration failed"
     },
     "FAILED": {
+      "ABANDON": "Cancel my work",
+      "CONFLICT": "A new version was saved while you worked.<br/>Would you like to cancel your work and load the new version or submit your version and overwrite?",
       "EDIT_OBSERVATION": "Edit observation",
       "LOGGED": "The problem has been logged.",
+      "OVERWRITE": "Submit and overwrite",
       "PROBLEM": "There has been a problem with your registration",
       "PROBLEM_HELP_TEXT": "Observations with errors are stored in your phone and when the problem is resolved you will be able to resubmit.",
       "REFERENCE": "Reference",
       "SEND_EMAIL": "Send to us by email",
       "SUBTITLE": "Missing network or submission took too long. We'll try again after a while and hope that the network has improved.",
-      "TITLE": "Submission failed",
-      "CONFLICT": "A new version was saved while you worked.<br/>Would you like to cancel your work and load the new version or submit your version and overwrite?",
-      "ABANDON": "Cancel my work",
-      "OVERWRITE": "Submit and overwrite"
+      "TITLE": "Submission failed"
     },
     "GENERAL_COMMENT": {
       "ADD_NOTES_HEADER": "Notes for observation",
@@ -665,7 +675,7 @@
     "LANGUAGE": "Language",
     "NORWAY_ONLY": "In Norway only",
     "NUMBER_OF_TILES_IN_CACHE": "Offline tiles cache size",
-    "READ_MORE_IN_LICENSE_AGREEMENT": "You can read about our use of data in our <a href=\"{{legalUrl}}\" target=\"_blank\">privacy policy</a>.",
+    "READ_MORE_IN_LICENSE_AGREEMENT": "You can read about our use of data in our privacy policy.",
     "RESET": "Reset app",
     "RESETTING": "App is resetting. Please wait...",
     "SHOW_ADVANCED": "Show advanced settings",


### PR DESCRIPTION
Sletting av observasjon som er sendt inn virker nå, og jeg vil gjerne ha tilbakemelding på hvordan jeg har løst det.
Føler meg ikke helt ferdig med denne ennå, det er noen ting som bør sjekkes og evt. løses:

- [ ] Har ikke skrevet noen enhetstester knytta til synkronisering ennå
- [ ] Oppdatering av observasjons-cache virker ikke helt som den henger med. Ser i hvert fall at slettede observasjoner fortsatt kan dukke opp i kartet
- [ ] Navigering tilbake til der man kom fra etter man har slettet er ikke på plass. Nå navigerer jeg alltid til "mine observasjoner" etter sletting
- [ ] Jeg er usikker på hvordan jeg skal løse språkendringene. Har foreløpig lastet ned engelsk språk fra Localize før jeg endret i denne fila. Ser jeg har fått med meg noen utdaterte tekster fra Localize

Tilbakemeldinger etter diskusjon med Aron:
- [ ] Popup som vises når man sletter er for komplisert. Fjerne valget om å tilbakestille / angre og heller ha dette som en egen knapp
- [ ] Hvis vi ikke får slettet med en gang, og bruker åpner observasjonen for redigering, må vi vise tydelig at denne er på tur til å bli slettet, og vi bør ikke kunne sende den inn på nytt. Eller gjøre om slik at sletter med en gang om vi har kontakt med server og heller sier ifra om vi ikke får det til og gir opp