### PR TITLE
Fix missing add-image-button on ios

### DIFF
--- a/src/app/modules/registration/components/edit-images/edit-images.page.scss
+++ b/src/app/modules/registration/components/edit-images/edit-images.page.scss
@@ -1,6 +1,4 @@
 app-edit-images {
   overflow: auto;
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
+  height: 100%;
 }


### PR DESCRIPTION
Bør fikse feil som forårsaker at "Legg til bilder"-knappen forsvinner på ios når man har lagt til 2 bilder.
Usikker på hva feilen skyldtes siden det kun var på ios, kanskje en sær ios-safari-flexbox-bug.

Den opprinnelige cssen var ganske forvirrende fordi `flex-grow: 1;` fungerte som `height: 100%` siden hver ionic page har display flex satt. Det ser man ikke via html / scss i edit-images.page, men man må bare vite om det. Så i tillegg til at bugen fikses gjør dette cssen lettere å forstå etter min mening.
