### PR TITLE
Support registration/<regid> route

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -37,10 +37,7 @@ const routes: Routes = [
   },
   {
     path: 'view-observation/:id',
-    loadChildren: () =>
-      import('./pages/view-observation/view-observation.module').then(
-        (m) => m.ViewObservationPageModule
-      )
+    redirectTo: 'registration/:id'
   },
   {
     path: 'observation-list',
@@ -67,6 +64,10 @@ const routes: Routes = [
       import('./modules/registration/registration.module').then(
         (m) => m.RegistrationModule
       )
+  },
+  {
+    path: 'Registration',
+    redirectTo: 'registration'
   },
   {
     path: 'legacy-trip',

--- a/src/app/modules/registration/registration-routing.module.ts
+++ b/src/app/modules/registration/registration-routing.module.ts
@@ -139,7 +139,14 @@ const routes: Routes = [
       import(
         './pages/snow/avalanche-evaluation/avalanche-evaluation.module'
       ).then((m) => m.AvalancheEvaluationPageModule)
-  }
+  },
+  {
+    path: 'registration/:id',
+    loadChildren: () =>
+      import('src/app/pages/view-observation/view-observation.module').then(
+        (m) => m.ViewObservationPageModule
+      ),
+  },
 ];
 
 @NgModule({


### PR DESCRIPTION
Løser https://nveprojects.atlassian.net/browse/RO-1870 

Med denne endringen skal appen støtte 

- /registration/<regid>
- /Registration/<regid>

samtidig som den fortsatt støtter den gamle /view-observation/<regid> - ruta. 
Vi har ikke noe detaljert observasjonsvisning i appen, men observasjonskortet vises enn så lenge.

Denne oppgaven må testes ved å skrive inn en gyldig rute rett i nettleseren, jeg tror ikke appen selv har noen knapper / linker som tar deg til en detaljside i dag, men er ikke sikker.