### PR TITLE
RO-1692: Sletting av innsendte observasjoner

### DIFF
--- a/src/app/core/services/add-update-delete-registration/add-update-delete-registration.service.ts
+++ b/src/app/core/services/add-update-delete-registration/add-update-delete-registration.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { firstValueFrom, Observable, Subject, timeout } from 'rxjs';
+import { catchError, firstValueFrom, Observable, Subject, take, tap, timeout } from 'rxjs';
 import { removeEmptyRegistrations } from 'src/app/modules/common-registration/registration.helpers';
 import { RegistrationService, RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 import { RegistrationDraft } from '../draft/draft-model';
@@ -119,10 +119,9 @@ export class AddUpdateDeleteRegistrationService {
       throw new Error('regId required');
     }
     return firstValueFrom(this.regobsApiRegistrationService.RegistrationDelete(regId).pipe(
-      timeout( timeoutInMillis),
-    )).then(() => {
-      this.deletedRegistrationIds.next(regId);
-    });
+      timeout(timeoutInMillis),
+      tap(() => this.deletedRegistrationIds.next(regId))
+    ));
   }
 
   /**

--- a/src/app/core/services/draft/draft-to-registration.service.spec.ts
+++ b/src/app/core/services/draft/draft-to-registration.service.spec.ts
@@ -5,7 +5,7 @@ import { Observable, of, ReplaySubject } from 'rxjs';
 import { SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
-import { AddUpdateDeleteRegistrationService } from '../add-update-delete-registration/add-updade-delete-registration.service';
+import { AddUpdateDeleteRegistrationService } from '../add-update-delete-registration/add-update-delete-registration.service';
 import { NetworkStatusService } from '../network-status/network-status.service';
 import { RegistrationDraft, RegistrationDraftErrorCode } from './draft-model';
 import { DraftRepositoryService } from './draft-repository.service';

--- a/src/app/core/services/draft/draft-to-registration.service.ts
+++ b/src/app/core/services/draft/draft-to-registration.service.ts
@@ -1,11 +1,10 @@
 import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Platform } from '@ionic/angular';
-import { combineLatest, exhaustMap, filter, firstValueFrom, from, interval, map, Observable, startWith, Subject, throttleTime, withLatestFrom } from 'rxjs';
+import { combineLatest, exhaustMap, filter, firstValueFrom, from, interval, map, startWith, throttleTime, withLatestFrom } from 'rxjs';
 import { SyncStatus } from 'src/app/modules/common-registration/registration.models';
-import { RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
-import { AddUpdateDeleteRegistrationService } from '../add-update-delete-registration/add-updade-delete-registration.service';
+import { AddUpdateDeleteRegistrationService } from '../add-update-delete-registration/add-update-delete-registration.service';
 import { NetworkStatusService } from '../network-status/network-status.service';
 import { UploadAttachmentError } from '../upload-attachments/upload-attachments.service';
 import { RegistrationDraft, RegistrationDraftErrorCode } from './draft-model';
@@ -24,15 +23,6 @@ const DEBUG_TAG = 'DraftToRegistrationService';
 })
 export class DraftToRegistrationService {
   private initialized = false;
-
-  /**
-   * Emits new uploaded registrations.
-   */
-  get newRegistrations$(): Observable<RegistrationViewModel> {
-    return this.newRegistrations.asObservable();
-  }
-
-  private newRegistrations = new Subject<RegistrationViewModel>();
 
   /**
    * Used to track what registrations we are currently uploading,
@@ -135,17 +125,14 @@ export class DraftToRegistrationService {
     this.loggerService.debug(`Sending registration ${draft.uuid} to regobs api`, DEBUG_TAG);
 
     try {
-      let result: RegistrationViewModel;
-
       if (draft.regId) {
         const ignoreVersionCheck = draft.syncStatus === SyncStatus.SyncAndIgnoreVersionCheck;
-        result = await this.addUpdateDeleteRegistrationService.update(draft, ignoreVersionCheck);
+        await this.addUpdateDeleteRegistrationService.update(draft, ignoreVersionCheck);
       } else {
-        result = await this.addUpdateDeleteRegistrationService.add(draft);
+        await this.addUpdateDeleteRegistrationService.add(draft);
       }
 
       await this.draftService.delete(draft.uuid);
-      this.newRegistrations.next(result);
     } catch (error) {
       const { message, code } = handleError(error);
       this.loggerService.error(error, DEBUG_TAG, message);

--- a/src/app/modules/registration/components/send-button/send-button.component.html
+++ b/src/app/modules/registration/components/send-button/send-button.component.html
@@ -13,11 +13,18 @@
         </ion-col>
       </ion-row>
       <ion-row class="ion-no-padding">
+        <ion-col *ngIf="draft.regId" class="delete-button-col ion-no-padding ion-text-center">
+          <ion-button (click)="requestDeleteDraft()" color="dark" size="small" fill="clear">
+            <svg-icon slot="start" src="/assets/icon/reset.svg"></svg-icon>
+            {{"REGISTRATION.DELETE.DRAFT.BUTTON" | translate}}
+          </ion-button>
+        </ion-col>
         <ion-col class="delete-button-col ion-no-padding ion-text-center">
-          <ion-button (click)="delete()" color="dark" size="small" fill="clear">
+          <ion-button (click)="requestDelete()" color="dark" size="small" fill="clear">
             <!-- <ion-icon slot="start" name="trash"></ion-icon> -->
             <svg-icon slot="start" src="/assets/icon/delete.svg"></svg-icon>
-            {{"REGISTRATION.DELETE" | translate}}
+            <span *ngIf="draft.regId">{{"REGISTRATION.DELETE.REGOBS.BUTTON" | translate}}</span>
+            <span *ngIf="!draft.regId">{{"REGISTRATION.DELETE.BUTTON" | translate}}</span>
           </ion-button>
         </ion-col>
       </ion-row>

--- a/src/app/modules/registration/components/send-button/send-button.component.html
+++ b/src/app/modules/registration/components/send-button/send-button.component.html
@@ -13,18 +13,16 @@
         </ion-col>
       </ion-row>
       <ion-row class="ion-no-padding">
-        <ion-col *ngIf="draft.regId" class="delete-button-col ion-no-padding ion-text-center">
+        <ion-col class="delete-button-col ion-no-padding ion-text-center">
           <ion-button (click)="requestDeleteDraft()" color="dark" size="small" fill="clear">
             <svg-icon slot="start" src="/assets/icon/reset.svg"></svg-icon>
             {{"REGISTRATION.DELETE.DRAFT.BUTTON" | translate}}
           </ion-button>
         </ion-col>
-        <ion-col class="delete-button-col ion-no-padding ion-text-center">
-          <ion-button (click)="requestDelete()" color="dark" size="small" fill="clear">
-            <!-- <ion-icon slot="start" name="trash"></ion-icon> -->
+        <ion-col *ngIf="draft.regId" class="delete-button-col ion-no-padding ion-text-center">
+          <ion-button (click)="requestDeleteFromRegobs()" color="dark" size="small" fill="clear">
             <svg-icon slot="start" src="/assets/icon/delete.svg"></svg-icon>
-            <span *ngIf="draft.regId">{{"REGISTRATION.DELETE.REGOBS.BUTTON" | translate}}</span>
-            <span *ngIf="!draft.regId">{{"REGISTRATION.DELETE.BUTTON" | translate}}</span>
+            {{"REGISTRATION.DELETE.SUBMITTED_REGISTRATION.BUTTON" | translate}}
           </ion-button>
         </ion-col>
       </ion-row>

--- a/src/app/modules/registration/components/send-button/send-button.component.ts
+++ b/src/app/modules/registration/components/send-button/send-button.component.ts
@@ -167,7 +167,7 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
       this.handleDeleteFromRegobsFailed(err);
       return;
     }
-    this.draftService.delete(this.draft.uuid);
+    await this.draftService.delete(this.draft.uuid);
     this.navigateToMyObservations();
   }
 

--- a/src/app/modules/registration/components/send-button/send-button.component.ts
+++ b/src/app/modules/registration/components/send-button/send-button.component.ts
@@ -162,7 +162,7 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
 
   private async deleteFromRegobs(): Promise<void> {
     try {
-      this.addUpdateDeleteRegistrationService.delete(this.draft.regId, DELETE_OBS_TIMEOUT_MS);
+      await this.addUpdateDeleteRegistrationService.delete(this.draft.regId, DELETE_OBS_TIMEOUT_MS);
     } catch (err) {
       this.handleDeleteFromRegobsFailed(err);
       return;

--- a/src/app/modules/registration/components/send-button/send-button.component.ts
+++ b/src/app/modules/registration/components/send-button/send-button.component.ts
@@ -8,7 +8,7 @@ import { SmartChanges } from 'src/app/core/helpers/simple-changes.helper';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
 import { DraftToRegistrationService } from 'src/app/core/services/draft/draft-to-registration.service';
-import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-update-delete-registration/add-updade-delete-registration.service';
+import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-update-delete-registration/add-update-delete-registration.service';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 
 const DEBUG_TAG = 'SendButtonComponent';
@@ -95,14 +95,6 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  async requestDelete(): Promise<void> {
-    if (this.draft.regId) {
-      this.requestDeleteFromRegobs();
-    } else {
-      this.requestDeleteDraft();
-    }
-  }
-
   async requestDeleteDraft(): Promise<void> {
     const translations = await firstValueFrom(this.translateService
       .get([
@@ -138,14 +130,14 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
   async requestDeleteFromRegobs(): Promise<void> {
     const translations = await firstValueFrom(this.translateService
       .get([
-        'REGISTRATION.DELETE.REGOBS.HEADER',
-        'REGISTRATION.DELETE.REGOBS.MESSAGE',
-        'REGISTRATION.DELETE.REGOBS.BUTTON',
+        'REGISTRATION.DELETE.SUBMITTED_REGISTRATION.HEADER',
+        'REGISTRATION.DELETE.SUBMITTED_REGISTRATION.MESSAGE',
+        'REGISTRATION.DELETE.SUBMITTED_REGISTRATION.BUTTON',
         'DIALOGS.CANCEL'
       ]));
     const alert = await this.alertController.create({
-      header: translations['REGISTRATION.DELETE.REGOBS.HEADER'],
-      message: translations['REGISTRATION.DELETE.REGOBS.MESSAGE'],
+      header: translations['REGISTRATION.DELETE.SUBMITTED_REGISTRATION.HEADER'],
+      message: translations['REGISTRATION.DELETE.SUBMITTED_REGISTRATION.MESSAGE'],
       buttons: [
         {
           text: translations['DIALOGS.CANCEL'],
@@ -153,7 +145,7 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
           cssClass: 'secondary'
         },
         {
-          text: translations['REGISTRATION.DELETE.REGOBS.BUTTON'],
+          text: translations['REGISTRATION.DELETE.SUBMITTED_REGISTRATION.BUTTON'],
           handler: () => {
             this.deleteFromRegobs();
           }
@@ -164,32 +156,31 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   private async deleteDraft(): Promise<void> {
-    this.draftService.delete(this.draft.uuid).then(() => {
-      this.navigateToMyObservations();
-    });
+    await this.draftService.delete(this.draft.uuid);
+    this.navigateToMyObservations();
   }
 
   private async deleteFromRegobs(): Promise<void> {
-    this.addUpdateDeleteRegistrationService.delete(this.draft.regId, DELETE_OBS_TIMEOUT_MS)
-      .then(() => {
-        this.draftService.delete(this.draft.uuid);
-        this.navigateToMyObservations();
-      })
-      .catch((err) => {
-        this.handleDeleteFromRegobsFailed(err);
-      });
+    try {
+      this.addUpdateDeleteRegistrationService.delete(this.draft.regId, DELETE_OBS_TIMEOUT_MS);
+    } catch (err) {
+      this.handleDeleteFromRegobsFailed(err);
+      return;
+    }
+    this.draftService.delete(this.draft.uuid);
+    this.navigateToMyObservations();
   }
 
   private async handleDeleteFromRegobsFailed(err: Error) {
     this.deleteDraft();
     const translations = await firstValueFrom(this.translateService
       .get([
-        'REGISTRATION.DELETE.REGOBS.FAILED.HEADER',
-        'REGISTRATION.DELETE.REGOBS.FAILED.MESSAGE'
+        'REGISTRATION.DELETE.SUBMITTED_REGISTRATION.FAILED.HEADER',
+        'REGISTRATION.DELETE.SUBMITTED_REGISTRATION.FAILED.MESSAGE'
       ]));
     const alert = await this.alertController.create({
-      header: translations['REGISTRATION.DELETE.REGOBS.FAILED.HEADER'],
-      message: translations['REGISTRATION.DELETE.REGOBS.FAILED.MESSAGE']
+      header: translations['REGISTRATION.DELETE.SUBMITTED_REGISTRATION.FAILED.HEADER'],
+      message: translations['REGISTRATION.DELETE.SUBMITTED_REGISTRATION.FAILED.MESSAGE']
     });
     this.logger.debug(`Delete of registration with regID ${this.draft.regId} failed`, DEBUG_TAG, err);
     await alert.present();

--- a/src/app/modules/registration/components/send-button/send-button.component.ts
+++ b/src/app/modules/registration/components/send-button/send-button.component.ts
@@ -87,9 +87,7 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
         }
 
         this.draftToRegistrationService.markDraftAsReadyToSubmit(this.draft);
-
-        // Navigate to my observations
-        this.navController.navigateRoot('my-observations');
+        this.navigateToMyObservations();
       } finally {
         this.isSending = false;
         this.cdr.detectChanges();
@@ -167,7 +165,7 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
 
   private async deleteDraft(): Promise<void> {
     this.draftService.delete(this.draft.uuid).then(() => {
-      this.navController.pop(); //Go back to where we started
+      this.navigateToMyObservations();
     });
   }
 
@@ -175,7 +173,7 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
     this.addUpdateDeleteRegistrationService.delete(this.draft.regId, DELETE_OBS_TIMEOUT_MS)
       .then(() => {
         this.draftService.delete(this.draft.uuid);
-        this.navController.navigateRoot('my-observations');
+        this.navigateToMyObservations();
       })
       .catch((err) => {
         this.handleDeleteFromRegobsFailed(err);
@@ -195,5 +193,9 @@ export class SendButtonComponent implements OnInit, OnDestroy, OnChanges {
     });
     this.logger.debug(`Delete of registration with regID ${this.draft.regId} failed`, DEBUG_TAG, err);
     await alert.present();
+  }
+
+  private navigateToMyObservations(): void {
+    this.navController.navigateRoot('my-observations');
   }
 }

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -67,18 +67,6 @@ export class SentListComponent implements OnDestroy {
         this.isEmpty.next(false);
         this.changeDetectorRef.detectChanges();
       });
-
-    //remove deleted registrations from the list when we get notified
-    addUpdateDeleteRegistrationService.deletedRegistrationIds$
-      .pipe(takeUntil(this.ngDestroy$))
-      .subscribe((deletedRegId) => {
-        const regsWithoutDeletedRegistration = this.loadedRegistrations
-          .filter(reg => reg.RegId !== deletedRegId);
-
-        this.loadedRegistrations = regsWithoutDeletedRegistration;
-        this.isEmpty.emit(this.loadedRegistrations.length === 0);
-        this.changeDetectorRef.detectChanges();
-      });
   }
 
   ngOnDestroy(): void {

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -31,7 +31,7 @@ const getUniqueRegistrations = (regs: RegistrationViewModel[]) => {
   styleUrls: ['./sent-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SentListComponent implements OnInit, OnDestroy {
+export class SentListComponent implements OnDestroy {
   loadedRegistrations: RegistrationViewModel[] = [];
   loaded = false;
   refreshFunc = this.refresh.bind(this);
@@ -71,10 +71,6 @@ export class SentListComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.ngDestroy$.next();
     this.ngDestroy$.complete();
-  }
-
-  async ngOnInit(): Promise<void> {
-    this.initRegistrationSubscription();
   }
 
   async refresh(cancelPromise?: Promise<void>): Promise<void> {

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -3,8 +3,7 @@ import { IonInfiniteScroll } from '@ionic/angular';
 import { combineLatest, Observable, of, Subject } from 'rxjs';
 import { distinctUntilChanged, finalize, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { enterZone, toPromiseWithCancel } from 'src/app/core/helpers/observable-helper';
-import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-update-delete-registration/add-updade-delete-registration.service';
-import { DraftToRegistrationService } from 'src/app/core/services/draft/draft-to-registration.service';
+import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-update-delete-registration/add-update-delete-registration.service';
 import { ObservationService } from 'src/app/core/services/observation/observation.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
@@ -12,6 +11,7 @@ import { RegistrationViewModel } from 'src/app/modules/common-regobs-api/models'
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { settings } from 'src/settings';
 
+const DEBUG_TAG = 'SentListComponent';
 const PAGE_SIZE = 10;
 const MAX_REGISTRATIONS_COUNT = 100;
 
@@ -43,18 +43,17 @@ export class SentListComponent implements OnDestroy {
   private ngDestroy$ = new Subject<void>();
 
   constructor(
-    draftToRegService: DraftToRegistrationService,
+    addUpdateDeleteRegistrationService: AddUpdateDeleteRegistrationService,
     private observationService: ObservationService,
     private userSettingService: UserSettingService,
     private regobsAuthService: RegobsAuthService,
     private changeDetectorRef: ChangeDetectorRef,
     private loggingService: LoggingService,
     private ngZone: NgZone,
-    addUpdateDeleteRegistrationService: AddUpdateDeleteRegistrationService
   ) {
     this.myObservationsUrl$ = this.createMyObservationsUrl$();
 
-    draftToRegService.newRegistrations$
+    addUpdateDeleteRegistrationService.changedRegistrations$
       .pipe(takeUntil(this.ngDestroy$))
       .subscribe((newRegistration) => {
         const regsWithoutNewRegistration = this.loadedRegistrations
@@ -107,7 +106,7 @@ export class SentListComponent implements OnDestroy {
       ]);
       this.isEmpty.emit(this.loadedRegistrations.length === 0);
     } catch (error) {
-      this.loggingService.debug('Could not load my registrations', 'SentListComponent.initRegistrationSubscription()', error);
+      this.loggingService.debug('Could not load my registrations', DEBUG_TAG, error);
     } finally {
       this.loaded = true;
       this.changeDetectorRef.detectChanges();

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -3,6 +3,7 @@ import { IonInfiniteScroll } from '@ionic/angular';
 import { combineLatest, Observable, of, Subject } from 'rxjs';
 import { distinctUntilChanged, finalize, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { enterZone, toPromiseWithCancel } from 'src/app/core/helpers/observable-helper';
+import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-update-delete-registration/add-updade-delete-registration.service';
 import { DraftToRegistrationService } from 'src/app/core/services/draft/draft-to-registration.service';
 import { ObservationService } from 'src/app/core/services/observation/observation.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
@@ -48,7 +49,8 @@ export class SentListComponent implements OnInit, OnDestroy {
     private regobsAuthService: RegobsAuthService,
     private changeDetectorRef: ChangeDetectorRef,
     private loggingService: LoggingService,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    addUpdateDeleteRegistrationService: AddUpdateDeleteRegistrationService
   ) {
     this.myObservationsUrl$ = this.createMyObservationsUrl$();
 
@@ -64,6 +66,18 @@ export class SentListComponent implements OnInit, OnDestroy {
         ];
 
         this.isEmpty.next(false);
+        this.changeDetectorRef.detectChanges();
+      });
+
+    //remove deleted registrations from the list when we get notified
+    addUpdateDeleteRegistrationService.deletedRegistrationIds$
+      .pipe(takeUntil(this.ngDestroy$))
+      .subscribe((deletedRegId) => {
+        const regsWithoutDeletedRegistration = this.loadedRegistrations
+          .filter(reg => reg.RegId !== deletedRegId);
+
+        this.loadedRegistrations = regsWithoutDeletedRegistration;
+        this.isEmpty.emit(this.loadedRegistrations.length === 0);
         this.changeDetectorRef.detectChanges();
       });
   }

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -3,8 +3,7 @@ import { IonInfiniteScroll } from '@ionic/angular';
 import { combineLatest, Observable, of, Subject } from 'rxjs';
 import { distinctUntilChanged, finalize, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { enterZone, toPromiseWithCancel } from 'src/app/core/helpers/observable-helper';
-import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-update-delete-registration/add-updade-delete-registration.service';
-import { DraftToRegistrationService } from 'src/app/core/services/draft/draft-to-registration.service';
+import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-update-delete-registration/add-update-delete-registration.service';
 import { ObservationService } from 'src/app/core/services/observation/observation.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
@@ -12,6 +11,7 @@ import { RegistrationViewModel } from 'src/app/modules/common-regobs-api/models'
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { settings } from 'src/settings';
 
+const DEBUG_TAG = 'SentListComponent';
 const PAGE_SIZE = 10;
 const MAX_REGISTRATIONS_COUNT = 100;
 
@@ -43,18 +43,17 @@ export class SentListComponent implements OnInit, OnDestroy {
   private ngDestroy$ = new Subject<void>();
 
   constructor(
-    draftToRegService: DraftToRegistrationService,
+    addUpdateDeleteRegistrationService: AddUpdateDeleteRegistrationService,
     private observationService: ObservationService,
     private userSettingService: UserSettingService,
     private regobsAuthService: RegobsAuthService,
     private changeDetectorRef: ChangeDetectorRef,
     private loggingService: LoggingService,
     private ngZone: NgZone,
-    addUpdateDeleteRegistrationService: AddUpdateDeleteRegistrationService
   ) {
     this.myObservationsUrl$ = this.createMyObservationsUrl$();
 
-    draftToRegService.newRegistrations$
+    addUpdateDeleteRegistrationService.changedRegistrations$
       .pipe(takeUntil(this.ngDestroy$))
       .subscribe((newRegistration) => {
         const regsWithoutNewRegistration = this.loadedRegistrations
@@ -111,7 +110,7 @@ export class SentListComponent implements OnInit, OnDestroy {
       ]);
       this.isEmpty.emit(this.loadedRegistrations.length === 0);
     } catch (error) {
-      this.loggingService.debug('Could not load my registrations', 'SentListComponent.initRegistrationSubscription()', error);
+      this.loggingService.debug('Could not load my registrations', DEBUG_TAG, error);
     } finally {
       this.loaded = true;
       this.changeDetectorRef.detectChanges();

--- a/src/app/pages/my-observations/my-observations.page.ts
+++ b/src/app/pages/my-observations/my-observations.page.ts
@@ -20,6 +20,7 @@ export class MyObservationsPage {
 
   ionViewDidEnter() {
     this.content.scrollToTop();
+    this.refresh();
   }
 
   async refresh(cancelPromise?: Promise<void>): Promise<void> {

--- a/src/app/pages/view-observation/view-observation.page.ts
+++ b/src/app/pages/view-observation/view-observation.page.ts
@@ -33,7 +33,7 @@ export class ViewObservationPage extends NgDestoryBase implements OnInit {
     const id = parseInt(this.activatedRoute.snapshot.params['id'], 10);
     this.registrationViewModel$ = this.userSettingService.userSetting$.pipe(
       switchMap((userSetting) =>
-        from(this.observationService.getObservationById(id, userSetting.appMode, userSetting.language)))
+        from(this.observationService.getObservationById(id, userSetting.appMode)))
     );
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -292,9 +292,25 @@
       "RIGHT_HERE": "Right here",
       "TITLE": "Danger Sign"
     },
-    "DELETE": "Delete observation",
-    "DELETE_CONFIRM": "Are you sure?",
-    "DIRT": {
+    "DELETE": {
+      "BUTTON": "Delete observation",
+      "DRAFT": {
+        "BUTTON": "Delete draft",
+        "HEADER": "Delete draft",
+        "MESSAGE_NEW": "This observation is not sent to Regobs yet. Do you want to delete it?",
+        "MESSAGE_EDIT": "Discard changes?"
+      },
+      "REGOBS": {
+        "BUTTON": "Delete observation from Regobs",
+        "HEADER": "Delete observation",
+        "MESSAGE": "Do you want to delete this observation from Regobs?",
+        "FAILED": {
+          "HEADER": "Delete failed",
+          "MESSAGE": "We were not able to delete the observation from Regobs. Please check your network connection and try again."
+        }
+      }
+    },
+     "DIRT": {
       "LAND_SLIDE_OBS": {
         "AVAL_TRIGGER": "Landslide trigger",
         "DAMAGE_EXTENT": "Damage extent",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -293,14 +293,13 @@
       "TITLE": "Danger Sign"
     },
     "DELETE": {
-      "BUTTON": "Delete observation",
       "DRAFT": {
         "BUTTON": "Delete draft",
         "HEADER": "Delete draft",
         "MESSAGE_NEW": "This observation is not sent to Regobs yet. Do you want to delete it?",
         "MESSAGE_EDIT": "Discard changes?"
       },
-      "REGOBS": {
+      "SUBMITTED_REGISTRATION": {
         "BUTTON": "Delete observation from Regobs",
         "HEADER": "Delete observation",
         "MESSAGE": "Do you want to delete this observation from Regobs?",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -292,8 +292,24 @@
       "RIGHT_HERE": "Akkurat her",
       "TITLE": "Faretegn"
     },
-    "DELETE": "Slett observasjon",
-    "DELETE_CONFIRM": "Er du sikker?",
+    "DELETE": {
+      "BUTTON": "Slett observasjon",
+      "DRAFT": {
+        "BUTTON": "Slett kladd",
+        "HEADER": "Slett kladd",
+        "MESSAGE_NEW": "Denne observasjonen er ikke sendt inn til Regobs. Vil du slette den?",
+        "MESSAGE_EDIT": "Vil du slette evt. endringer du har gjort på denne observasjonen?"
+      },
+      "REGOBS": {
+        "BUTTON": "Slett observasjon fra Regobs",
+        "HEADER": "Slett observasjon",
+        "MESSAGE": "Vil du slette denne observasjonen fra Regobs for godt?",
+        "FAILED": {
+          "HEADER": "Sletting feilet",
+          "MESSAGE": "Vi fikk ikke slettet observasjonen fra Regobs. Sjekk gjerne om du har nett og prøv igjen."
+        }
+      }
+    },
     "DIRT": {
       "LAND_SLIDE_OBS": {
         "AVAL_TRIGGER": "Skredutløser",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -293,14 +293,13 @@
       "TITLE": "Faretegn"
     },
     "DELETE": {
-      "BUTTON": "Slett observasjon",
       "DRAFT": {
         "BUTTON": "Slett kladd",
         "HEADER": "Slett kladd",
         "MESSAGE_NEW": "Denne observasjonen er ikke sendt inn til Regobs. Vil du slette den?",
         "MESSAGE_EDIT": "Vil du slette evt. endringer du har gjort på denne observasjonen?"
       },
-      "REGOBS": {
+      "SUBMITTED_REGISTRATION": {
         "BUTTON": "Slett observasjon fra Regobs",
         "HEADER": "Slett observasjon",
         "MESSAGE": "Vil du slette denne observasjonen fra Regobs for godt?",


### PR DESCRIPTION
Ny implementasjon av slettefunksjon.
Denne sletter observasjonen fra API'et med en gang om den får til.
Har også lagt til en egen knapp for å slette evt. lokale endringer på en observasjon som er sendt inn.
Se https://github.com/NVE/regObs4/pull/243 for forrige forsøk.