### PR TITLE
RO-1313: Skjuler uferdige filtre i app

### DIFF
--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -1,60 +1,61 @@
 <ion-list [ngClass]="{'scrollDesktop': !isIosOrAndroid, 'mobilePadding': isMobileWeb }" class="ion-no-margin">
   <ion-list-header color="varsom-blue" class="ion-no-margin">
-    <!-- TODO: Legge til Varsom Translations på all tekst -->
-    <ion-label>
-      Filtrering
-    </ion-label>
+    <ion-label>{{'OBSERVATION_FILTER.TITLE' | translate}}</ion-label>
   </ion-list-header>
   <app-observations-days-back></app-observations-days-back>
   <app-update-observations></app-update-observations>
-  <ion-list-header color="varsom-blue" class="ion-no-margin">
-    <ion-label>
-      Observasjonstype
-    </ion-label>
-  </ion-list-header>
-  <!-- TODO: Checkboxer må endre seg basert på hvilken naturfare som er valgt! Se på eksisterende funksjonalitet i side-menu.component -->
-  <ion-item>
-    <ion-checkbox checked="true" [(ngModel)]="masterCheck" [indeterminate]="isIndeterminate" (click)="checkMaster($event)" color="varsom-dark-blue" mode="md">
-    </ion-checkbox>
-    <ion-label class="ion-padding-start">Alle</ion-label>
-    <ion-button class="toggleAllTypesButton" (click)="toggleAllObservationTypes()" fill="clear">
-      <ion-icon [name]="showObservationTypes ? 'chevron-up-circle-outline' : 'chevron-down-circle-outline' "></ion-icon>
-    </ion-button>
-  </ion-item>
-    <ng-container *ngIf="this.showObservationTypes">
-      <ion-item>
-        <ion-list lines="none">
-          <!-- TODO: Hente ut riktige observasjonstyper i checkboxer -->
-          <ion-item *ngFor="let type of filteredObservationTypes">
-            <ion-checkbox [(ngModel)]="type.isChecked" (ionChange)="checkEvent()" color="varsom-dark-blue" mode="md"></ion-checkbox>
-            <ion-label class="ion-padding-start">{{type.value}}</ion-label>
-          </ion-item>
-        </ion-list>
-      </ion-item>
-    </ng-container>
+  <div *ngIf="!isIosOrAndroid">
+    <!-- Dette er på prototypestadiet, så vi skjuler dette i appen foreløpig -->
+    <!-- TODO: Oversettelser på all tekst -->
+    <ion-list-header color="varsom-blue" class="ion-no-margin">
+      <ion-label>
+        Observasjonstype
+      </ion-label>
+    </ion-list-header>
+    <!-- TODO: Checkboxer må endre seg basert på hvilken naturfare som er valgt! Se på eksisterende funksjonalitet i side-menu.component -->
+    <ion-item>
+      <ion-checkbox checked="true" [(ngModel)]="masterCheck" [indeterminate]="isIndeterminate" (click)="checkMaster($event)" color="varsom-dark-blue" mode="md">
+      </ion-checkbox>
+      <ion-label class="ion-padding-start">Alle</ion-label>
+      <ion-button class="toggleAllTypesButton" (click)="toggleAllObservationTypes()" fill="clear">
+        <ion-icon [name]="showObservationTypes ? 'chevron-up-circle-outline' : 'chevron-down-circle-outline' "></ion-icon>
+      </ion-button>
+    </ion-item>
+      <ng-container *ngIf="this.showObservationTypes">
+        <ion-item>
+          <ion-list lines="none">
+            <!-- TODO: Hente ut riktige observasjonstyper i checkboxer -->
+            <ion-item *ngFor="let type of filteredObservationTypes">
+              <ion-checkbox [(ngModel)]="type.isChecked" (ionChange)="checkEvent()" color="varsom-dark-blue" mode="md"></ion-checkbox>
+              <ion-label class="ion-padding-start">{{type.value}}</ion-label>
+            </ion-item>
+          </ion-list>
+        </ion-item>
+      </ng-container>
 
