### PR TITLE
Use timeout for fetch data request + clean code

### DIFF
--- a/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
+++ b/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
@@ -38,7 +38,7 @@ export abstract class ApiSyncOfflineBaseService<T> {
   constructor(
     protected offlineDbService: OfflineDbService,
     protected logger: LoggingService,
-    protected userSettingService: UserSettingService,
+    protected userSettingService: UserSettingService
   ) {
     this.data$ = this.getDataObservable().pipe(shareReplay(1));
   }

--- a/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
+++ b/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
@@ -18,10 +18,6 @@ export interface ApiSyncOfflineBaseServiceOptions {
   offlineTableKey?: string | number;
 }
 
-// As we can use cached data anyway, use a short timeout here to avoid blank screen issues if fetching new data takes
-// a long time
-const FETCH_NEW_DATA_TIMEOUT = 2000;
-
 @Injectable()
 export abstract class ApiSyncOfflineBaseService<T> {
   public readonly data$: Observable<T>;
@@ -35,6 +31,10 @@ export abstract class ApiSyncOfflineBaseService<T> {
     validSeconds: getCacheAge(),
     useLangKeyAsDbKey: true
   }
+
+  // As we can use cached data anyway, use a short timeout here to avoid blank screen issues if fetching new data takes
+  // a long time
+  protected FETCH_NEW_DATA_TIMEOUT = 2000;
 
   constructor(
     protected offlineDbService: OfflineDbService,
@@ -132,7 +132,7 @@ export abstract class ApiSyncOfflineBaseService<T> {
    */
   private getUpdatedDataAndSaveResultIfSuccess(appMode: AppMode, langKey: LangKey) {
     return this.getUpdatedData(appMode, langKey).pipe(
-      timeout(FETCH_NEW_DATA_TIMEOUT),
+      timeout(this.FETCH_NEW_DATA_TIMEOUT),
       switchMap((data) =>
         this.saveDataToOfflineDb(appMode, langKey, data).pipe(
           catchError((err) => {

--- a/src/app/modules/common-registration/services/cache-age.ts
+++ b/src/app/modules/common-registration/services/cache-age.ts
@@ -1,0 +1,12 @@
+import { Capacitor } from '@capacitor/core';
+
+const CACHE_AGE_WEB    = 43200;   // 12 hours
+const CACHE_AGE_NATIVE = 604800;  // 1 week
+
+export const getCacheAge = () => {
+  if (Capacitor.isNativePlatform()) {
+    return CACHE_AGE_NATIVE;
+  } else {
+    return CACHE_AGE_WEB;
+  }
+};

--- a/src/app/modules/common-registration/services/help-text/help-text.service.ts
+++ b/src/app/modules/common-registration/services/help-text/help-text.service.ts
@@ -11,7 +11,6 @@ import { getLangKeyString } from 'src/app/modules/common-core/helpers';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 
-const CACHE_AGE = 43200; // 12 hours
 const HELP_TEXTS_ASSETS_FOLDER = '/assets/json';
 
 @Injectable({
@@ -26,10 +25,6 @@ export class HelpTextService extends ApiSyncOfflineBaseService<HelptextDto[]> {
     protected userSettingService: UserSettingService
   ) {
     super(
-      {
-        useLangKeyAsDbKey: true,
-        validSeconds: CACHE_AGE
-      },
       offlineDbService,
       logger,
       userSettingService

--- a/src/app/modules/common-registration/services/kdv/kdv.service.ts
+++ b/src/app/modules/common-registration/services/kdv/kdv.service.ts
@@ -29,8 +29,7 @@ export class KdvService extends ApiSyncOfflineBaseService<KdvElementsResponseDto
     super(
       offlineDbService,
       logger,
-      userSettingService
-    );
+      userSettingService);
   }
 
   protected getDebugTag(): string {

--- a/src/app/modules/common-registration/services/kdv/kdv.service.ts
+++ b/src/app/modules/common-registration/services/kdv/kdv.service.ts
@@ -14,7 +14,6 @@ import { LoggingService } from 'src/app/modules/shared/services/logging/logging.
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 
 const KDV_ASSETS_FOLDER = '/assets/json';
-const CACHE_AGE = 43200; // 12 hours
 
 @Injectable({
   providedIn: 'root'
@@ -28,13 +27,10 @@ export class KdvService extends ApiSyncOfflineBaseService<KdvElementsResponseDto
     protected userSettingService: UserSettingService
   ) {
     super(
-      {
-        useLangKeyAsDbKey: true,
-        validSeconds: CACHE_AGE
-      },
       offlineDbService,
       logger,
-      userSettingService);
+      userSettingService
+    );
   }
 
   protected getDebugTag(): string {


### PR DESCRIPTION
Nå timer requesten ut etter 2 sekunder, deretter brukes cachet data på telefonen.

I tillegg varer nå cachen i 1 uke (fra 12 timer tidligere) på telefon og 12 timer i nettleser (som tidligere).

Denne oppgaven er litt vanskelig å teste siden det er flere ulike sjekker og avhengigheter som påvirker hvilke data som brukes, men hvis man er på NVEs nett kan man i alle fall teste at det uansett skal dukke opp noe etter 2 sekunder. Har man en fresh installasjon av appen skal den uansett prøve å hente data fra apiet.