### PR TITLE
RO-1689: Save comments for new attachments

### DIFF
--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -24,7 +24,7 @@
     </ion-fab>
 
     <app-text-comment
-      [value]="getNewAttachmentComment(attachment)"
+      [value]="attachment.Comment"
       (valueChange)="setNewAttachmentComment(attachment, $event)"
       title="{{ pictureCommentText | translate}}"
       rows="2"

--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -22,9 +22,14 @@
         <ion-icon name="close"></ion-icon>
       </ion-fab-button>
     </ion-fab>
-    <!-- Har kommentert ut denne til vi finner en løsning på RO-1689 som ikke lugger-->
-    <!--app-text-comment [(value)]="attachment.Comment" title="{{ pictureCommentText | translate}}" rows="2"
-      placeholder="{{ pictureCommentPlaceholder | translate }}"></app-text-comment-->
+
+    <app-text-comment
+      [value]="getNewAttachmentComment(attachment)"
+      (valueChange)="setNewAttachmentComment(attachment, $event)"
+      title="{{ pictureCommentText | translate}}"
+      rows="2"
+      placeholder="{{ pictureCommentPlaceholder | translate }}"
+    ></app-text-comment>
   </div>
 
 </div>

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -10,8 +10,10 @@ import { File } from '@ionic-native/file/ngx';
 import { LoggingService } from '../../../shared/services/logging/logging.service';
 import { LogLevel } from '../../../shared/services/logging/log-level.model';
 import { GeoHazard } from 'src/app/modules/common-core/models';
-import { Observable } from 'rxjs';
+import { combineLatest, concatMap, filter, firstValueFrom, interval, Observable, skip, startWith, takeUntil } from 'rxjs';
 import { RemoteOrLocalAttachmentEditModel } from 'src/app/core/services/draft/draft-model';
+import { NavigationStart, Router } from '@angular/router';
+import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 
 const DEBUG_TAG = 'AddPictureItemComponent';
 const MIME_TYPE = 'image/jpeg';