-  <ion-list-header color="varsom-blue" class="ion-no-margin">
-    <ion-label>
-      Observatør
-    </ion-label>
-  </ion-list-header>
-  <!-- TODO: Legg til eller hente kompetanser i menyen. Husk at på snø er det en spesiell kompetanse A -->
-  <ion-item>
-    <ion-label class="no-margin-bottom" color="dark" position="stacked">Kompetanse</ion-label>
-    <ion-select placeholder="Alle kompetansenivå" [interface]="popupType">
-      <ion-select-option>
-      </ion-select-option>
-    </ion-select>
-  </ion-item>
-  <!-- TODO: Finne ut hvordan vi implementerer navnesøk - aynskront eller med søkeknapp? -->
-  <ion-item>
-    <ion-label class="no-margin-bottom" color="dark" position="stacked">Søk</ion-label>
-    <ion-searchbar mode="ios" class="ion-no-padding" placeholder="Søk på observatørnavn"></ion-searchbar>
-  </ion-item>
+    <ion-list-header color="varsom-blue" class="ion-no-margin">
+      <ion-label>
+        Observatør
+      </ion-label>
+    </ion-list-header>
+    <!-- TODO: Legg til eller hente kompetanser i menyen. Husk at på snø er det en spesiell kompetanse A -->
+    <ion-item>
+      <ion-label class="no-margin-bottom" color="dark" position="stacked">Kompetanse</ion-label>
+      <ion-select placeholder="Alle kompetansenivå" [interface]="popupType">
+        <ion-select-option>
+        </ion-select-option>
+      </ion-select>
+    </ion-item>
+    <!-- TODO: Finne ut hvordan vi implementerer navnesøk - aynskront eller med søkeknapp? -->
+    <ion-item>
+      <ion-label class="no-margin-bottom" color="dark" position="stacked">Søk</ion-label>
+      <ion-searchbar mode="ios" class="ion-no-padding" placeholder="Søk på observatørnavn"></ion-searchbar>
+    </ion-item>
 
-  <!-- TODO: Implementere reset filter funksjonalitet -->
-  <ion-item>
-    <ion-button class="resetFiltersButton" type="button" fill="clear"><ion-icon src="./assets/icon/reset-button.svg">
-      </ion-icon>Tilbakestill filtere</ion-button>
-</ion-item>
+    <!-- TODO: Implementere reset filter funksjonalitet -->
+    <ion-item>
+      <ion-button class="resetFiltersButton" type="button" fill="clear"><ion-icon src="./assets/icon/reset-button.svg">
+        </ion-icon>Tilbakestill filtere</ion-button>
+    </ion-item>
+  </div>
 </ion-list>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -207,6 +207,9 @@
     "TITLE": "My profile",
     "USER": "User"
   },
+  "OBSERVATION_FILTER": {
+    "TITLE": "Observation filter"
+  },
   "OBSERVATION_LIST": {
     "ALL_OBSERVATIONS": "All observations",
     "FORMS": "Forms",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -207,6 +207,9 @@
     "TITLE": "Min side",
     "USER": "Bruker"
   },
+  "OBSERVATION_FILTER": {
+    "TITLE": "Observasjonsfilter"
+  },
   "OBSERVATION_LIST": {
     "ALL_OBSERVATIONS": "Alle observasjoner",
     "FORMS": "Skjemaer",


### PR DESCRIPTION
På mobil skjuler vi nå den delen av filtermenyen som ikke virker, slik at vi unngår å innføre nye feil i appen.
Så kan vi fikse dette når vi vil jobbe videre med filtrering.
Det ser kanskje litt rart ut med en meny som tar hele høyden, for meg kan vi gjerne begrense høyden. Men har ikke gjort noe med dette:
![image](https://user-images.githubusercontent.com/71138449/177321548-a2267732-1951-4f3c-a0c5-894985c007ae.png)
