### PR TITLE
RO-1693: Håndter at registrering (i Regobs) er slettet i appen

### DIFF
--- a/src/app/components/observation/observation-list-card/observation-list-card.component.ts
+++ b/src/app/components/observation/observation-list-card/observation-list-card.component.ts
@@ -272,11 +272,11 @@ export class ObservationListCardComponent implements OnChanges {
       catchError(error => {
         let msg: string;
         if (error instanceof TimeoutError) {
-          msg = `Failed to fetch obs before edit after ${FETCH_OBS_TIMEOUT_MS}ms, using cached obs`;
+          msg = `Failed to fetch obs before edit after ${FETCH_OBS_TIMEOUT_MS}ms`;
         } else if (error instanceof HttpErrorResponse && error.status === 410) {
           msg = 'Obs was deleted from Regobs';
         } else {
-          msg = 'An unknown error occured while fetching obs before edit, using cached obs';
+          msg = 'An unknown error occured while fetching obs before edit';
         }
         this.logger.error(error, DEBUG_TAG, msg);
         return of(null);

--- a/src/app/core/services/draft/draft-model.ts
+++ b/src/app/core/services/draft/draft-model.ts
@@ -16,6 +16,7 @@ export declare const enum RegistrationDraftErrorCode {
   AttachmentError = 10,
   RegistrationError = 20,
   ConflictError = 25,
+  GoneError = 27,
   ServerError = 30,
   Unknown = 40,
 }

--- a/src/app/core/services/draft/draft-to-registration.service.ts
+++ b/src/app/core/services/draft/draft-to-registration.service.ts
@@ -201,6 +201,9 @@ function handleError(error: Error): {code: RegistrationDraftErrorCode; message: 
     } else if (error.status === HttpStatusCode.Conflict) {
       code = RegistrationDraftErrorCode.ConflictError;
       message = error.message || `Registration conflict ${error.status} - ${error.statusText}`;
+    } else if (error.status === HttpStatusCode.Gone) {
+      code = RegistrationDraftErrorCode.GoneError;
+      message = error.message || `Registration is deleted in Regobs ${error.status} - ${error.statusText}`;
     } else if (error.status > HttpStatusCode.BadRequest) {
       code = RegistrationDraftErrorCode.ServerError;
       message = error.message || `Response failed with ${error.status} - ${error.statusText}`;

--- a/src/app/core/services/observation/observation.service.ts
+++ b/src/app/core/services/observation/observation.service.ts
@@ -190,7 +190,7 @@ export class ObservationService {
     await this.updateCacheAndSave(newObservations, observation.GeoHazardTID);
   }
 
-  private async deleteFetchedObservation(regId: number) {
+  async deleteFetchedObservation(regId: number) {
     const cachedObservations = await firstValueFrom(this.observations$);
 
     const index = cachedObservations.findIndex(obs => obs.RegId === regId);

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.html
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.html
@@ -6,7 +6,7 @@
   </ion-list-header>
   <app-version-conflict *ngIf="conflictError" [draft]="draft"></app-version-conflict>
   <app-gone-registration *ngIf="goneError" [draft]="draft"></app-gone-registration>
-  <ng-container *ngIf="!conflictError">
+  <ng-container *ngIf="!(conflictError || goneError)">
     <ion-item>
       <ion-label class="ion-text-wrap" *ngIf="networkError">
         {{'REGISTRATION.FAILED.SUBTITLE' | translate}}

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.html
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.html
@@ -5,6 +5,7 @@
     </ion-label>
   </ion-list-header>
   <app-version-conflict *ngIf="conflictError" [draft]="draft"></app-version-conflict>
+  <app-gone-registration *ngIf="goneError" [draft]="draft"></app-gone-registration>
   <ng-container *ngIf="!conflictError">
     <ion-item>
       <ion-label class="ion-text-wrap" *ngIf="networkError">

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.ts
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.ts
@@ -35,6 +35,10 @@ export class FailedRegistrationComponent {
     return this.draft.error.code === RegistrationDraftErrorCode.ConflictError;
   }
 
+  get goneError() {
+    return this.draft.error.code === RegistrationDraftErrorCode.GoneError;
+  }
+
   get registrationError() {
     return this.draft.error.code === RegistrationDraftErrorCode.RegistrationError;
   }
@@ -42,7 +46,6 @@ export class FailedRegistrationComponent {
   get unknownError() {
     return (
       this.draft.error.code === RegistrationDraftErrorCode.AttachmentError ||
-      this.draft.error.code === RegistrationDraftErrorCode.ConflictError ||
       this.draft.error.code === RegistrationDraftErrorCode.Unknown
     );
   }

--- a/src/app/modules/registration/components/gone-registration/gone-registration.component.html
+++ b/src/app/modules/registration/components/gone-registration/gone-registration.component.html
@@ -1,0 +1,17 @@
+<ion-list lines="full">
+  <ion-item>
+    <ion-label class="ion-text-wrap" [innerHTML]="'REGISTRATION.FAILED.GONE' | translate"></ion-label>
+  </ion-item>
+  <ion-item (click)="abandon()">
+    <ion-icon slot="start" name="refresh"></ion-icon>
+    <ion-label class="ion-text-wrap">
+      {{'REGISTRATION.FAILED.ABANDON' | translate}}
+    </ion-label>
+  </ion-item>
+  <ion-item (click)="submitAsNew()">
+    <ion-icon slot="start" name="warning"></ion-icon>
+    <ion-label class="ion-text-wrap">
+      {{'REGISTRATION.FAILED.SUBMIT_NEW' | translate}}
+    </ion-label>
+  </ion-item>
+</ion-list>

--- a/src/app/modules/registration/components/gone-registration/gone-registration.component.ts
+++ b/src/app/modules/registration/components/gone-registration/gone-registration.component.ts
@@ -1,0 +1,47 @@
+import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+import { NavController } from '@ionic/angular';
+import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
+import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
+import { DraftToRegistrationService } from 'src/app/core/services/draft/draft-to-registration.service';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+
+const DEBUG_TAG = 'VersionConflictComponent';
+
+/**
+ * Visible on the overview page for a draft if you got a version conflict when you submitted the draft.
+ * Shows the error message and let you overwrite the remote version or abandon your changes
+ */
+@Component({
+  selector: 'app-gone-registration',
+  templateUrl: './gone-registration.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class GoneRegistrationComponent {
+
+  @Input() draft: RegistrationDraft;
+
+  constructor(
+    private draftToRegistrationService: DraftToRegistrationService,
+    private draftRepository: DraftRepositoryService,
+    private logger: LoggingService,
+    private navController: NavController)
+  {}
+
+  submitAsNew(): void {
+    // //TODO:
+    // const oldUuid = this.draft.uuid;
+    // this.logger.debug(`Saving draft with uuid ${this.draft.uuid} as new observation `, DEBUG_TAG);
+    // this.draftToRegistrationService.markDraftAsReadyToSubmit(this.draft, true);
+    this.navigateToMyObservations(); //so we can see that the draft happily submits
+  }
+
+  abandon(): void {
+    this.logger.debug(`Draft ${this.draft.uuid} abandoned`, DEBUG_TAG);
+    this.draftRepository.delete(this.draft.uuid);
+    this.navigateToMyObservations(); //so we can find the new version
+  }
+
+  navigateToMyObservations(): void {
+    this.navController.navigateRoot('my-observations');
+  }
+}

--- a/src/app/modules/registration/components/gone-registration/gone-registration.component.ts
+++ b/src/app/modules/registration/components/gone-registration/gone-registration.component.ts
@@ -3,13 +3,15 @@ import { NavController } from '@ionic/angular';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
 import { DraftToRegistrationService } from 'src/app/core/services/draft/draft-to-registration.service';
+import { ObservationService } from 'src/app/core/services/observation/observation.service';
+import { uuidv4 } from 'src/app/modules/common-core/helpers';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 
 const DEBUG_TAG = 'VersionConflictComponent';
 
 /**
- * Visible on the overview page for a draft if you got a version conflict when you submitted the draft.
- * Shows the error message and let you overwrite the remote version or abandon your changes
+ * Visible on the overview page for a draft if you got a HTTP Gone when you submitted the draft.
+ * Shows the error message and let you submit a new draft based on the deleted registration or abandon your changes
  */
 @Component({
   selector: 'app-gone-registration',
@@ -23,22 +25,32 @@ export class GoneRegistrationComponent {
   constructor(
     private draftToRegistrationService: DraftToRegistrationService,
     private draftRepository: DraftRepositoryService,
+    private observationService: ObservationService,
     private logger: LoggingService,
     private navController: NavController)
   {}
 
-  submitAsNew(): void {
-    // //TODO:
-    // const oldUuid = this.draft.uuid;
-    // this.logger.debug(`Saving draft with uuid ${this.draft.uuid} as new observation `, DEBUG_TAG);
-    // this.draftToRegistrationService.markDraftAsReadyToSubmit(this.draft, true);
+  async submitAsNew(): Promise<void> {
+    const uuid = uuidv4();
+    await this.draftRepository.copyDraftAndSave(this.draft, uuid);
+    const newDraft = await this.draftRepository.load(uuid);
+    this.logger.debug(
+      `Submitting new draft with uuid ${newDraft.uuid} based on deleted registration with regId ${this.draft.regId}`,
+      DEBUG_TAG);
+    this.draftToRegistrationService.markDraftAsReadyToSubmit(newDraft, false);
+    this.delete();
     this.navigateToMyObservations(); //so we can see that the draft happily submits
   }
 
   abandon(): void {
     this.logger.debug(`Draft ${this.draft.uuid} abandoned`, DEBUG_TAG);
-    this.draftRepository.delete(this.draft.uuid);
-    this.navigateToMyObservations(); //so we can find the new version
+    this.delete();
+    this.navigateToMyObservations(); //so we can see that the observation is gone
+  }
+
+  private delete(): void {
+    this.draftRepository.delete(this.draft.uuid); //delete draft that was deleted in Regobs
+    this.observationService.deleteFetchedObservation(this.draft.regId); //delete observation from map and list view
   }
 
   navigateToMyObservations(): void {

--- a/src/app/modules/registration/pages/overview/overview.module.ts
+++ b/src/app/modules/registration/pages/overview/overview.module.ts
@@ -7,6 +7,7 @@ import { SharedComponentsModule } from '../../shared-components.module';
 import { FailedRegistrationComponent } from '../../components/failed-registration/failed-registration.component';
 import { SaveAsDraftRouteGuard } from '../save-as-draft.guard';
 import { VersionConflictComponent } from '../../components/version-conflict/version-conflict.component';
+import { GoneRegistrationComponent } from '../../components/gone-registration/gone-registration.component';
 
 const routes: Routes = [
   {
@@ -23,7 +24,8 @@ const routes: Routes = [
     SendButtonComponent,
     SummaryItemComponent,
     FailedRegistrationComponent,
-    VersionConflictComponent
+    VersionConflictComponent,
+    GoneRegistrationComponent
   ]
 })
 export class OverviewPageModule {}

--- a/src/app/modules/registration/pages/overview/overview.page.html
+++ b/src/app/modules/registration/pages/overview/overview.page.html
@@ -25,5 +25,5 @@
       ></app-summary-item>
     </ion-list>
   </ion-content>
-  <app-send-button [draft]="draft"></app-send-button>
+  <app-send-button *ngIf="!hideSendButton(draft)" [draft]="draft"></app-send-button>
 </ng-container>

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -5,7 +5,7 @@ import { UserGroupService } from '../../../../core/services/user-group/user-grou
 import { ISummaryItem } from '../../components/summary-item/summary-item.model';
 import { ActivatedRoute } from '@angular/router';
 import { SummaryItemService } from '../../services/summary-item.service';
-import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
+import { RegistrationDraft, RegistrationDraftErrorCode } from 'src/app/core/services/draft/draft-model';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
 
 @Component({
@@ -34,6 +34,12 @@ export class OverviewPage implements OnInit {
 
   draftHasStatusSync(draft: RegistrationDraft): boolean {
     return draft?.syncStatus === SyncStatus.Sync || draft?.syncStatus === SyncStatus.SyncAndIgnoreVersionCheck;
+  }
+
+  //If conflict or registration is gone, re-sumbit or cancelling is handled by the failed-registration-component
+  hideSendButton(draft: RegistrationDraft): boolean {
+    return this.draftHasStatusSync(draft)
+    && [RegistrationDraftErrorCode.ConflictError, RegistrationDraftErrorCode.GoneError].includes(draft?.error?.code);
   }
 
   trackByFunction(index: number, item: ISummaryItem) {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -345,7 +345,14 @@
       "TITLE": "Submission failed",
       "CONFLICT": "A new version was saved while you worked.<br/>Would you like to cancel your work and load the new version or submit your version and overwrite?",
       "ABANDON": "Cancel my work",
-      "OVERWRITE": "Submit and overwrite"
+      "OVERWRITE": "Submit and overwrite",
+      "GONE": "This observation is deleted in Regobs. <br/>Would you like to abandon your changes or submit the draft as a new observation?",
+      "SUBMIT_NEW": "Submit as new observation"
+    },
+    "FETCH_FOR_EDIT_FAILED": {
+      "HEADER": "Synchronization failed",
+      "MESSAGE": "We couldn't fetch a fresh copy of this observation from Regobs. You may still edit this, but there is a chance of conflict when you submit the observation later if the same observation has been changed elsewhere.",
+      "CONFIRM_BUTTON": "Edit observation"
     },
     "GENERAL_COMMENT": {
       "ADD_NOTES_HEADER": "Notes for observation",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -345,7 +345,9 @@
       "TITLE": "Innsending feilet",
       "CONFLICT": "Mens du jobbet har observasjonen blitt endret et annet sted.<br/>Vil du forkaste dine endringer eller vil du sende inn og overskrive endringene som ble gjort et annet sted?",
       "ABANDON": "Forkast mine endringer",
-      "OVERWRITE": "Send inn og overskriv"
+      "OVERWRITE": "Send inn og overskriv",
+      "GONE": "Denne observasjonen er slettet i Regobs. <br/>Vil du forkaste dine endringer eller vil du sende inn kladden som en ny observasjon?",
+      "SUBMIT_NEW": "Send inn som ny observasjon"
     },
     "GENERAL_COMMENT": {
       "ADD_NOTES_HEADER": "Notat fra observasjonen",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -349,6 +349,11 @@
       "GONE": "Denne observasjonen er slettet i Regobs. <br/>Vil du forkaste dine endringer eller vil du sende inn kladden som en ny observasjon?",
       "SUBMIT_NEW": "Send inn som ny observasjon"
     },
+    "FETCH_FOR_EDIT_FAILED": {
+      "HEADER": "Synkronisering feilet",
+      "MESSAGE": "Vi fikk ikke til å hente en fersk utgave av observasjonen fra Regobs. Du kan likevel redigere denne, men det er en sjanse for å støte på konflikter når du prøver å sende den inn hvis flere har jobbet med samme observasjon eller du har jobbet med observasjonen på flere enheter.",
+      "CONFIRM_BUTTON": "Rediger observasjon"
+    },
     "GENERAL_COMMENT": {
       "ADD_NOTES_HEADER": "Notat fra observasjonen",
       "ADD_PICTURE": "Legg til et bilde",


### PR DESCRIPTION
Når man sender inn en registrering som er slettet, får man mulighet til å sende kladden inn som en ny registrering.
Det ble klønete å tilby den samme funksjonaliteten når man starter å redigere en registrering, så der viser jeg heller en generell advarsel om at man kan komme i trøbbel seinere når man prøver å sende inn. Denne advarselen får man uansett hva som feiler når man prøver å hente en fersk utgave av registreringa fra server, så det er vel i tråd med hva vi snakket om da vi diskuterte dette tidligere.
Se Jira-saken for "definisjon av ferdig".