@@ -22,7 +24,7 @@ const MIME_TYPE = 'image/jpeg';
   styleUrls: ['./edit-images.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EditImagesComponent implements OnInit {
+export class EditImagesComponent extends NgDestoryBase implements OnInit {
   @Input() draftUuid: string;
   @Input() existingAttachments: RemoteOrLocalAttachmentEditModel[];
   @Output() existingAttachmentsChange = new EventEmitter();
@@ -39,6 +41,11 @@ export class EditImagesComponent implements OnInit {
   @Input() ref?: string;
 
   newAttachments$: Observable<AttachmentUploadEditModelWithBlob[]>;
+  // On ios or android, metadata is saved to disk,
+  // but that lags when we save to disk too often, so keep a memory cache here.
+  // In the constructor there is a subscription that saves the cache to disk on an interval,
+  // or when we navigate away from this page.
+  newAttachmentMetadataCache = new Map<AttachmentUploadEditModel['id'], AttachmentUploadEditModel>();
 
   get filteredExistingImages(): RemoteOrLocalAttachmentEditModel[] {
     if (this.existingAttachments == null) {
@@ -57,13 +64,53 @@ export class EditImagesComponent implements OnInit {
     private toastController: ToastController,
     private actionSheetController: ActionSheetController,
     private newAttachmentService: NewAttachmentService,
-  ) {}
+    router: Router
+  ) {
+    super();
+
+    // Save new attachment metadata every 5 seconds, when we navigate away, or when this component is destroyed
+    combineLatest([
+      router.events.pipe(filter(e => e instanceof NavigationStart), startWith(null)),
+      interval(5000).pipe(startWith(null)),
+    ]).pipe(
+      skip(1),
+      // Use concatmap to avoid paralell saving to disk. We want the current save operation to complete before a new
+      // one starts. The save operation clears the cache, so if two save operations are initiated at the same time,
+      // the first one will save and the last one will do nothing.
+      concatMap(() => this.saveNewAttachmentMetadata()),
+      takeUntil(this.ngDestroy$),
+    ).subscribe();
+  }
 
   ngOnInit() {
     this.newAttachments$ = this.newAttachmentService.getAttachmentsWithBlob(
       this.draftUuid,
       { ref: this.ref, type: this.attachmentType, registrationTid: this.registrationTid }
     );
+  }
+
+  private async saveNewAttachmentMetadata() {
+    let i = 0;
+    for (const metadata of this.newAttachmentMetadataCache.values()) {
+      await firstValueFrom(this.newAttachmentService.saveAttachmentMeta$(this.draftUuid, metadata));
+      i += 1;
+    }
+
+    if (i > 0) {
+      this.logger.debug(`Saved metadata for ${i} attachments`, DEBUG_TAG);
+    }
+    this.newAttachmentMetadataCache.clear();
+  }
+
+  getNewAttachmentComment(attachment: AttachmentUploadEditModel): AttachmentUploadEditModel['Comment'] {
+    if (this.newAttachmentMetadataCache.has(attachment.id)) {
+      return this.newAttachmentMetadataCache.get(attachment.id).Comment;
+    }
+    return attachment.Comment;
+  }
+
+  setNewAttachmentComment(attachment: AttachmentUploadEditModel, comment: AttachmentUploadEditModel['Comment']) {
+    this.newAttachmentMetadataCache.set(attachment.id, { ...attachment, Comment: comment });
   }
 
   async addClick() {

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -68,7 +68,7 @@ export class EditImagesComponent extends NgDestoryBase implements OnInit {
   ) {
     super();
 
-    // Save new attachment metadata every 5 seconds, when we navigate away, or when this component is destroyed
+    // Save new attachment metadata every 5 seconds or when we navigate away
     combineLatest([
       router.events.pipe(filter(e => e instanceof NavigationStart), startWith(null)),
       interval(5000).pipe(startWith(null)),

--- a/src/app/modules/registration/components/text-comment/text-comment.component.html
+++ b/src/app/modules/registration/components/text-comment/text-comment.component.html
@@ -1,6 +1,23 @@
 <ion-item>
-  <ion-label color="medium" position="stacked" class="ion-text-uppercase">{{ title | translate }}</ion-label>
-  <ion-textarea autocapitalize="sentences" [maxlength]="max" [disabled]="disabled" type="textarea" (ionBlur)="onBlur()"
-    [rows]="rows" [(ngModel)]="value" [autoGrow]="true" (ngModelChange)="valueChange.emit($event)"
-    placeholder="{{ placeholder | translate}}"></ion-textarea>
+  
+  <ion-label 
+    color="medium"
+    position="stacked"
+    class="ion-text-uppercase"
+  >
+    {{ title | translate }}
+  </ion-label>
+
+  <ion-textarea
+    autocapitalize="sentences"
+    [maxlength]="max"
+    [disabled]="disabled"
+    type="textarea"
+    (ionBlur)="onBlur()"
+    [rows]="rows"
+    [(ngModel)]="value"
+    [autoGrow]="true"
+    placeholder="{{ placeholder | translate}}"
+  ></ion-textarea>
+
 </ion-item>


### PR DESCRIPTION
Forslag til hvordan vi kan lagre bildekommentarer.
Denne løsningen kan feile om denne funksjonen starter å kjøre (den blir kaldt i et intervall) men ikke fullfører før man fortsetter å oppdaterer kommentaren, siden den sletter cachen til slutt:

https://github.com/NVE/regObs4/blob/67bc72682d5b2b01764610a4097eb7aeb93c725d/src/app/modules/registration/components/edit-images/edit-images.component.ts#L92-L103

Kun testet for bilder på faretegn, ikke testet feks for vannstandsmålinger.

Edit: Laget et nytt forslag som baserer seg på at vi endrer til å bare emite endringer fra app-text-comment på blur.