### PR TITLE
Fix logic in observertrips and memory leak in map

### DIFF
--- a/src/app/core/services/observer-trips/observer-trips.spec.ts
+++ b/src/app/core/services/observer-trips/observer-trips.spec.ts
@@ -1,0 +1,75 @@
+import { fakeAsync, flush, tick } from '@angular/core/testing';
+import { BehaviorSubject, firstValueFrom, ReplaySubject } from 'rxjs';
+import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
+import { TripService } from 'src/app/modules/common-regobs-api';
+import { LoggedInUser } from 'src/app/modules/login/models/logged-in-user.model';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { DatabaseService } from '../database/database.service';
+import { ObserverTripsService, dataKey, dataModifiedKey, toggledOnKey, isAuthorizedKey } from './observer-trips.service';
+
+describe('ObserverTripsService', () => {
+  let tripService: jasmine.SpyObj<TripService>;
+  let loggerService: jasmine.SpyObj<LoggingService>;
+  let database: any;
+  let dbService: DatabaseService;
+  let loggedInUser: ReplaySubject<LoggedInUser>;
+  let authService: jasmine.SpyObj<RegobsAuthService>;
+  let service: ObserverTripsService;
+
+  beforeEach(() => {
+    tripService = jasmine.createSpyObj('TripService', ['TripGet']);
+    loggerService = jasmine.createSpyObj('LoggerService', ['debug', 'error']);
+    database = {};
+    dbService = {
+      get: async (key) => database[key],
+      set: async (key, val) => database[key] = val
+    } as DatabaseService;
+    spyOn(dbService, 'get');
+    spyOn(dbService, 'set');
+    loggedInUser = new ReplaySubject<LoggedInUser>();
+    authService = jasmine.createSpyObj('RegobsAuthService', {}, { loggedInUser$: loggedInUser.asObservable() });
+    service = new ObserverTripsService(tripService, loggerService, dbService, authService);
+  });
+
+  it('should not fetch data if it has valid data saved in database', fakeAsync(async () => {
+    database = {
+      isAuthorizedKey: true,
+      toggleKey: true,
+      dataKey: { features: true },
+      dataModifiedKey: Date.now()
+    };
+
+    loggedInUser.next({ isLoggedIn: true });
+
+    const geojson = await firstValueFrom(service.geojson$);
+
+    // Let stuff happen
+    tick(100);
+
+    expect(geojson.features).toBeTrue();
+  }));
+
+  it('it should not do anything until a user is logged in', fakeAsync(() => {
+    // Let some time pass
+    tick(100);
+
+    // We should have asked for the logged in user
+    expect(Object.getOwnPropertyDescriptor(authService, 'loggedInUser$').get).toHaveBeenCalled();
+
+    // But nothing else should have happened
+    expect(tripService.TripGet).toHaveBeenCalledTimes(0);
+    expect(dbService.get).toHaveBeenCalledTimes(0);
+    expect(dbService.set).toHaveBeenCalledTimes(0);
+
+    // emit something else than a logged in user
+    loggedInUser.next({ email: null, token: null, isLoggedIn: false });
+
+    // Let some time pass
+    tick(100);
+
+    // Still should not have called any other dependencies
+    expect(tripService.TripGet).toHaveBeenCalledTimes(0);
+    expect(dbService.get).toHaveBeenCalledTimes(0);
+    expect(dbService.set).toHaveBeenCalledTimes(0);
+  }));
+});

--- a/src/app/core/services/observer-trips/observer-trips.spec.ts
+++ b/src/app/core/services/observer-trips/observer-trips.spec.ts
@@ -1,5 +1,6 @@
-import { fakeAsync, flush, tick } from '@angular/core/testing';
-import { BehaviorSubject, firstValueFrom, ReplaySubject } from 'rxjs';
+import { discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, resetFakeAsyncZone, tick } from '@angular/core/testing';
+import { BehaviorSubject, firstValueFrom, of, ReplaySubject, timeout } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
 import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
 import { TripService } from 'src/app/modules/common-regobs-api';
 import { LoggedInUser } from 'src/app/modules/login/models/logged-in-user.model';
