### PR TITLE
RO-1784/1786/1780: La kladden huske om den ble laget med enkel visning

### DIFF
--- a/src/app/core/services/draft/draft-model.ts
+++ b/src/app/core/services/draft/draft-model.ts
@@ -67,4 +67,10 @@ export interface RegistrationDraft {
   readonly registration: RegistrationEditModelWithRemoteOrLocalAttachments;
 
   readonly error?: RegistrationDraftError;
+
+  /**
+   * @returns true if the draft was made in simple mode
+   * Simple mode means that the user have fewer choices.
+   */
+  readonly simpleMode?: boolean;
 }

--- a/src/app/core/services/draft/draft-model.ts
+++ b/src/app/core/services/draft/draft-model.ts
@@ -72,5 +72,5 @@ export interface RegistrationDraft {
    * @returns true if the draft was made in simple mode
    * Simple mode means that the user have fewer choices.
    */
-  readonly simpleMode?: boolean;
+  readonly simpleMode: boolean;
 }

--- a/src/app/core/services/draft/draft-repository.service.spec.ts
+++ b/src/app/core/services/draft/draft-repository.service.spec.ts
@@ -72,11 +72,53 @@ describe('DraftRepositoryService', () => {
     const draft = await service.create(GeoHazard.Ice);
     expect(draft.uuid.length).toBeGreaterThan(0);
     expect(draft.syncStatus).toBe(SyncStatus.Draft);
+    expect(draft.simpleMode).toBe(false);
     expect(draft.registration.GeoHazardTID).toBe(GeoHazard.Ice);
     expect(draft.lastSavedTime).toBe(undefined); //not saved yet
     expect(draft.registration.DtObsTime).toBe(null);
     expect(draft.registration.ObsLocation).toEqual({ Latitude: 0, Longitude: 0 });
     expect(draft.registration.Attachments).toEqual([]);
+  });
+
+  it('create() should choose simple mode for snow registrations if simple mode setting is set', async () => {
+    const snowDraft = await service.create(GeoHazard.Snow);
+    expect(snowDraft.simpleMode).toBeTrue();
+
+    //verify that drafts for other geo hazards don't have simple mode
+    const iceDraft = await service.create(GeoHazard.Ice);
+    expect(iceDraft.simpleMode).toBeFalse();
+    const soilDraft = await service.create(GeoHazard.Soil);
+    expect(soilDraft.simpleMode).toBeFalse();
+    const waterDraft = await service.create(GeoHazard.Water);
+    expect(waterDraft.simpleMode).toBeFalse();
+
+    //deselect simple mode setting => snow drafts should now be created with complete mode, not simple
+    userSettingService.saveUserSettings({
+      ...await firstValueFrom(userSettingService.userSetting$),
+      appMode: AppMode.Test,
+      simpleSnowObservations: false
+    });
+    const completeSnowDraft = await service.create(GeoHazard.Snow);
+    expect(completeSnowDraft.simpleMode).toBeFalse();
+  });
+
+  it('load() should be backward compatible with database model before simpleMode was added', async () => {
+    const uuid = 'DRAFT_WITHOUT_SIMPLE_MODE';
+    const oldDraftRecord = {
+      UUID: uuid,
+      syncStatus: SyncStatus.Draft,
+      lastSavedTime: new Date().getMilliseconds(),
+      registration: {
+        GeoHazardTID: GeoHazard.Snow,
+        DtObsTime: null,
+        ObsLocation: { Latitude: 0, Longitude: 0 },
+        Attachments: []
+      }
+    };
+    database.set(`drafts.TEST.${uuid}`, oldDraftRecord);
+
+    const loadedDraft = await service.load(uuid);
+    expect(loadedDraft.simpleMode).toBeUndefined();
   });
 
   it('save() should store a draft', async () => {
@@ -91,6 +133,7 @@ describe('DraftRepositoryService', () => {
     const savedDraft = await database.get(`drafts.TEST.${draft.uuid}`);
     expect(savedDraft.uuid).toEqual(draft.uuid);
     expect(savedDraft.syncStatus).toBe(SyncStatus.Draft);
+    expect(savedDraft.simpleMode).toBeTrue();
     expect(savedDraft.registration.GeoHazardTID).toBe(GeoHazard.Snow);
     expect(savedDraft.registration.DtObsTime).toBe('2022-02-13 08:00');
     expect(savedDraft.registration.ObsLocation).toEqual({ Latitude: 0, Longitude: 0 });

--- a/src/app/core/services/draft/draft-to-registration.service.spec.ts
+++ b/src/app/core/services/draft/draft-to-registration.service.spec.ts
@@ -21,6 +21,7 @@ describe('DraftToRegistrationService', () => {
   const draft: RegistrationDraft = {  // Default test draft
     uuid: 'abc',
     syncStatus: SyncStatus.Sync,
+    simpleMode: false,
     registration: {
       GeoHazardTID: 10,
       DtObsTime: 'Test'

--- a/src/app/core/services/upload-attachments/upload-attachments.service.spec.ts
+++ b/src/app/core/services/upload-attachments/upload-attachments.service.spec.ts
@@ -38,6 +38,7 @@ describe('UploadAttachmentsService', () => {
     const draft: RegistrationDraft = {
       uuid: '12345-abc',
       syncStatus: SyncStatus.Sync,
+      simpleMode: false,
       registration: {
         GeoHazardTID: 10,
         DtObsTime: 'test',
@@ -104,6 +105,7 @@ describe('UploadAttachmentsService', () => {
     const draft: RegistrationDraft = {
       uuid: '12345-abc',
       syncStatus: SyncStatus.Sync,
+      simpleMode: false,
       registration: {
         GeoHazardTID: 10,
         DtObsTime: 'test',
@@ -195,6 +197,7 @@ describe('UploadAttachmentsService', () => {
     const draft: RegistrationDraft = {
       uuid: regUuid,
       syncStatus: SyncStatus.Sync,
+      simpleMode: false,
       registration: {
         GeoHazardTID: 10,
         DtObsTime: 'test',

--- a/src/app/modules/common-registration/helpers/registration.helper.spec.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.spec.ts
@@ -10,6 +10,7 @@ import { removeEmptyRegistrations } from './registration.helper';
 const draft: RegistrationDraft = {
   uuid: 'abc',
   syncStatus: SyncStatus.Sync,
+  simpleMode: false,
   registration: {
     GeoHazardTID: GeoHazard.Snow,
     GeneralObservation: { ObsComment: 'comment' },
@@ -18,36 +19,36 @@ const draft: RegistrationDraft = {
 };
 
 const viewModel: RegistrationViewModel = {
-    GeoHazardTID: GeoHazard.Snow,
-    GeneralObservation: { ObsComment: 'comment' },
-    DtObsTime: 'test',
-    Attachments: [{
-        RegistrationTID: RegistrationTid.GeneralObservation,
-        UrlFormats: {"Medium": "common"}
-    }],
-    Summaries: [{
-        RegistrationTID: RegistrationTid.SnowProfile2,
-        AdaptiveElements: [{
-            type: "SnowProfilePlot",
-            pngUrl: "snow"
-        } as SnowProfileData]
-    }],
-    WaterLevel2: {
-        WaterLevelMeasurement: [{
-            DtMeasurementTime: new Date(1970).toISOString(),
-            Attachments: [{
-                RegistrationTID: RegistrationTid.WaterLevel2,
-                UrlFormats: {"Medium": "water"}
-            }]
-        }]
-    },
-    DamageObs: [{
-        DamageTypeTID: 1,
-        Attachments: [{
-            RegistrationTID: RegistrationTid.DamageObs,
-            UrlFormats: {"Medium": "damage"}
-        }]
+  GeoHazardTID: GeoHazard.Snow,
+  GeneralObservation: { ObsComment: 'comment' },
+  DtObsTime: 'test',
+  Attachments: [{
+    RegistrationTID: RegistrationTid.GeneralObservation,
+    UrlFormats: {'Medium': 'common'}
+  }],
+  Summaries: [{
+    RegistrationTID: RegistrationTid.SnowProfile2,
+    AdaptiveElements: [{
+      type: 'SnowProfilePlot',
+      pngUrl: 'snow'
+    } as SnowProfileData]
+  }],
+  WaterLevel2: {
+    WaterLevelMeasurement: [{
+      DtMeasurementTime: new Date(1970).toISOString(),
+      Attachments: [{
+        RegistrationTID: RegistrationTid.WaterLevel2,
+        UrlFormats: {'Medium': 'water'}
+      }]
     }]
+  },
+  DamageObs: [{
+    DamageTypeTID: 1,
+    Attachments: [{
+      RegistrationTID: RegistrationTid.DamageObs,
+      UrlFormats: {'Medium': 'damage'}
+    }]
+  }]
 };
 
 describe('registration.helper', () => {
@@ -70,35 +71,35 @@ describe('registration.helper', () => {
 
   it('Empty registrationTid should return all attachments', () => {
     expect(
-        getAllAttachmentsFromViewModel(viewModel).map(x => x.UrlFormats["Medium"])
-    ).toEqual(["snow", "common", "damage", "water"])
+      getAllAttachmentsFromViewModel(viewModel).map(x => x.UrlFormats['Medium'])
+    ).toEqual(['snow', 'common', 'damage', 'water']);
   });
 
   it('SnowProfile2 registrationTid should return profile', () => {
     expect(
-        getAllAttachmentsFromViewModel(viewModel, RegistrationTid.SnowProfile2)
-          .map(x => x.UrlFormats["Medium"])
-    ).toEqual(["snow"])
+      getAllAttachmentsFromViewModel(viewModel, RegistrationTid.SnowProfile2)
+        .map(x => x.UrlFormats['Medium'])
+    ).toEqual(['snow']);
   });
 
   it('GeneralObservation registrationTid should return common attachment', () => {
     expect(
-        getAllAttachmentsFromViewModel(viewModel, RegistrationTid.GeneralObservation)
-          .map(x => x.UrlFormats["Medium"])
-    ).toEqual(["common"])
+      getAllAttachmentsFromViewModel(viewModel, RegistrationTid.GeneralObservation)
+        .map(x => x.UrlFormats['Medium'])
+    ).toEqual(['common']);
   });
 
   it('DamageObs registrationTid should return damage attachment', () => {
     expect(
-        getAllAttachmentsFromViewModel(viewModel, RegistrationTid.DamageObs)
-          .map(x => x.UrlFormats["Medium"])
-    ).toEqual(["damage"])
+      getAllAttachmentsFromViewModel(viewModel, RegistrationTid.DamageObs)
+        .map(x => x.UrlFormats['Medium'])
+    ).toEqual(['damage']);
   });
 
   it('WaterLevel2 registrationTid should return water attachment', () => {
     expect(
-        getAllAttachmentsFromViewModel(viewModel, RegistrationTid.WaterLevel2)
-          .map(x => x.UrlFormats["Medium"])
-    ).toEqual(["water"])
+      getAllAttachmentsFromViewModel(viewModel, RegistrationTid.WaterLevel2)
+        .map(x => x.UrlFormats['Medium'])
+    ).toEqual(['water']);
   });
 });

--- a/src/app/modules/registration/pages/base-page.service.spec.ts
+++ b/src/app/modules/registration/pages/base-page.service.spec.ts
@@ -20,6 +20,7 @@ describe('BasePageService', () => {
   const avalancheObsDraft: RegistrationDraft = {
     uuid: 'draft',
     syncStatus: SyncStatus.Draft,
+    simpleMode: false,
     registration: {
       GeoHazardTID: 10,
       DtObsTime: 'obsTime',
@@ -81,6 +82,7 @@ describe('BasePageService', () => {
     const expectedEmptyDraft: RegistrationDraft = {
       uuid: 'draft',
       syncStatus: SyncStatus.Draft,
+      simpleMode: false,
       registration: {
         GeoHazardTID: 10,
         DtObsTime: 'obsTime'

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.spec.ts
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.spec.ts
@@ -16,6 +16,7 @@ describe('IceThicknessPage', () => {
       },
       uuid: null,
       syncStatus: null,
+      simpleMode: false,
     };
   });
 

--- a/src/app/modules/registration/pages/obs-location/obs-location.page.ts
+++ b/src/app/modules/registration/pages/obs-location/obs-location.page.ts
@@ -2,9 +2,7 @@ import { Component, OnInit, NgZone, OnDestroy, ViewChild } from '@angular/core';
 import * as L from 'leaflet';
 import { NavController } from '@ionic/angular';
 import {
-  ObsLocationsResponseDtoV2,
-  ObsLocationEditModel
-} from 'src/app/modules/common-regobs-api/models';
+  ObsLocationsResponseDtoV2} from 'src/app/modules/common-regobs-api/models';
 import { ActivatedRoute } from '@angular/router';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 import { firstValueFrom, Observable, Subscription } from 'rxjs';
@@ -12,10 +10,8 @@ import { FullscreenService } from '../../../../core/services/fullscreen/fullscre
 import { SwipeBackService } from '../../../../core/services/swipe-back/swipe-back.service';
 import { LocationTime, SetLocationInMapComponent } from '../../components/set-location-in-map/set-location-in-map.component';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
-import { RegobsAuthService } from '../../../auth/services/regobs-auth.service';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
-import { LoggedInUser } from 'src/app/modules/login/models/logged-in-user.model';
 
 @Component({
   selector: 'app-obs-location',
@@ -33,7 +29,6 @@ export class ObsLocationPage implements OnInit, OnDestroy {
   setLocationInMapComponent: SetLocationInMapComponent;
 
   private subscription: Subscription;
-  private loggedInUser: LoggedInUser;
 
   constructor(
     private draftService: DraftRepositoryService,
@@ -43,7 +38,6 @@ export class ObsLocationPage implements OnInit, OnDestroy {
     private fullscreenService: FullscreenService,
     private swipeBackService: SwipeBackService,
     private userSettingService: UserSettingService,
-    private regobsAuthService: RegobsAuthService
   ) {
     this.fullscreen$ = this.fullscreenService.isFullscreen$;
   }
@@ -84,11 +78,6 @@ export class ObsLocationPage implements OnInit, OnDestroy {
         Id: obsLocation.ObsLocationID
       };
     }
-    this.subscription = this.regobsAuthService.loggedInUser$.subscribe(
-      (val) => {
-        this.loggedInUser = val;
-      }
-    );
 
     this.ngZone.run(() => {
       this.isLoaded = true;
@@ -120,9 +109,8 @@ export class ObsLocationPage implements OnInit, OnDestroy {
   }
 
   async onLocationTimeSet(event: LocationTime) {
-
     if (!this.draft) {
-      this.draft = this.draftService.create(this.geoHazard);
+      this.draft = await this.draftService.create(this.geoHazard);
     }
 
     await this.setLocationTimeAndSaveDraft(event);
@@ -141,7 +129,7 @@ export class ObsLocationPage implements OnInit, OnDestroy {
           ...this.draft.registration,
           ObsLocation: location
         }
-      }
+      };
     }
 
     if (datetime !== undefined) {
@@ -151,7 +139,7 @@ export class ObsLocationPage implements OnInit, OnDestroy {
           ...this.draft.registration,
           DtObsTime: datetime
         }
-      }
+      };
     }
 
     // Save updated draft with new obs location

--- a/src/app/modules/registration/pages/overview/overview.page.html
+++ b/src/app/modules/registration/pages/overview/overview.page.html
@@ -38,7 +38,7 @@
       [draft]="draft"
     ></app-failed-registration>
 
-    <app-simple-snow-obs *ngIf="draft.simpleMode" [draft]="draft"></app-simple-snow-obs>
+    <app-simple-snow-obs *ngIf="showSimpleMode(draft)" [draft]="draft"></app-simple-snow-obs>
 
     <ion-list lines="full">
       <!-- "Summary" items for each form -->

--- a/src/app/modules/registration/pages/overview/overview.page.html
+++ b/src/app/modules/registration/pages/overview/overview.page.html
@@ -10,14 +10,10 @@
 </ion-header>
 <ng-container *ngIf="draft$ | async as draft">
   <ion-content>
-
     <!-- Simple snow obs header-->
-    <ion-grid class="header">
+    <ion-grid *ngIf="showSnowObsModeSelector$ | async" class="header">
       <ion-row>
-        <ion-col
-          *ngIf="userSetting.simpleSnowObservations"
-          class="question"
-        >
+        <ion-col *ngIf="draft.simpleMode" class="question">
           <ion-item>
             <ion-label>
               {{"REGISTRATION.OVERVIEW.SIMPLE.HEADER_QUESTION" | translate}}
@@ -28,7 +24,7 @@
           <ion-item>
             <ion-label>{{'REGISTRATION.OVERVIEW.SIMPLE.TOGGLE' | translate}}</ion-label>
             <ion-toggle
-              [ngModel]="userSetting.simpleSnowObservations"
+              [ngModel]="draft.simpleMode"
               (ionChange)="changeMode($event)"
             ></ion-toggle>
           </ion-item>
@@ -42,7 +38,7 @@
       [draft]="draft"
     ></app-failed-registration>
 
-    <app-simple-snow-obs *ngIf="userSetting.simpleSnowObservations" [draft]="draft"></app-simple-snow-obs>
+    <app-simple-snow-obs *ngIf="draft.simpleMode" [draft]="draft"></app-simple-snow-obs>
 
     <ion-list lines="full">
       <!-- "Summary" items for each form -->

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -73,7 +73,7 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
 
     this.summaryItems$ = this.draft$.pipe(
       switchMap((draft) => {
-        if (draft.simpleMode && draft.simpleMode === true) {
+        if (draft.simpleMode === true) {
           return from(this.getLocationAndTimeSummaryItem(draft));
         } else {
           return this.summaryItemService.getSummaryItems$(uuid);
@@ -112,7 +112,7 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
           //draft is compatible with simple mode, so change to simple mode
           this.saveDraftAndSimpleModeSetting(draft, true);
         }
-      } else if (draft.simpleMode && draft.simpleMode === true) {
+      } else if (draft.simpleMode === true) {
         //user want to change mode to standard
         this.saveDraftAndSimpleModeSetting(draft, false);
       }

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -68,12 +68,12 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
       });
 
     this.showSnowObsModeSelector$ = this.draft$.pipe(
-      map((draft) => draft.registration.GeoHazardTID === GeoHazard.Snow)
+      map((draft) => draft.registration.GeoHazardTID === GeoHazard.Snow && !this.syncFailed(draft))
     );
 
     this.summaryItems$ = this.draft$.pipe(
       switchMap((draft) => {
-        if (draft.simpleMode === true) {
+        if (this.showSimpleMode(draft)) {
           return from(this.getLocationAndTimeSummaryItem(draft));
         } else {
           return this.summaryItemService.getSummaryItems$(uuid);
@@ -82,8 +82,19 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
     );
   }
 
+  private syncFailed(draft: RegistrationDraft): boolean {
+    return draft.error && this.draftHasStatusSync(draft);
+  }
+
   private async getLocationAndTimeSummaryItem(draft: RegistrationDraft): Promise<ISummaryItem[]> {
     return [await this.summaryItemService.getLocationAndTimeSummaryItem(draft)];
+  }
+
+  showSimpleMode(draft: RegistrationDraft): boolean {
+    if (this.syncFailed(draft)) {
+      return false;
+    }
+    return draft.simpleMode === true;
   }
 
   draftHasStatusSync(draft: RegistrationDraft): boolean {

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -94,7 +94,7 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
     if (this.syncFailed(draft)) {
       return false;
     }
-    return draft.simpleMode === true;
+    return draft.simpleMode;
   }
 
   draftHasStatusSync(draft: RegistrationDraft): boolean {
@@ -105,7 +105,7 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
     const draft = await firstValueFrom(this.draft$);
     if (event.detail.checked != draft.simpleMode) {
       //we only want to change mode if toogle value is different than current mode
-      if (event.detail.checked === true) {
+      if (event.detail.checked) {
         //user wants to change mode to simple
         if (this.draftContainsDataNotAvailableForSimpleMode(draft)) {
           const okToConvertToSimple = await this.requestConvertToSimple();
@@ -123,7 +123,7 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
           //draft is compatible with simple mode, so change to simple mode
           this.saveDraftAndSimpleModeSetting(draft, true);
         }
-      } else if (draft.simpleMode === true) {
+      } else if (draft.simpleMode) {
         //user want to change mode to standard
         this.saveDraftAndSimpleModeSetting(draft, false);
       }

--- a/src/app/modules/registration/services/summary-item.service.spec.ts
+++ b/src/app/modules/registration/services/summary-item.service.spec.ts
@@ -10,6 +10,7 @@ describe('SummaryItemService', () => {
     const draftV1: RegistrationDraft = {
       uuid: 'draft',
       syncStatus: SyncStatus.Draft,
+      simpleMode: false,
       registration: {
         GeoHazardTID: 10,
         DtObsTime: 'obsTime',


### PR DESCRIPTION
Denne løser både [RO-1784](https://nveprojects.atlassian.net/browse/RO-1784), [RO-1786](https://nveprojects.atlassian.net/browse/RO-1786) og [RO-1780](https://nveprojects.atlassian.net/browse/RO-1780).
Når det gjelder visning av feilmeldinger, har jeg valgt å løse dette på en forholdsvis enkel måte. Feilmeldingssida for enkel observasjon ser nå helt lik ut som for fullstendig observasjon. Men når man trykker på "Rediger observasjon", vises observasjonen i enkel visning.
Det at vi husker om en registrering ble laget i enkel visning stopper når registreringa er sendt inn, siden vi ikke har noen funksjonalitet i API'et for å ta vare på dette. Så når du redigerer en registrering som er sendt inn, får du ikke enkel visning, selv om det var dette du brukte opprinnelig.