### PR TITLE
Enkel modus er nå standard når man lager ny snøobservasjon

### DIFF
--- a/src/app/core/models/user-settings.model.ts
+++ b/src/app/core/models/user-settings.model.ts
@@ -26,8 +26,8 @@ export interface UserSetting {
   photographer?: string;
 
   /**
-   * true = use simple snow obs schema
-   * false/undefined = use full/complete snow obs schemas
+   * true = use full/complete snow obs schemas
+   * false/undefined = use simple snow obs schema
    */
-   simpleSnowObservations: boolean;
+   preferCompleteSnowObservations: boolean;
 }

--- a/src/app/core/services/draft/draft-repository.service.spec.ts
+++ b/src/app/core/services/draft/draft-repository.service.spec.ts
@@ -97,7 +97,7 @@ describe('DraftRepositoryService', () => {
     userSettingService.saveUserSettings({
       ...await firstValueFrom(userSettingService.userSetting$),
       appMode: AppMode.Test,
-      simpleSnowObservations: false
+      preferCompleteSnowObservations: true
     });
     const completeSnowDraft = await service.create(GeoHazard.Snow);
     expect(completeSnowDraft.simpleMode).toBeFalse();

--- a/src/app/core/services/draft/draft-repository.service.ts
+++ b/src/app/core/services/draft/draft-repository.service.ts
@@ -145,7 +145,7 @@ export class DraftRepositoryService {
   private async useSimpleMode(geoHazard: GeoHazard): Promise<boolean> {
     if (geoHazard === GeoHazard.Snow) {
       const userSetting = await firstValueFrom(this.userSettingService.userSetting$);
-      return userSetting.simpleSnowObservations;
+      return !userSetting.preferCompleteSnowObservations;
     }
     return false;
   }

--- a/src/app/core/services/user-setting/user-settings.default.ts
+++ b/src/app/core/services/user-setting/user-settings.default.ts
@@ -26,5 +26,5 @@ export const DEFAULT_USER_SETTINGS: (langKey: LangKey) => UserSetting = (
   consentForSendingAnalyticsDialogCompleted: false,
   featureToggeGpsDebug: false,
   featureToggleDeveloperMode: false,
-  simpleSnowObservations: true
+  preferCompleteSnowObservations: false
 });

--- a/src/app/modules/registration/pages/overview/overview.page.html
+++ b/src/app/modules/registration/pages/overview/overview.page.html
@@ -23,31 +23,22 @@
         <ion-col class="simple-obs-toggle">
           <ion-item>
             <ion-label>{{'REGISTRATION.OVERVIEW.SIMPLE.TOGGLE' | translate}}</ion-label>
-            <ion-toggle
-              [ngModel]="draft.simpleMode"
-              (ionChange)="changeMode($event)"
-            ></ion-toggle>
+            <ion-toggle [ngModel]="draft.simpleMode" (ionChange)="changeMode($event)"></ion-toggle>
           </ion-item>
         </ion-col>
       </ion-row>
     </ion-grid>
 
     <!-- Error info if posting the registration failed -->
-    <app-failed-registration
-      *ngIf="draft.error && draftHasStatusSync(draft)"
-      [draft]="draft"
-    ></app-failed-registration>
+    <app-failed-registration *ngIf="draft.error && draftHasStatusSync(draft)" [draft]="draft"></app-failed-registration>
 
     <app-simple-snow-obs *ngIf="showSimpleMode(draft)" [draft]="draft"></app-simple-snow-obs>
 
     <ion-list lines="full">
       <!-- "Summary" items for each form -->
-      <app-summary-item
-        [readonly]="draftHasStatusSync(draft)"
-        *ngFor="let item of summaryItems$ | async; trackBy: trackByFunction"
-        [simpleObsMode]="userSetting.simpleSnowObservations"
-        [item]="item"
-      ></app-summary-item>
+      <app-summary-item [readonly]="draftHasStatusSync(draft)"
+        *ngFor="let item of summaryItems$ | async; trackBy: trackByFunction" [simpleObsMode]="draft.simpleMode"
+        [item]="item"></app-summary-item>
     </ion-list>
   </ion-content>
   <app-send-button *ngIf="!hideSendButton(draft)" [draft]="draft"></app-send-button>

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -136,7 +136,7 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
       simpleMode
     };
     this.draftRepository.save(draftToSave); //save mode on draft
-    this.userSetting.simpleSnowObservations = simpleMode;
+    this.userSetting.preferCompleteSnowObservations = !simpleMode;
     this.userSettingService.saveUserSettings(this.userSetting); //save default mode for new registrations
   }
 


### PR DESCRIPTION
Har snudd på innstillingen for modus for snøobservasjoner, slik at alle nå får se enkel observasjon neste gang de lager en ny snøobservasjon. Deretter kan de velge å bytte til "proff-modus" om de ønsker. 
Før denne fiksen fikk ikke brukere som hadde brukt Regobs fra før enkel snøobs som standard.
Flg. bør testes:

- [x] Hvis du har brukt appen fra før (og har lagret user-settings i lokal database), skal enkel obs nå være standard
- [x] Appen skal huske hvilken modus man aktivt valgte sist, og nye observasjoner skal åpnes denne modus
- [x] En kladd skal huske hvilken modus den ble laget i, inntil du sender den inn, helt uavhengig av hva som er foretrukket modus