### PR TITLE
RO 1313-Fikset slik at menyen kan scrolles også i appen

### DIFF
--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -1,4 +1,4 @@
-<ion-list [ngClass]="{'scrollDesktop': !isIosOrAndroid, 'mobilePadding': isMobileWeb }" class="ion-no-margin">
+<ion-list class="ion-no-margin">
   <ion-list-header color="varsom-blue" class="ion-no-margin">
     <!-- TODO: Legge til Varsom Translations på all tekst -->
     <ion-label>

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
@@ -12,5 +12,8 @@
 
 ion-list {
   width: 100%;
+  padding-top: 0;
   padding-bottom: 0;
+  overflow: auto;
+  max-height: 100vh;
 }

--- a/src/app/modules/side-menu/components/side-menu.component.html
+++ b/src/app/modules/side-menu/components/side-menu.component.html
@@ -1,4 +1,4 @@
-<ion-list [ngClass]="{'scrollDesktop': !isIosOrAndroid, 'mobilePadding': isMobileWeb }" lines="full" class="ion-no-margin" *ngIf="userSettings">
+<ion-list lines="full" class="ion-no-margin" *ngIf="userSettings">
   <ion-list-header color="varsom-blue" class="ion-no-margin">
     <ion-label class="list-header-label">
       {{'MENU.USER_SETTINGS' | translate}}

--- a/src/app/modules/side-menu/components/side-menu.component.scss
+++ b/src/app/modules/side-menu/components/side-menu.component.scss
@@ -1,6 +1,9 @@
 ion-list {
-  padding-top: 0px;
-  padding-bottom: 0px;
+  width: 100%;
+  padding-top: 0;
+  padding-bottom: 0;
+  overflow: auto;
+  max-height: 100vh;
 
   ion-list-header {
     font-size: var(--h3-font-size);

--- a/src/global.scss
+++ b/src/global.scss
@@ -607,15 +607,6 @@ ion-select-popover ion-list ion-item ion-radio {
   --backdrop-opacity: var(--ion-backdrop-opacity, 0);
 }
 
-.scrollDesktop {
-  max-height: 100vh;
-  overflow: auto;
-}
-
-.mobilePadding {
-  padding-bottom: 8em;
-}
-
 .padding-medium {
   padding-left: 8px;
 }


### PR DESCRIPTION
overflow: auto var ikke aktivert for appen.
Har testet litt forskjellig oppsett, og det virker som vi kunne bruke samme css både på skrivebord, mobil web og app.
Så jeg tok vekk de spesielle globale klassene som var laget for sidemeny og filtermeny og kjører samme css overalt.