@@ -12,11 +13,14 @@ describe('ObserverTripsService', () => {
   let loggerService: jasmine.SpyObj<LoggingService>;
   let database: any;
   let dbService: DatabaseService;
+  let dbServiceGetSpy: jasmine.Spy;
+  let dbServiceSetSpy: jasmine.Spy;
   let loggedInUser: ReplaySubject<LoggedInUser>;
   let authService: jasmine.SpyObj<RegobsAuthService>;
   let service: ObserverTripsService;
 
   beforeEach(() => {
+    resetFakeAsyncZone();
     tripService = jasmine.createSpyObj('TripService', ['TripGet']);
     loggerService = jasmine.createSpyObj('LoggerService', ['debug', 'error']);
     database = {};
@@ -24,8 +28,8 @@ describe('ObserverTripsService', () => {
       get: async (key) => database[key],
       set: async (key, val) => database[key] = val
     } as DatabaseService;
-    spyOn(dbService, 'get');
-    spyOn(dbService, 'set');
+    dbServiceGetSpy = spyOn(dbService, 'get').and.callThrough();
+    dbServiceSetSpy = spyOn(dbService, 'set').and.callThrough();
     loggedInUser = new ReplaySubject<LoggedInUser>();
     authService = jasmine.createSpyObj('RegobsAuthService', {}, { loggedInUser$: loggedInUser.asObservable() });
     service = new ObserverTripsService(tripService, loggerService, dbService, authService);
@@ -33,10 +37,10 @@ describe('ObserverTripsService', () => {
 
   it('should not fetch data if it has valid data saved in database', fakeAsync(async () => {
     database = {
-      isAuthorizedKey: true,
-      toggleKey: true,
-      dataKey: { features: true },
-      dataModifiedKey: Date.now()
+      [isAuthorizedKey]: true,
+      [toggledOnKey]: true,
+      [dataKey]: { features: true },
+      [dataModifiedKey]: Date.now()
     };
 
     loggedInUser.next({ isLoggedIn: true });
@@ -46,30 +50,94 @@ describe('ObserverTripsService', () => {
     // Let stuff happen
     tick(100);
 
+    // It should not be needed to write anything to the db in this scenario
+    expect(dbServiceSetSpy).toHaveBeenCalledTimes(0);
+
+    // Check that service checks the authorized value and reads data from database
+    // TODO: Remove
+    const dbArgs = dbServiceGetSpy.calls.allArgs();
+    expect(dbArgs).toContain([isAuthorizedKey]);
+    expect(dbArgs).toContain([dataKey]);
+    expect(dbArgs).toContain([dataModifiedKey]);
+
+    // Check that tripService was not called
+    expect(tripService.TripGet).toHaveBeenCalledTimes(0);
+
     expect(geojson.features).toBeTrue();
   }));
 
-  it('it should not do anything until a user is logged in', fakeAsync(() => {
+  it('should fetch data if data is too old', fakeAsync(async () => {
+    // "as null" because TripGet return type is Observable<null> but it returns an observable with geojson data
+    tripService.TripGet.and.returnValue(of({ features: [{ type: 'NewFeature1' }, { type: 'NewFeature2' }] } as null));
+
+    database = {
+      [isAuthorizedKey]: true,
+      [toggledOnKey]: true,
+      [dataKey]: { features: [{ type: 'OldFeature1' }, { type: 'OldFeature1' }, { type: 'OldFeature1' }] },
+      [dataModifiedKey]: 100
+    };
+
+    loggedInUser.next({ isLoggedIn: true });
+
+    // Something must subscribe for stuff to happen
+    const geojson = await firstValueFrom(service.geojson$);
+
+    // Let time pass
+    tick(100);
+
+    // Check that tripService was called to fetch new data
+    expect(tripService.TripGet).toHaveBeenCalledTimes(1);
+    expect(geojson.features).toHaveSize(2);
+    expect(geojson.features[0].type).toBe('NewFeature1');
+  }));
+
+  it('should use old data if fetching new data fails', fakeAsync(async () => {
+    // "as null" because TripGet return type is Observable<null> but it returns an observable with geojson data
+    tripService.TripGet.and.throwError('Failed to fetch new data');
+
+    database = {
+      [isAuthorizedKey]: true,
+      [toggledOnKey]: true,
+      [dataKey]: { features: [{ type: 'OldFeature1' }, { type: 'OldFeature1' }, { type: 'OldFeature1' }] },
+      [dataModifiedKey]: 100
+    };
+
+    loggedInUser.next({ isLoggedIn: true });
+
+    // Something must subscribe for stuff to happen
+    const geojson = await firstValueFrom(service.geojson$);
+
+    // Let time pass
+    tick(100);
+
+    // Check that tripService was called to try fetching new data
+    expect(tripService.TripGet).toHaveBeenCalledTimes(1);
+    expect(geojson.features[0].type).toBe('OldFeature1');
+  }));
+
+  it('it should not do anything until a user is logged in', fakeAsync(async () => {
+    // Subscribe to geojson so logic in service starts
+    const geojsonPromise = firstValueFrom(service.geojson$.pipe(timeout(1000)));
+
     // Let some time pass
     tick(100);
 
-    // We should have asked for the logged in user
-    expect(Object.getOwnPropertyDescriptor(authService, 'loggedInUser$').get).toHaveBeenCalled();
-
     // But nothing else should have happened
     expect(tripService.TripGet).toHaveBeenCalledTimes(0);
-    expect(dbService.get).toHaveBeenCalledTimes(0);
-    expect(dbService.set).toHaveBeenCalledTimes(0);
+    expect(dbServiceGetSpy).toHaveBeenCalledTimes(0);
 
     // emit something else than a logged in user
     loggedInUser.next({ email: null, token: null, isLoggedIn: false });
 
-    // Let some time pass
-    tick(100);
+    // Let timeout complete and promise to reject
+    try {
+      tick(2000);
+      await geojsonPromise;
+    // eslint-disable-next-line no-empty
+    } catch (error) {}
 
-    // Still should not have called any other dependencies
+    // Still should not have called any dependencies
     expect(tripService.TripGet).toHaveBeenCalledTimes(0);
-    expect(dbService.get).toHaveBeenCalledTimes(0);
-    expect(dbService.set).toHaveBeenCalledTimes(0);
+    expect(dbServiceGetSpy).toHaveBeenCalledTimes(0);
   }));
 });

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -220,7 +220,6 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     this.observationTripLayers = null;
   }
 
-  // TODO: Lages det flere lag / click handlers hvis man toggler av og på flere ganger?
   private async showOrHideObserverTripsLayer(map: L.Map, geojson: FeatureCollection) {
     if (geojson == null) {
       this.removeObserverTripMapLayers(map);
@@ -287,7 +286,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     if (this.showObserverTrips) {
-      this.observerTripsService.geojson.pipe(takeUntil(this.ngDestroy$)).subscribe(geojson => {
+      this.observerTripsService.geojson$.pipe(takeUntil(this.ngDestroy$)).subscribe(geojson => {
         this.showOrHideObserverTripsLayer(map, geojson);
       });
     }

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -14,7 +14,7 @@ import {
 import { Capacitor } from '@capacitor/core';
 import * as L from 'leaflet';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
-import { timer, Subject, from, BehaviorSubject, combineLatest } from 'rxjs';
+import { timer, Subject, from, BehaviorSubject, combineLatest, race } from 'rxjs';
 import { UserSetting } from '../../../../core/models/user-settings.model';
 import { settings } from '../../../../../settings';
 import { Position } from '@capacitor/geolocation';
@@ -102,7 +102,8 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('observerTripsContainer') observerTripsContainer: ElementRef<HTMLDivElement>;
   observationTripName = '';
   observationTripDescription: string = null;
-  observationTripLayers: L.GeoJSON[];
+  private observationTripLayers: L.GeoJSON[];
+  private removeObserverTripEventHandlers = new Subject<void>();
 
   loaded = false;
   private map: L.Map;
@@ -208,20 +209,22 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     this.observerTripsContainer.nativeElement.style.display = 'none';
   }
 
-  private cleanupObserverTrips(map: L.Map) {
+  private removeObserverTripMapLayers(map: L.Map) {
     if (this.observationTripLayers != null) {
       this.observationTripLayers.forEach(l => {
         if (map.hasLayer(l)) {
           map.removeLayer(l);
         }
       });
-      this.observationTripLayers = null;
     }
+    this.observationTripLayers = null;
   }
 
-  private async addObserverTripsLayer(map: L.Map, geojson: FeatureCollection) {
+  // TODO: Lages det flere lag / click handlers hvis man toggler av og på flere ganger?
+  private async showOrHideObserverTripsLayer(map: L.Map, geojson: FeatureCollection) {
     if (geojson == null) {
-      this.cleanupObserverTrips(map);
+      this.removeObserverTripMapLayers(map);
+      this.removeObserverTripEventHandlers.next();
       return;
     }
 
@@ -265,8 +268,12 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     layerToBindClickHandlerTo.on('click', clickHandler);
     map.on('zoomend', addOrRemoveLayers);
 
-    // Clean up event listeners on destroy
-    this.ngDestroy$.subscribe(() => {
+    // Clean up event listeners on destroy or when toggled off
+    race(
+      this.ngDestroy$,
+      this.removeObserverTripEventHandlers,
+      this.observerTripsService.toggledOn.pipe(filter(toggledOn => !toggledOn))
+    ).pipe(take(1)).subscribe(() => {
       layerToBindClickHandlerTo.off('click', clickHandler);
       map.off('zoomend', addOrRemoveLayers);
     });
@@ -281,7 +288,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
 
     if (this.showObserverTrips) {
       this.observerTripsService.geojson.pipe(takeUntil(this.ngDestroy$)).subscribe(geojson => {
-        this.addObserverTripsLayer(map, geojson);
+        this.showOrHideObserverTripsLayer(map, geojson);
       });
     }
 

--- a/src/app/modules/side-menu/components/side-menu.component.html
+++ b/src/app/modules/side-menu/components/side-menu.component.html
@@ -44,7 +44,7 @@
     </ion-label>
     <ion-toggle [(ngModel)]="userSettings.showMapCenter" (ionChange)="saveUserSettings()"></ion-toggle>
   </ion-item>
-  <ion-item *ngIf="observerTrips.canShow | async">
+  <ion-item *ngIf="observerTrips.isAuthorized | async">
     <!-- Obstur icon, has the same style as the map layer -->
     <svg slot="start" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <line x1="2" y1="20.8787" x2="20.8787" y2="2" stroke="#FF0000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="4 4"/>
@@ -53,7 +53,7 @@
       Vis obsturer
     </ion-label>
     <ion-toggle 
-      [checked]="observerTrips.toggleOn.value"
+      [checked]="observerTrips.toggledOn | async"
       (ionChange)="observerTrips.toggle()"
     ></ion-toggle>
   </ion-item>


### PR DESCRIPTION
Har prøvd å rydde opp litt etter at vi så at obstur-laget ikke ble skrudd av og på når man brukte togglen.
Logikken i obstur-servicen er fortsatt ganske vanskelig å lese siden den er avhengig av om du har tilgang, om du har data lagret fra før av, om den er for gammel eller fortsatt gyldig osv.
Har lagt til tester, og jeg tror i alle fall det fungerer som det skal nå.

Denne PRen fikser også litt logikk i map.component.ts som førte til at minneforbruket økte når man togglet obstur-laget av og på mange ganger. Jeg tror det var at en event-listener ikke ble slettet når laget ble togglet av, som førte til at alle varabler i event-listenerens closure ble tatt vare på (også obstur-geojsonen).