### PR TITLE
RO-1313: Forenklet koden i bildekarusellen, fjernet swiper-referansen

### DIFF
--- a/src/app/components/img-swiper/img-swiper.component.html
+++ b/src/app/components/img-swiper/img-swiper.component.html
@@ -6,7 +6,7 @@
     [pager]="true"
     [ngClass]="{'loaded': isSwiperLoaded}"
     (ionSlideTransitionEnd)="onSlideTransitionEnd()"
-    (ionSlidesDidLoad)="slidesLoaded($event)"
+    (ionSlidesDidLoad)="slidesLoaded()"
     (ionSlideTouchStart)="onSlideTouchStart()"
   >
     <ion-slide
@@ -42,12 +42,12 @@
   [attachment]="attachments[0]" preferSize="Large"></app-remote-image>
   <app-map-image *ngIf="isSingleMap" class="single" [location]="location" (click)="onLocationClick()">
   </app-map-image>
-    <ion-label *ngIf="showLabel && !isDesktop" [ngClass]="{'loaded': isLoaded}">
-      <span class="img-comment-header" *ngIf="showIndex">{{imageIndex + 1}}/{{imageLength}}&nbsp;</span>
-      <span [ngClass]="{'img-comment-header': slides[activeIndex].description }"
-        *ngIf="slides[activeIndex].header">{{ slides[activeIndex].header | translate }}<ng-container
-          *ngIf="slides[activeIndex].description">:&nbsp;
-        </ng-container></span>
-      <ng-container *ngIf="slides[activeIndex].description">{{ slides[activeIndex].description }}</ng-container>
-    </ion-label>
+  <ion-label *ngIf="showLabel && !isDesktop" [ngClass]="{'loaded': isLoaded}">
+    <span class="img-comment-header" *ngIf="showIndex">{{imageIndex + 1}}/{{imageLength}}&nbsp;</span>
+    <span [ngClass]="{'img-comment-header': slides[activeIndex].description }"
+      *ngIf="slides[activeIndex].header">{{ slides[activeIndex].header | translate }}<ng-container
+        *ngIf="slides[activeIndex].description">:&nbsp;
+      </ng-container></span>
+    <ng-container *ngIf="slides[activeIndex].description">{{ slides[activeIndex].description }}</ng-container>
+  </ion-label>
 </div>

--- a/src/app/components/img-swiper/img-swiper.component.ts
+++ b/src/app/components/img-swiper/img-swiper.component.ts
@@ -5,15 +5,13 @@ import {
   Output,
   ViewChild,
   OnChanges,
-  SimpleChanges,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   OnDestroy
 } from '@angular/core';
 import { IonSlides } from '@ionic/angular';
 import { ImgSwiperSlide } from './img-swiper-slide';
-import { Subject, interval, race } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 import { ImageLocation } from './image-location.model';
 import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
 import { BreakpointService } from '../../core/services/breakpoint.service';
@@ -60,7 +58,6 @@ export class ImgSwiperComponent implements OnChanges, OnDestroy {
 
   moreThanFourPics = false;
 
-  swiper: any;
   state:
     | 'loading'
     | 'empty'
@@ -161,27 +158,13 @@ export class ImgSwiperComponent implements OnChanges, OnDestroy {
     return 1;
   }
 
-  slidesLoaded(el: any) {
-    this.swiper = el.target.swiper;
-    // TODO: Dette (tror jeg) fører til at img-swiperen ikke fungerer
-    // if (this.shouldMoveMap) {
-    //   this.activeIndex = 1;
-    //   interval(100)
-    //     .pipe(takeUntil(race(this.ngDestroy$, this.touchStart$)))
-    //     .subscribe(() => {
-    //       this.moveMapInSwiperToLeftOutsideView();
-    //     });
-    // }
+  slidesLoaded() {
     this.state = 'swiper-ready';
     this.updateUi();
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges() {
     this.state = 'loading';
-    if (this.swiper) {
-      this.swiper.destroy();
-      this.swiper = undefined;
-    }
     this.updateUi();
     setTimeout(() => this.init(), 0);
   }
@@ -238,12 +221,6 @@ export class ImgSwiperComponent implements OnChanges, OnDestroy {
       header: this.attachments[index].RegistrationName,
       description: this.attachments[index].Comment
     }));
-  }
-
-  private moveMapInSwiperToLeftOutsideView() {
-    if (this.swiper && this.swiper.$wrapperEl && this.swiper.$wrapperEl[0]) {
-      this.swiper.$wrapperEl[0].style.transform = 'translate3d(-60%, 0px, 0px)';
-    }
   }
 
   getImageIndex(img: AttachmentViewModel) {

--- a/src/app/components/map-item-bar/map-item-bar.component.ts
+++ b/src/app/components/map-item-bar/map-item-bar.component.ts
@@ -18,6 +18,11 @@ import { getAllAttachmentsFromViewModel } from 'src/app/modules/common-registrat
   templateUrl: './map-item-bar.component.html',
   styleUrls: ['./map-item-bar.component.scss']
 })
+/**
+ * Show key info from selected registration on top of the map.
+ * To show this, klick on a registrations icon in the map.
+ * Also include an image slider if registration contain images.
+ */
 export class MapItemBarComponent implements OnInit, OnDestroy {
   visible: boolean;
   topHeader: string;


### PR DESCRIPTION
Fikset dette kulepunktet i RO-1313: Fjern enten swiper eller slider i img-swiper.component.ts, peker til det samme?

Testet på web og Android.