### PR TITLE
RO-1877: Skiføre ble ikke vist i appen hvis vi ikke hadde greid å hente skiførevalg fra API'et

### DIFF
--- a/src/app/modules/common-registration/services/kdv/kdv.service.ts
+++ b/src/app/modules/common-registration/services/kdv/kdv.service.ts
@@ -12,6 +12,7 @@ import { KdvViewRepositoryKey } from '../../models/view-repository-key.type';
 import { ApiSyncOfflineBaseService } from '../api-sync-offline-base/api-sync-offline-base.service';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
+import { LogLevel } from 'src/app/modules/shared/services/logging/log-level.model';
 
 const KDV_ASSETS_FOLDER = '/assets/json';
 
@@ -37,7 +38,15 @@ export class KdvService extends ApiSyncOfflineBaseService<KdvElementsResponseDto
   }
 
   public getKdvRepositoryByKeyObservable(key: KdvKey): Observable<KdvElement[]> {
-    return this.data$.pipe(map((val) => val.KdvRepositories[key]));
+    return this.data$.pipe(
+      map((kdvElementsresponse) => {
+        const kdvsForGivenKey = kdvElementsresponse.KdvRepositories[key];
+        if (!kdvsForGivenKey) {
+          this.logger.log(`No KDVs for '${key}', returning empty array`, null, LogLevel.Warning, this.getDebugTag());
+          return [];
+        }
+        return kdvsForGivenKey;
+      }));
   }
 
   public getViewRepositoryByKeyObservable(key: KdvViewRepositoryKey): Observable<unknown> {

--- a/src/assets/json/kdvelements.de.json
+++ b/src/assets/json/kdvelements.de.json
@@ -22,8 +22,13 @@
         "Description": null
       },
       {
-        "Id": 212,
-        "Name": "Schneedecke mit viel Wasser",
+        "Id": 204,
+        "Name": "Oberflächenabfluss",
+        "Description": null
+      },
+      {
+        "Id": 205,
+        "Name": "Unzureichende Drainage",
         "Description": null
       },
       {
@@ -37,26 +42,6 @@
         "Description": null
       },
       {
-        "Id": 230,
-        "Name": "Erosion entlang von Flüssen",
-        "Description": null
-      },
-      {
-        "Id": 214,
-        "Name": "Bäche finden neue Wege",
-        "Description": null
-      },
-      {
-        "Id": 204,
-        "Name": "Oberflächenabfluss",
-        "Description": null
-      },
-      {
-        "Id": 205,
-        "Name": "Unzureichende Drainage",
-        "Description": null
-      },
-      {
         "Id": 208,
         "Name": "Risse/Kriechen im Gelände",
         "Description": null
@@ -67,6 +52,16 @@
         "Description": null
       },
       {
+        "Id": 212,
+        "Name": "Schneedecke mit viel Wasser",
+        "Description": null
+      },
+      {
+        "Id": 214,
+        "Name": "Bäche finden neue Wege",
+        "Description": null
+      },
+      {
         "Id": 222,
         "Name": "Bewegung am Erdrutschrand",
         "Description": null
@@ -74,6 +69,11 @@
       {
         "Id": 223,
         "Name": "Lehnende Bäume",
+        "Description": null
+      },
+      {
+        "Id": 230,
+        "Name": "Erosion entlang von Flüssen",
         "Description": null
       },
       {
@@ -89,6 +89,11 @@
         "Description": null
       },
       {
+        "Id": 211,
+        "Name": "Personen",
+        "Description": null
+      },
+      {
         "Id": 220,
         "Name": "Straßen",
         "Description": null
@@ -99,18 +104,13 @@
         "Description": null
       },
       {
-        "Id": 260,
-        "Name": "Gebäude",
-        "Description": null
-      },
-      {
-        "Id": 211,
-        "Name": "Personen",
-        "Description": null
-      },
-      {
         "Id": 251,
         "Name": "Landwirtschaftliche Flächen",
+        "Description": null
+      },
+      {
+        "Id": 260,
+        "Name": "Gebäude",
         "Description": null
       },
       {
@@ -141,11 +141,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Kleine Steinlawine",
-        "Description": null
-      },
-      {
         "Id": 6,
         "Name": "Steinschlag",
         "Description": null
@@ -163,6 +158,11 @@
       {
         "Id": 10,
         "Name": "Quicktonrutsch",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Kleine Steinlawine",
         "Description": null
       }
     ],
@@ -299,8 +299,38 @@
         "Description": null
       },
       {
+        "Id": 714,
+        "Name": "Ice fisher",
+        "Description": null
+      },
+      {
+        "Id": 715,
+        "Name": "Horse riding / wagons / sledge",
+        "Description": null
+      },
+      {
+        "Id": 716,
+        "Name": "Dogsled",
+        "Description": null
+      },
+      {
+        "Id": 717,
+        "Name": "Save an animal",
+        "Description": null
+      },
+      {
+        "Id": 719,
+        "Name": "Person injured by ice run",
+        "Description": null
+      },
+      {
         "Id": 720,
         "Name": "Snowmobile auf dem Eis",
+        "Description": null
+      },
+      {
+        "Id": 721,
+        "Name": "Auto auf dem Eis",
         "Description": null
       },
       {
@@ -309,8 +339,18 @@
         "Description": "All Terrain Vehicle"
       },
       {
-        "Id": 721,
-        "Name": "Auto auf dem Eis",
+        "Id": 723,
+        "Name": "Bicycle",
+        "Description": null
+      },
+      {
+        "Id": 724,
+        "Name": "Motorcycle",
+        "Description": null
+      },
+      {
+        "Id": 725,
+        "Name": "Kicksledge",
         "Description": null
       },
       {
@@ -329,6 +369,11 @@
         "Description": null
       },
       {
+        "Id": 735,
+        "Name": "Airplane / helicopter",
+        "Description": null
+      },
+      {
         "Id": 772,
         "Name": "Eislauf",
         "Description": null
@@ -341,6 +386,21 @@
       {
         "Id": 774,
         "Name": "Treibeis",
+        "Description": null
+      },
+      {
+        "Id": 775,
+        "Name": "Anchor ice dam",
+        "Description": null
+      },
+      {
+        "Id": 776,
+        "Name": "Frazil ice plugging",
+        "Description": null
+      },
+      {
+        "Id": 777,
+        "Name": "Eisstau",
         "Description": null
       },
       {
@@ -361,11 +421,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Eisbildung entlang des Ufers",
-        "Description": null
-      },
-      {
         "Id": 2,
         "Name": "Teilweise vereist vor Ort",
         "Description": null
@@ -376,13 +431,13 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "See eisbedeckt",
+        "Id": 10,
+        "Name": "Eis bricht entlang des Ufers",
         "Description": null
       },
       {
-        "Id": 10,
-        "Name": "Eis bricht entlang des Ufers",
+        "Id": 11,
+        "Name": "Eisbildung entlang des Ufers",
         "Description": null
       },
       {
@@ -391,13 +446,18 @@
         "Description": null
       },
       {
-        "Id": 41,
-        "Name": "Treibendes Frazil-Eis am Fluss",
+        "Id": 21,
+        "Name": "See eisbedeckt",
         "Description": null
       },
       {
         "Id": 40,
         "Name": "Flusseislauf",
+        "Description": null
+      },
+      {
+        "Id": 41,
+        "Name": "Treibendes Frazil-Eis am Fluss",
         "Description": null
       },
       {
@@ -413,14 +473,14 @@
         "Description": null
       },
       {
-        "Id": 2,
-        "Name": "Jetzt erstes Eis am Ufer",
-        "Description": "Kein Eis am Ufer gestern."
-      },
-      {
         "Id": 1,
         "Name": "Jetzt erstmal Eis vor Ort",
         "Description": "Gestern kein Eis vor Ort. Möglicherweise war Eis am Ufer. Messpunkt liegt normalerweise etwas vom Ufer entfernt."
+      },
+      {
+        "Id": 2,
+        "Name": "Jetzt erstes Eis am Ufer",
+        "Description": "Kein Eis am Ufer gestern."
       },
       {
         "Id": 3,
@@ -581,6 +641,11 @@
         "Description": null
       },
       {
+        "Id": 60,
+        "Name": "Eislawine",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Andere (im Kommentar)",
         "Description": null
@@ -608,11 +673,6 @@
         "Description": null
       },
       {
-        "Id": 4,
-        "Name": "Aktuelle Risse",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "Starker Schneefall",
         "Description": "Brukes i elrapp"
@@ -633,6 +693,16 @@
         "Description": null
       },
       {
+        "Id": 14,
+        "Name": "Shooting cracks",
+        "Description": null
+      },
+      {
+        "Id": 15,
+        "Name": "Glide cracks",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Andere Gefahren (spezifiziere)",
         "Description": null
@@ -650,13 +720,13 @@
         "Description": null
       },
       {
-        "Id": 113,
-        "Name": "Skigebiet, abseits der Piste",
+        "Id": 112,
+        "Name": "Skigebiet",
         "Description": null
       },
       {
-        "Id": 112,
-        "Name": "Skigebiet",
+        "Id": 113,
+        "Name": "Skigebiet, abseits der Piste",
         "Description": null
       },
       {
@@ -680,13 +750,13 @@
         "Description": null
       },
       {
-        "Id": 130,
-        "Name": "Schneemobil",
+        "Id": 120,
+        "Name": "Straße",
         "Description": null
       },
       {
-        "Id": 120,
-        "Name": "Straße",
+        "Id": 130,
+        "Name": "Schneemobil",
         "Description": null
       },
       {
@@ -712,23 +782,23 @@
         "Description": null
       },
       {
-        "Id": 12,
-        "Name": "Trockene Lockerschneelawine",
-        "Description": null
-      },
-      {
         "Id": 11,
         "Name": "Nasse Lockerschneelawine",
         "Description": null
       },
       {
-        "Id": 22,
-        "Name": "Trockene Schneebrettlawine",
+        "Id": 12,
+        "Name": "Trockene Lockerschneelawine",
         "Description": null
       },
       {
         "Id": 21,
         "Name": "Nasse Schneebrettlawine",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Trockene Schneebrettlawine",
         "Description": null
       },
       {
@@ -863,24 +933,24 @@
         "Description": "Aufbauend umgewandelte Kristalle in Bodennähe"
       },
       {
-        "Id": 19,
-        "Name": "Aufbauend umgewandelte Kristalle unter einer Kruste",
-        "Description": "Aufbauend umgewandelte Kristalle unter einer Kruste"
-      },
-      {
         "Id": 18,
         "Name": "Aufbauend umgewandelte Kristalle über einer Kruste",
         "Description": "Aufbauend umgewandelte Kristalle über einer Kruste"
       },
       {
-        "Id": 22,
-        "Name": "Wasseransammlung über Schneeschichten",
-        "Description": "Wasseransammlung über Schneeschichten"
+        "Id": 19,
+        "Name": "Aufbauend umgewandelte Kristalle unter einer Kruste",
+        "Description": "Aufbauend umgewandelte Kristalle unter einer Kruste"
       },
       {
         "Id": 20,
         "Name": "Schmelzen in Bodennähe",
         "Description": "Schmelzen in Bodennähe"
+      },
+      {
+        "Id": 22,
+        "Name": "Wasseransammlung über Schneeschichten",
+        "Description": "Wasseransammlung über Schneeschichten"
       },
       {
         "Id": 24,
@@ -1030,6 +1100,11 @@
         "Description": null
       },
       {
+        "Id": 22,
+        "Name": "Spontanauszulösungen",
+        "Description": null
+      },
+      {
         "Id": 30,
         "Name": "Sehr schwer auszulösen",
         "Description": null
@@ -1047,11 +1122,6 @@
       {
         "Id": 60,
         "Name": "Sehr leicht auszulösen",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "Spontanauszulösungen",
         "Description": null
       }
     ],
@@ -1254,16 +1324,6 @@
         "Description": null
       },
       {
-        "Id": 26,
-        "Name": "Auslösung durch Person(en)",
-        "Description": null
-      },
-      {
-        "Id": 27,
-        "Name": "Ausgelöst durch ein Snowmobile",
-        "Description": null
-      },
-      {
         "Id": 22,
         "Name": "Fernauslösung",
         "Description": null
@@ -1276,6 +1336,16 @@
       {
         "Id": 25,
         "Name": "Sprengauslösung",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Auslösung durch Person(en)",
+        "Description": null
+      },
+      {
+        "Id": 27,
+        "Name": "Ausgelöst durch ein Snowmobile",
         "Description": null
       },
       {
@@ -1348,6 +1418,21 @@
         "Description": null
       },
       {
+        "Id": 50,
+        "Name": "Oberflächennahe kantige Kristalle",
+        "Description": null
+      },
+      {
+        "Id": 61,
+        "Name": "Raureif auf einer harten Oberfläche",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Oberflächenreif auf einer weichen Oberfläche",
+        "Description": null
+      },
+      {
         "Id": 101,
         "Name": "Sehr viel lockerer Schnee (>30cm)",
         "Description": null
@@ -1363,23 +1448,8 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Raureif auf einer harten Oberfläche",
-        "Description": null
-      },
-      {
-        "Id": 62,
-        "Name": "Oberflächenreif auf einer weichen Oberfläche",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Oberflächennahe kantige Kristalle",
-        "Description": null
-      },
-      {
-        "Id": 107,
-        "Name": "Kruste",
+        "Id": 104,
+        "Name": "Nasser lockerer Schnee",
         "Description": null
       },
       {
@@ -1393,8 +1463,8 @@
         "Description": null
       },
       {
-        "Id": 104,
-        "Name": "Nasser lockerer Schnee",
+        "Id": 107,
+        "Name": "Kruste",
         "Description": null
       },
       {
@@ -1491,26 +1561,6 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "ECTPV",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "ECTP",
-        "Description": null
-      },
-      {
-        "Id": 23,
-        "Name": "ECTN",
-        "Description": null
-      },
-      {
-        "Id": 24,
-        "Name": "ECTX",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "KBT",
         "Description": null
@@ -1538,6 +1588,26 @@
       {
         "Id": 15,
         "Name": "CTN",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "ECTPV",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "ECTP",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "ECTN",
+        "Description": null
+      },
+      {
+        "Id": 24,
+        "Name": "ECTX",
         "Description": null
       }
     ],
@@ -1961,6 +2031,38 @@
       {
         "Id": 13,
         "Name": "Ganze Schicht",
+        "Description": null
+      }
+    ],
+    "Snow_SkiConditionsKDV": [
+      {
+        "Id": 0,
+        "Name": "Not given",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Bad",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Ok",
+        "Description": null
+      },
+      {
+        "Id": 30,
+        "Name": "Good",
+        "Description": null
+      },
+      {
+        "Id": 40,
+        "Name": "Very Good",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Perfect",
         "Description": null
       }
     ],
@@ -2469,13 +2571,13 @@
         "Description": null
       },
       {
-        "Id": 25,
-        "Name": "Evakuierung",
+        "Id": 20,
+        "Name": "Nur Materialschäden",
         "Description": null
       },
       {
-        "Id": 20,
-        "Name": "Nur Materialschäden",
+        "Id": 25,
+        "Name": "Evakuierung",
         "Description": null
       },
       {
@@ -2516,6 +2618,11 @@
         "Description": "Unbekannt für Schnee."
       },
       {
+        "Id": 105,
+        "Name": "A",
+        "Description": "Automatischer Service"
+      },
+      {
         "Id": 110,
         "Name": "*",
         "Description": "Der Beobachter verfügt über grundlegende Fähigkeiten zur Beurteilung der Lawinengefahr. Der Beobachter ist nicht darin geschult, wie regObs und [Varsom?] die Lawinengefahr kommunizieren."
@@ -2539,11 +2646,6 @@
         "Id": 150,
         "Name": "*****",
         "Description": "Beobachter ist Lawinenprognostiker."
-      },
-      {
-        "Id": 105,
-        "Name": "A",
-        "Description": "Automatischer Service"
       },
       {
         "Id": 200,
@@ -2750,13 +2852,18 @@
         "Description": null
       },
       {
-        "Id": 60,
-        "Name": "Privat",
+        "Id": 20,
+        "Name": "Regelmäßiger Auftrag des Lawinenwarndienstes",
         "Description": null
       },
       {
-        "Id": 55,
-        "Name": "Ausbildungstour",
+        "Id": 30,
+        "Name": "Außerordentlicher Auftrag des Lawinenwarnienstes",
+        "Description": null
+      },
+      {
+        "Id": 40,
+        "Name": "Im Auftrag des Lawinenwarndienstes",
         "Description": null
       },
       {
@@ -2765,18 +2872,18 @@
         "Description": null
       },
       {
-        "Id": 20,
-        "Name": "Wert nicht angegeben",
+        "Id": 55,
+        "Name": "Ausbildungstour",
         "Description": null
       },
       {
-        "Id": 30,
-        "Name": "Wert nicht angegeben",
+        "Id": 60,
+        "Name": "Privat",
         "Description": null
       },
       {
-        "Id": 40,
-        "Name": "Wert nicht angegeben",
+        "Id": 70,
+        "Name": "Geführte Tour",
         "Description": null
       }
     ],
@@ -2879,19 +2986,153 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Vom Administrator abgelehnt",
+        "Id": 52,
+        "Name": "Gelöscht von Admin",
         "Description": null
       },
       {
-        "Id": 52,
-        "Name": "Gelöscht von Admin",
+        "Id": 61,
+        "Name": "Vom Administrator abgelehnt",
         "Description": null
       },
       {
         "Id": 101,
         "Name": "Zu administrativen Zwecken",
         "Description": "Die Beobachtung einer zu einem Ausbildungszweck. Es wird so versteckt, als ob es gelöscht worden wäre."
+      }
+    ],
+    "RegistrationKDV": [
+      {
+        "Id": 10,
+        "Name": "Anmerkungen",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Ereignis",
+        "Description": null
+      },
+      {
+        "Id": 13,
+        "Name": "Gefahrenzeichen",
+        "Description": null
+      },
+      {
+        "Id": 14,
+        "Name": "Schaden",
+        "Description": "Gilt für alle Georisiken. Wird vorerst nur von Wasser verwendet."
+      },
+      {
+        "Id": 21,
+        "Name": "Wetter",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Schneedecke",
+        "Description": null
+      },
+      {
+        "Id": 25,
+        "Name": "Test",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Lawinenbeobachtung",
+        "Description": null
+      },
+      {
+        "Id": 31,
+        "Name": "Beurteilung der Lawinengefahr",
+        "Description": null
+      },
+      {
+        "Id": 32,
+        "Name": "Lawinenprobleme",
+        "Description": null
+      },
+      {
+        "Id": 33,
+        "Name": "Lawinenaktivität",
+        "Description": null
+      },
+      {
+        "Id": 36,
+        "Name": "Schneeprofil",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Eisdicke",
+        "Description": null
+      },
+      {
+        "Id": 51,
+        "Name": "Eisdecke",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Wasserpegel",
+        "Description": "neue Beobachtung des Wasserstandes für das Hochwasserdatenbankprojekt"
+      },
+      {
+        "Id": 71,
+        "Name": "Erdrutsch",
+        "Description": null
+      },
+      {
+        "Id": 80,
+        "Name": "Ereignisse",
+        "Description": null
+      },
+      {
+        "Id": 81,
+        "Name": "Lawinen und Gefahrenzeichen",
+        "Description": null
+      },
+      {
+        "Id": 82,
+        "Name": "Schneedecke und Wetter",
+        "Description": null
+      },
+      {
+        "Id": 83,
+        "Name": "Bewertungen und Probleme",
+        "Description": null
+      }
+    ],
+    "SourceKDV": [
+      {
+        "Id": 0,
+        "Name": "Keine Angabe",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Ich habe das gesehen",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Mir wurde das gesagt",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "In den Nachrichten / in einem Bericht gelesen",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Ich habe ein Bild/Webkamera gesehen",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "Assumed/simulated",
+        "Description": null
       }
     ]
   },
@@ -3045,6 +3286,183 @@
         "AvalancheExtTID": 25,
         "AvalCauseTID": 22
       }
-    ]
+    ],
+    "RegistrationTypesV": {
+      "10": [
+        {
+          "Id": 80,
+          "Name": "Ereignisse",
+          "SubTypes": [
+            {
+              "Id": 26,
+              "Name": "Lawinenbeobachtung",
+              "SortOrder": 12
+            },
+            {
+              "Id": 11,
+              "Name": "Ereignis",
+              "SortOrder": 97
+            }
+          ],
+          "SortOrder": 80
+        },
+        {
+          "Id": 81,
+          "Name": "Lawinen und Gefahrenzeichen",
+          "SubTypes": [
+            {
+              "Id": 13,
+              "Name": "Gefahrenzeichen",
+              "SortOrder": 10
+            },
+            {
+              "Id": 26,
+              "Name": "Lawinenbeobachtung",
+              "SortOrder": 12
+            },
+            {
+              "Id": 33,
+              "Name": "Lawinenaktivität",
+              "SortOrder": 13
+            }
+          ],
+          "SortOrder": 81
+        },
+        {
+          "Id": 82,
+          "Name": "Schneedecke und Wetter",
+          "SubTypes": [
+            {
+              "Id": 22,
+              "Name": "Schneedecke",
+              "SortOrder": 14
+            },
+            {
+              "Id": 21,
+              "Name": "Wetter",
+              "SortOrder": 14
+            },
+            {
+              "Id": 25,
+              "Name": "Test",
+              "SortOrder": 16
+            },
+            {
+              "Id": 36,
+              "Name": "Schneeprofil",
+              "SortOrder": 36
+            }
+          ],
+          "SortOrder": 82
+        },
+        {
+          "Id": 83,
+          "Name": "Bewertungen und Probleme",
+          "SubTypes": [
+            {
+              "Id": 32,
+              "Name": "Lawinenprobleme",
+              "SortOrder": 17
+            },
+            {
+              "Id": 31,
+              "Name": "Beurteilung der Lawinengefahr",
+              "SortOrder": 18
+            }
+          ],
+          "SortOrder": 83
+        },
+        {
+          "Id": 10,
+          "Name": "Anmerkungen",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "20": [
+        {
+          "Id": 13,
+          "Name": "Gefahrenzeichen",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 71,
+          "Name": "Erdrutsch",
+          "SubTypes": [],
+          "SortOrder": 71
+        },
+        {
+          "Id": 10,
+          "Name": "Anmerkungen",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "60": [
+        {
+          "Id": 13,
+          "Name": "Gefahrenzeichen",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 14,
+          "Name": "Schaden",
+          "SubTypes": [],
+          "SortOrder": 14
+        },
+        {
+          "Id": 62,
+          "Name": "Wasserpegel",
+          "SubTypes": [],
+          "SortOrder": 62
+        },
+        {
+          "Id": 11,
+          "Name": "Ereignis",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Anmerkungen",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "70": [
+        {
+          "Id": 51,
+          "Name": "Eisdecke",
+          "SubTypes": [],
+          "SortOrder": 7
+        },
+        {
+          "Id": 50,
+          "Name": "Eisdicke",
+          "SubTypes": [],
+          "SortOrder": 8
+        },
+        {
+          "Id": 13,
+          "Name": "Gefahrenzeichen",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 11,
+          "Name": "Ereignis",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Anmerkungen",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ]
+    }
   }
 }

--- a/src/assets/json/kdvelements.en.json
+++ b/src/assets/json/kdvelements.en.json
@@ -22,8 +22,13 @@
         "Description": null
       },
       {
-        "Id": 212,
-        "Name": "Snow cover with much water",
+        "Id": 204,
+        "Name": "Surface runoff",
+        "Description": null
+      },
+      {
+        "Id": 205,
+        "Name": "Insufficient drainage",
         "Description": null
       },
       {
@@ -37,26 +42,6 @@
         "Description": null
       },
       {
-        "Id": 230,
-        "Name": "Erosion along streams/rivers",
-        "Description": null
-      },
-      {
-        "Id": 214,
-        "Name": "Streams find new paths",
-        "Description": null
-      },
-      {
-        "Id": 204,
-        "Name": "Surface runoff",
-        "Description": null
-      },
-      {
-        "Id": 205,
-        "Name": "Insufficient drainage",
-        "Description": null
-      },
-      {
         "Id": 208,
         "Name": "Cracks/creep in terrain",
         "Description": null
@@ -67,6 +52,16 @@
         "Description": null
       },
       {
+        "Id": 212,
+        "Name": "Snow cover with much water",
+        "Description": null
+      },
+      {
+        "Id": 214,
+        "Name": "Streams find new paths",
+        "Description": null
+      },
+      {
         "Id": 222,
         "Name": "Movement at landslide scarp",
         "Description": null
@@ -74,6 +69,11 @@
       {
         "Id": 223,
         "Name": "Leaning trees",
+        "Description": null
+      },
+      {
+        "Id": 230,
+        "Name": "Erosion along streams/rivers",
         "Description": null
       },
       {
@@ -89,6 +89,11 @@
         "Description": null
       },
       {
+        "Id": 211,
+        "Name": "People",
+        "Description": null
+      },
+      {
         "Id": 220,
         "Name": "Roads",
         "Description": null
@@ -99,18 +104,13 @@
         "Description": null
       },
       {
-        "Id": 260,
-        "Name": "Buildings",
-        "Description": null
-      },
-      {
-        "Id": 211,
-        "Name": "People",
-        "Description": null
-      },
-      {
         "Id": 251,
         "Name": "Agricultural areas",
+        "Description": null
+      },
+      {
+        "Id": 260,
+        "Name": "Buildings",
         "Description": null
       },
       {
@@ -141,11 +141,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Small rock avalanche",
-        "Description": null
-      },
-      {
         "Id": 6,
         "Name": "Rock fall",
         "Description": null
@@ -163,6 +158,11 @@
       {
         "Id": 10,
         "Name": "Quick clay slide",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Small rock avalanche",
         "Description": null
       }
     ],
@@ -284,11 +284,6 @@
         "Description": null
       },
       {
-        "Id": 714,
-        "Name": "Ice fisher",
-        "Description": null
-      },
-      {
         "Id": 711,
         "Name": "Skating",
         "Description": null
@@ -304,8 +299,8 @@
         "Description": null
       },
       {
-        "Id": 719,
-        "Name": "Person injured by ice run",
+        "Id": 714,
+        "Name": "Ice fisher",
         "Description": null
       },
       {
@@ -324,9 +319,24 @@
         "Description": null
       },
       {
-        "Id": 725,
-        "Name": "Kicksledge",
+        "Id": 719,
+        "Name": "Person injured by ice run",
         "Description": null
+      },
+      {
+        "Id": 720,
+        "Name": "Snowmobiling on the ice",
+        "Description": null
+      },
+      {
+        "Id": 721,
+        "Name": "Car on ice",
+        "Description": null
+      },
+      {
+        "Id": 722,
+        "Name": "ATV",
+        "Description": "All Terrain Vehicle"
       },
       {
         "Id": 723,
@@ -339,18 +349,8 @@
         "Description": null
       },
       {
-        "Id": 720,
-        "Name": "Snowmobiling on the ice",
-        "Description": null
-      },
-      {
-        "Id": 722,
-        "Name": "ATV",
-        "Description": "All Terrain Vehicle"
-      },
-      {
-        "Id": 721,
-        "Name": "Car on ice",
+        "Id": 725,
+        "Name": "Kicksledge",
         "Description": null
       },
       {
@@ -389,6 +389,21 @@
         "Description": null
       },
       {
+        "Id": 775,
+        "Name": "Anchor ice dam",
+        "Description": null
+      },
+      {
+        "Id": 776,
+        "Name": "Frazil ice plugging",
+        "Description": "Frazil ice beneath the ice plugs the river."
+      },
+      {
+        "Id": 777,
+        "Name": "Ice jam",
+        "Description": null
+      },
+      {
         "Id": 790,
         "Name": "Other",
         "Description": null
@@ -406,11 +421,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Ice formation along shore",
-        "Description": null
-      },
-      {
         "Id": 2,
         "Name": "Partly ice covered at site",
         "Description": null
@@ -421,13 +431,13 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "Lake ice covered",
+        "Id": 10,
+        "Name": "Ice breaking up along shore",
         "Description": null
       },
       {
-        "Id": 10,
-        "Name": "Ice breaking up along shore",
+        "Id": 11,
+        "Name": "Ice formation along shore",
         "Description": null
       },
       {
@@ -436,13 +446,18 @@
         "Description": null
       },
       {
-        "Id": 41,
-        "Name": "Drifting frazil ice on river",
+        "Id": 21,
+        "Name": "Lake ice covered",
         "Description": null
       },
       {
         "Id": 40,
         "Name": "River ice run",
+        "Description": null
+      },
+      {
+        "Id": 41,
+        "Name": "Drifting frazil ice on river",
         "Description": null
       },
       {
@@ -458,14 +473,14 @@
         "Description": null
       },
       {
-        "Id": 2,
-        "Name": "No ice, now first ice at shore",
-        "Description": "No ice along the shore before today."
-      },
-      {
         "Id": 1,
         "Name": "No ice, now first ice at site",
         "Description": "No ice at site before today. There may have been ice along the shore. \"Site\" is generally a virtual point out on the lake away from the shore."
+      },
+      {
+        "Id": 2,
+        "Name": "No ice, now first ice at shore",
+        "Description": "No ice along the shore before today."
       },
       {
         "Id": 3,
@@ -479,7 +494,7 @@
       },
       {
         "Id": 99,
-        "Name": "Break - Unknown until today",
+        "Name": "Unknown previous ice cover",
         "Description": "Break in measurements. The ice cover from previous observation is probably not valid until yeaterday."
       }
     ],
@@ -607,7 +622,7 @@
       },
       {
         "Id": 20,
-        "Name": "Bulk ice",
+        "Name": "Aufeis (icings)",
         "Description": null
       },
       {
@@ -624,6 +639,11 @@
         "Id": 50,
         "Name": "Frazil ice clog in ice channel",
         "Description": null
+      },
+      {
+        "Id": 60,
+        "Name": "Ice fall",
+        "Description": "Ice falling from a rock/construction, or a glacier."
       },
       {
         "Id": 99,
@@ -653,11 +673,6 @@
         "Description": null
       },
       {
-        "Id": 4,
-        "Name": "Recent cracks",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "Large snowfall",
         "Description": "Brukes i elrapp"
@@ -678,6 +693,16 @@
         "Description": null
       },
       {
+        "Id": 14,
+        "Name": "Shooting cracks",
+        "Description": null
+      },
+      {
+        "Id": 15,
+        "Name": "Glide cracks",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Other danger sign (specify)",
         "Description": null
@@ -695,13 +720,13 @@
         "Description": null
       },
       {
-        "Id": 113,
-        "Name": "Skiresort, off-piste",
+        "Id": 112,
+        "Name": "Ski resort",
         "Description": null
       },
       {
-        "Id": 112,
-        "Name": "Ski resort",
+        "Id": 113,
+        "Name": "Skiresort, off-piste",
         "Description": null
       },
       {
@@ -725,13 +750,13 @@
         "Description": null
       },
       {
-        "Id": 130,
-        "Name": "Snowmobile",
+        "Id": 120,
+        "Name": "Road",
         "Description": null
       },
       {
-        "Id": 120,
-        "Name": "Road",
+        "Id": 130,
+        "Name": "Snowmobile",
         "Description": null
       },
       {
@@ -757,23 +782,23 @@
         "Description": null
       },
       {
-        "Id": 12,
-        "Name": "Dry loose-snow avalanche",
-        "Description": null
-      },
-      {
         "Id": 11,
         "Name": "Wet loose-snow avalanche",
         "Description": null
       },
       {
-        "Id": 22,
-        "Name": "Dry slab avalanche",
+        "Id": 12,
+        "Name": "Dry loose-snow avalanche",
         "Description": null
       },
       {
         "Id": 21,
         "Name": "Wet slab avalanche",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Dry slab avalanche",
         "Description": null
       },
       {
@@ -908,24 +933,24 @@
         "Description": "Faceted snow near the ground"
       },
       {
-        "Id": 19,
-        "Name": "Faceted snow beneath a crust",
-        "Description": "Faceted snow beneath a crust"
-      },
-      {
         "Id": 18,
         "Name": "Faceted snow above a crust",
         "Description": "Faceted snow above a crust"
       },
       {
-        "Id": 22,
-        "Name": "Water pooling above snow layers",
-        "Description": "Water pooling above snow layers"
+        "Id": 19,
+        "Name": "Faceted snow beneath a crust",
+        "Description": "Faceted snow beneath a crust"
       },
       {
         "Id": 20,
         "Name": "Melting near the ground",
         "Description": "Melting near the ground"
+      },
+      {
+        "Id": 22,
+        "Name": "Water pooling above snow layers",
+        "Description": "Water pooling above snow layers"
       },
       {
         "Id": 24,
@@ -1012,17 +1037,17 @@
       },
       {
         "Id": 1,
-        "Name": "Isolated steep slopes",
+        "Name": "Few steep slopes",
         "Description": null
       },
       {
         "Id": 2,
-        "Name": "Specific steep slopes",
+        "Name": "Some steep slopes",
         "Description": null
       },
       {
         "Id": 3,
-        "Name": "Widespread steep slopes",
+        "Name": "Many steep slopes",
         "Description": null
       }
     ],
@@ -1075,6 +1100,11 @@
         "Description": null
       },
       {
+        "Id": 22,
+        "Name": "Spontaneous release",
+        "Description": null
+      },
+      {
         "Id": 30,
         "Name": "Very difficult to trigger",
         "Description": null
@@ -1092,11 +1122,6 @@
       {
         "Id": 60,
         "Name": "Very easy to trigger",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "Spontaneous release",
         "Description": null
       }
     ],
@@ -1299,16 +1324,6 @@
         "Description": null
       },
       {
-        "Id": 26,
-        "Name": "Human triggered",
-        "Description": null
-      },
-      {
-        "Id": 27,
-        "Name": "Triggered by snowmobile",
-        "Description": null
-      },
-      {
         "Id": 22,
         "Name": "Remotely triggered",
         "Description": null
@@ -1321,6 +1336,16 @@
       {
         "Id": 25,
         "Name": "Released by explosives",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Human triggered",
+        "Description": null
+      },
+      {
+        "Id": 27,
+        "Name": "Triggered by snowmobile",
         "Description": null
       },
       {
@@ -1393,6 +1418,21 @@
         "Description": null
       },
       {
+        "Id": 50,
+        "Name": "Near surface facets",
+        "Description": null
+      },
+      {
+        "Id": 61,
+        "Name": "Surface hoar on a hard surface",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Surface hoar on a soft surface",
+        "Description": null
+      },
+      {
         "Id": 101,
         "Name": "Very much loose snow (>30cm)",
         "Description": null
@@ -1408,23 +1448,8 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Surface hoar on a hard surface",
-        "Description": null
-      },
-      {
-        "Id": 62,
-        "Name": "Surface hoar on a soft surface",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Near surface facets",
-        "Description": null
-      },
-      {
-        "Id": 107,
-        "Name": "Crust",
+        "Id": 104,
+        "Name": "Wet loose snow",
         "Description": null
       },
       {
@@ -1438,8 +1463,8 @@
         "Description": null
       },
       {
-        "Id": 104,
-        "Name": "Wet loose snow",
+        "Id": 107,
+        "Name": "Crust",
         "Description": null
       },
       {
@@ -1536,26 +1561,6 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "ECTPV",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "ECTP",
-        "Description": null
-      },
-      {
-        "Id": 23,
-        "Name": "ECTN",
-        "Description": null
-      },
-      {
-        "Id": 24,
-        "Name": "ECTX",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "LBT",
         "Description": null
@@ -1583,6 +1588,26 @@
       {
         "Id": 15,
         "Name": "CTN",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "ECTPV",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "ECTP",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "ECTN",
+        "Description": null
+      },
+      {
+        "Id": 24,
+        "Name": "ECTX",
         "Description": null
       }
     ],
@@ -2009,6 +2034,38 @@
         "Description": null
       }
     ],
+    "Snow_SkiConditionsKDV": [
+      {
+        "Id": 0,
+        "Name": "Not given",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Bad",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Ok",
+        "Description": null
+      },
+      {
+        "Id": 30,
+        "Name": "Good",
+        "Description": null
+      },
+      {
+        "Id": 40,
+        "Name": "Very Good",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Perfect",
+        "Description": null
+      }
+    ],
     "Water_DangerSignKDV": [
       {
         "Id": 600,
@@ -2022,17 +2079,17 @@
       },
       {
         "Id": 611,
-        "Name": "Blocked waterway due to ice",
+        "Name": "Blocked gutters due to ice",
         "Description": null
       },
       {
         "Id": 612,
-        "Name": "Waterway clogged by sediments",
+        "Name": "Gutters clogged by sediments",
         "Description": null
       },
       {
         "Id": 621,
-        "Name": "Moderat raise of water level",
+        "Name": "Moderate raise of water level",
         "Description": null
       },
       {
@@ -2514,13 +2571,13 @@
         "Description": null
       },
       {
-        "Id": 25,
-        "Name": "Evacuation",
+        "Id": 20,
+        "Name": "Only material damage",
         "Description": null
       },
       {
-        "Id": 20,
-        "Name": "Only material damage",
+        "Id": 25,
+        "Name": "Evacuation",
         "Description": null
       },
       {
@@ -2561,6 +2618,11 @@
         "Description": "Unknown for snow."
       },
       {
+        "Id": 105,
+        "Name": "A",
+        "Description": "Automatic service"
+      },
+      {
         "Id": 110,
         "Name": "*",
         "Description": "The observer has basic skills to assess avalanche danger. The observer is not educated in how regObs and Varsom communicates avalanche danger."
@@ -2584,11 +2646,6 @@
         "Id": 150,
         "Name": "*****",
         "Description": "Observer is an avalanche forecaster."
-      },
-      {
-        "Id": 105,
-        "Name": "A",
-        "Description": "Automatic service"
       },
       {
         "Id": 200,
@@ -2738,7 +2795,7 @@
       {
         "Id": 750,
         "Name": "*****",
-        "Description": "Educated personel in NVE or eqivalent."
+        "Description": "Educated personnel in NVE or equivalent."
       }
     ],
     "UTMSourceKDV": [
@@ -2795,13 +2852,18 @@
         "Description": null
       },
       {
-        "Id": 60,
-        "Name": "Private",
+        "Id": 20,
+        "Name": "Regular task for avalanche warning service",
         "Description": null
       },
       {
-        "Id": 55,
-        "Name": "Education trip",
+        "Id": 30,
+        "Name": "Extraordninary task for avalanche warning service",
+        "Description": null
+      },
+      {
+        "Id": 40,
+        "Name": "Ordered task for avalanche warning service",
         "Description": null
       },
       {
@@ -2810,18 +2872,18 @@
         "Description": null
       },
       {
-        "Id": 20,
-        "Name": "Value not given",
+        "Id": 55,
+        "Name": "Education and course",
         "Description": null
       },
       {
-        "Id": 30,
-        "Name": "Value not given",
+        "Id": 60,
+        "Name": "Private trip",
         "Description": null
       },
       {
-        "Id": 40,
-        "Name": "Value not given",
+        "Id": 70,
+        "Name": "Guided trip",
         "Description": null
       }
     ],
@@ -2924,19 +2986,153 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Disapproved by data admin",
+        "Id": 52,
+        "Name": "Deleted by admin",
         "Description": null
       },
       {
-        "Id": 52,
-        "Name": "Deleted by admin",
+        "Id": 61,
+        "Name": "Disapproved by data admin",
         "Description": null
       },
       {
         "Id": 101,
         "Name": "For administarive purpose",
         "Description": "The observation or group has an administrative purpose. It is elswize hidden as though it has been deleted."
+      }
+    ],
+    "RegistrationKDV": [
+      {
+        "Id": 10,
+        "Name": "Notes",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Incident",
+        "Description": null
+      },
+      {
+        "Id": 13,
+        "Name": "Danger Sign",
+        "Description": null
+      },
+      {
+        "Id": 14,
+        "Name": "Damages",
+        "Description": "Gjelder alle geohazard. Brukes kun av vann foreløpig."
+      },
+      {
+        "Id": 21,
+        "Name": "Weather",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Snow Cover",
+        "Description": null
+      },
+      {
+        "Id": 25,
+        "Name": "Tests",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Avalanche Observation",
+        "Description": null
+      },
+      {
+        "Id": 31,
+        "Name": "Avalanche Danger Assessment",
+        "Description": null
+      },
+      {
+        "Id": 32,
+        "Name": "Avalanche Problems",
+        "Description": null
+      },
+      {
+        "Id": 33,
+        "Name": "Avalanche Activity",
+        "Description": null
+      },
+      {
+        "Id": 36,
+        "Name": "Snow Profile",
+        "Description": "SnowProfile top-node"
+      },
+      {
+        "Id": 50,
+        "Name": "Ice Thickness",
+        "Description": null
+      },
+      {
+        "Id": 51,
+        "Name": "Ice Cover",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Water Level",
+        "Description": "new waterlevel observation for flood database project"
+      },
+      {
+        "Id": 71,
+        "Name": "Landslide",
+        "Description": null
+      },
+      {
+        "Id": 80,
+        "Name": "Incidents",
+        "Description": "Grupperings type - Hendelser"
+      },
+      {
+        "Id": 81,
+        "Name": "Avalanches and Danger Signs",
+        "Description": "Grupperings type - Skred og faretegn"
+      },
+      {
+        "Id": 82,
+        "Name": "Snow Cover and Weather",
+        "Description": "Grupperings type - Snødekke og vær"
+      },
+      {
+        "Id": 83,
+        "Name": "Evaluations and Problems",
+        "Description": "Grupperings type - Vurderinger og problemer"
+      }
+    ],
+    "SourceKDV": [
+      {
+        "Id": 0,
+        "Name": "Not given",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Have seen this myself",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Have been told",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "Read in news/report",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Seen picture/webcam/satellite",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "Assumed/simulated",
+        "Description": null
       }
     ]
   },
@@ -3090,6 +3286,183 @@
         "AvalancheExtTID": 25,
         "AvalCauseTID": 22
       }
-    ]
+    ],
+    "RegistrationTypesV": {
+      "10": [
+        {
+          "Id": 80,
+          "Name": "Incidents",
+          "SubTypes": [
+            {
+              "Id": 26,
+              "Name": "Avalanche Observation",
+              "SortOrder": 12
+            },
+            {
+              "Id": 11,
+              "Name": "Incident",
+              "SortOrder": 97
+            }
+          ],
+          "SortOrder": 80
+        },
+        {
+          "Id": 81,
+          "Name": "Avalanches and Danger Signs",
+          "SubTypes": [
+            {
+              "Id": 13,
+              "Name": "Danger Sign",
+              "SortOrder": 10
+            },
+            {
+              "Id": 26,
+              "Name": "Avalanche Observation",
+              "SortOrder": 12
+            },
+            {
+              "Id": 33,
+              "Name": "Avalanche Activity",
+              "SortOrder": 13
+            }
+          ],
+          "SortOrder": 81
+        },
+        {
+          "Id": 82,
+          "Name": "Snow Cover and Weather",
+          "SubTypes": [
+            {
+              "Id": 21,
+              "Name": "Weather",
+              "SortOrder": 14
+            },
+            {
+              "Id": 22,
+              "Name": "Snow Cover",
+              "SortOrder": 14
+            },
+            {
+              "Id": 25,
+              "Name": "Tests",
+              "SortOrder": 16
+            },
+            {
+              "Id": 36,
+              "Name": "Snow Profile",
+              "SortOrder": 36
+            }
+          ],
+          "SortOrder": 82
+        },
+        {
+          "Id": 83,
+          "Name": "Evaluations and Problems",
+          "SubTypes": [
+            {
+              "Id": 32,
+              "Name": "Avalanche Problems",
+              "SortOrder": 17
+            },
+            {
+              "Id": 31,
+              "Name": "Avalanche Danger Assessment",
+              "SortOrder": 18
+            }
+          ],
+          "SortOrder": 83
+        },
+        {
+          "Id": 10,
+          "Name": "Notes",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "20": [
+        {
+          "Id": 13,
+          "Name": "Danger Sign",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 71,
+          "Name": "Landslide",
+          "SubTypes": [],
+          "SortOrder": 71
+        },
+        {
+          "Id": 10,
+          "Name": "Notes",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "60": [
+        {
+          "Id": 13,
+          "Name": "Danger Sign",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 14,
+          "Name": "Damages",
+          "SubTypes": [],
+          "SortOrder": 14
+        },
+        {
+          "Id": 62,
+          "Name": "Water Level",
+          "SubTypes": [],
+          "SortOrder": 62
+        },
+        {
+          "Id": 11,
+          "Name": "Incident",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Notes",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "70": [
+        {
+          "Id": 51,
+          "Name": "Ice Cover",
+          "SubTypes": [],
+          "SortOrder": 7
+        },
+        {
+          "Id": 50,
+          "Name": "Ice Thickness",
+          "SubTypes": [],
+          "SortOrder": 8
+        },
+        {
+          "Id": 13,
+          "Name": "Danger Sign",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 11,
+          "Name": "Incident",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Notes",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ]
+    }
   }
 }

--- a/src/assets/json/kdvelements.fr.json
+++ b/src/assets/json/kdvelements.fr.json
@@ -1,0 +1,3468 @@
+{
+    "KdvRepositories": {
+        "Dirt_DangerSignKDV": [
+            {
+                "Id": 200,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 201,
+                "Name": "Aucune obs d'instabilité",
+                "Description": null
+            },
+            {
+                "Id": 202,
+                "Name": "Fortes pluies",
+                "Description": null
+            },
+            {
+                "Id": 203,
+                "Name": "Importante fonte des neiges",
+                "Description": null
+            },
+            {
+                "Id": 204,
+                "Name": "Ruissellement en surface",
+                "Description": null
+            },
+            {
+                "Id": 205,
+                "Name": "Drainage insuffisant",
+                "Description": null
+            },
+            {
+                "Id": 206,
+                "Name": "Débit élevé des cours d'eau",
+                "Description": null
+            },
+            {
+                "Id": 207,
+                "Name": "Cours d'eau de couleur marron",
+                "Description": null
+            },
+            {
+                "Id": 208,
+                "Name": "Fissures/fluage du terrain",
+                "Description": null
+            },
+            {
+                "Id": 209,
+                "Name": "Glissement de terrain observé",
+                "Description": null
+            },
+            {
+                "Id": 212,
+                "Name": "Manteau neigeux gorgé d'eau",
+                "Description": null
+            },
+            {
+                "Id": 214,
+                "Name": "Avulsion (nouveau tracé)",
+                "Description": null
+            },
+            {
+                "Id": 222,
+                "Name": "Mouvement à l'escarpement",
+                "Description": null
+            },
+            {
+                "Id": 223,
+                "Name": "Arbres inclinés",
+                "Description": null
+            },
+            {
+                "Id": 230,
+                "Name": "Érosion le long des rivières",
+                "Description": null
+            },
+            {
+                "Id": 299,
+                "Name": "Autre signes d'instabilité",
+                "Description": null
+            }
+        ],
+        "Dirt_ActivityInfluencedKDV": [
+            {
+                "Id": 200,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 211,
+                "Name": "Personnes",
+                "Description": null
+            },
+            {
+                "Id": 220,
+                "Name": "Routes",
+                "Description": null
+            },
+            {
+                "Id": 240,
+                "Name": "Chemins de fer",
+                "Description": null
+            },
+            {
+                "Id": 251,
+                "Name": "Zones agricoles",
+                "Description": null
+            },
+            {
+                "Id": 260,
+                "Name": "Bâtiments",
+                "Description": null
+            },
+            {
+                "Id": 290,
+                "Name": "Autre",
+                "Description": null
+            }
+        ],
+        "Dirt_LandSlideKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Glissmt de terrain superficiel",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Avalanche de débris",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Lave torrentielle",
+                "Description": null
+            },
+            {
+                "Id": 6,
+                "Name": "Chute de blocs",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "Avalanche de neige mouillée",
+                "Description": null
+            },
+            {
+                "Id": 8,
+                "Name": "Glissement dans les argiles",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Glissement d'argile rapide",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "Petite avalanche de roches",
+                "Description": null
+            }
+        ],
+        "Dirt_LandSlideTriggerKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Départ spontané",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Fouilles dans la zone",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Problèmes de drainage",
+                "Description": null
+            },
+            {
+                "Id": 9,
+                "Name": "Autre (préciser)",
+                "Description": null
+            }
+        ],
+        "Dirt_LandSlideSizeKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "< 100 m3",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "100 à 10 000 m3",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "> 10000 m3",
+                "Description": null
+            },
+            {
+                "Id": 9,
+                "Name": "Autre (veuillez préciser)",
+                "Description": null
+            }
+        ],
+        "Ice_DangerSignKDV": [
+            {
+                "Id": 700,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 701,
+                "Name": "Aucune obs d'instabilité",
+                "Description": null
+            },
+            {
+                "Id": 705,
+                "Name": "Faible épaisseur de glace",
+                "Description": null
+            },
+            {
+                "Id": 711,
+                "Name": "Glace libérée des côtes/ rives",
+                "Description": null
+            },
+            {
+                "Id": 712,
+                "Name": "Arrivée d'eau libre de glace",
+                "Description": null
+            },
+            {
+                "Id": 713,
+                "Name": "Exutoire libre de glace",
+                "Description": null
+            },
+            {
+                "Id": 714,
+                "Name": "Grandes fissures ou canaux",
+                "Description": null
+            },
+            {
+                "Id": 720,
+                "Name": "Glace fortement inondée",
+                "Description": null
+            },
+            {
+                "Id": 730,
+                "Name": "Augmentation du débit",
+                "Description": null
+            },
+            {
+                "Id": 799,
+                "Name": "Autre (préciser)",
+                "Description": null
+            }
+        ],
+        "Ice_ActivityInfluencedKDV": [
+            {
+                "Id": 700,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 710,
+                "Name": "À pied",
+                "Description": null
+            },
+            {
+                "Id": 711,
+                "Name": "Patins à glace",
+                "Description": null
+            },
+            {
+                "Id": 712,
+                "Name": "Ski de fond",
+                "Description": null
+            },
+            {
+                "Id": 713,
+                "Name": "Ski-kite (ski/surf à voile)",
+                "Description": null
+            },
+            {
+                "Id": 714,
+                "Name": "Pêche sur glace",
+                "Description": null
+            },
+            {
+                "Id": 715,
+                "Name": "Équitation/Impliquant 1 cheval",
+                "Description": null
+            },
+            {
+                "Id": 716,
+                "Name": "Traîneau à chiens",
+                "Description": null
+            },
+            {
+                "Id": 717,
+                "Name": "Sauvetage d'animaux",
+                "Description": null
+            },
+            {
+                "Id": 719,
+                "Name": "Personne blessée par la glace",
+                "Description": null
+            },
+            {
+                "Id": 720,
+                "Name": "Motoneige sur la glace",
+                "Description": null
+            },
+            {
+                "Id": 721,
+                "Name": "Voiture sur la glace",
+                "Description": null
+            },
+            {
+                "Id": 722,
+                "Name": "Véhicule 4x4",
+                "Description": "Véhicule 4x4"
+            },
+            {
+                "Id": 723,
+                "Name": "Vélo",
+                "Description": null
+            },
+            {
+                "Id": 724,
+                "Name": "Moto",
+                "Description": null
+            },
+            {
+                "Id": 725,
+                "Name": "Traineau scandinave",
+                "Description": null
+            },
+            {
+                "Id": 730,
+                "Name": "Tracteur sur la glace",
+                "Description": null
+            },
+            {
+                "Id": 731,
+                "Name": "Camion / engin sur la glace",
+                "Description": null
+            },
+            {
+                "Id": 732,
+                "Name": "Dameuse",
+                "Description": null
+            },
+            {
+                "Id": 735,
+                "Name": "Avion/ hélicoptère",
+                "Description": null
+            },
+            {
+                "Id": 772,
+                "Name": "Course de glace",
+                "Description": null
+            },
+            {
+                "Id": 773,
+                "Name": "Aufeis - glace formée/ couches",
+                "Description": null
+            },
+            {
+                "Id": 774,
+                "Name": "Glace à la dérive",
+                "Description": null
+            },
+            {
+                "Id": 775,
+                "Name": "Barrage de glace de fond",
+                "Description": null
+            },
+            {
+                "Id": 776,
+                "Name": "Bouchon de frasil",
+                "Description": null
+            },
+            {
+                "Id": 777,
+                "Name": "dérive de glace",
+                "Description": null
+            },
+            {
+                "Id": 790,
+                "Name": "Autres",
+                "Description": null
+            }
+        ],
+        "Ice_IceCoverKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Pas de glace",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Partiellement couvert de glace",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "En glace par endroit",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Glace cassante sur les rives",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "Glace sur le long du rivage",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Pas de glace sur les lacs",
+                "Description": null
+            },
+            {
+                "Id": 21,
+                "Name": "Lac couvert de glace",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Débâcle (rivière)",
+                "Description": null
+            },
+            {
+                "Id": 41,
+                "Name": "Aiguilles de glace à la dérive",
+                "Description": null
+            },
+            {
+                "Id": 99,
+                "Name": "Inconnu",
+                "Description": null
+            }
+        ],
+        "Ice_IceCoverBeforeKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "1ères glaces loin du rivage",
+                "Description": "Pas de glace sur le site de mesure avant aujourd'hui, même s'il a pu y avoir de la glace sur les rives. Le \"site\" est un point virtuel du lac, situé loin des rives du lac."
+            },
+            {
+                "Id": 2,
+                "Name": "Première glace sur les rivages",
+                "Description": "Pas de glace le long de la côte avant aujourd'hui."
+            },
+            {
+                "Id": 3,
+                "Name": "Pas encore de glace ce jour",
+                "Description": "Pas de glace cet hiver, pas même aujourd’hui."
+            },
+            {
+                "Id": 10,
+                "Name": "Dernière observation valide",
+                "Description": "Observations faites en continu. Nous pouvons supposer que la couverture de glace de l'observation précédente est valable jusqu'à hier. Aujourd'hui, c'est une nouvelle valeur (ou la même couverture de glace)"
+            },
+            {
+                "Id": 99,
+                "Name": "Glace : état antérieur inconnu",
+                "Description": "Interruption des mesures. L'état de la glace des dernières observations n'est probablement pas valable jusqu'à hier."
+            }
+        ],
+        "Ice_IceLayerKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Glace noire",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Glace",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "Mélange eau/glace (slush)",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "probablement glace+glace noire",
+                "Description": null
+            },
+            {
+                "Id": 9,
+                "Name": "Cristaux de glace dans l'eau",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "Glace noire décroissant",
+                "Description": null
+            },
+            {
+                "Id": 13,
+                "Name": "Glace décroissant",
+                "Description": null
+            },
+            {
+                "Id": 14,
+                "Name": "Glace colonnaire (printemps)",
+                "Description": null
+            },
+            {
+                "Id": 99,
+                "Name": "Autre (veuillez préciser)",
+                "Description": null
+            }
+        ],
+        "Ice_IceSkateabilityKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "à ne pas patiner",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Douteux à patiner",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Normal à patiner",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Très bon à patiner",
+                "Description": null
+            },
+            {
+                "Id": 50,
+                "Name": "Excellentissime à patiner",
+                "Description": null
+            }
+        ],
+        "Ice_IceCapacityKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Faible risq de passer à traver",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Danger de passer à travers",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Fort risq. de passer à travers",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Glace portante pour 1 personne",
+                "Description": null
+            }
+        ],
+        "Ice_IceProblemKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Embâcle/ dérive de glace",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Formations de glace (Aufeis)",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Barrage de glace de fond",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Frasil obstruant les grilles",
+                "Description": null
+            },
+            {
+                "Id": 50,
+                "Name": "Engorgement de frazil",
+                "Description": null
+            },
+            {
+                "Id": 60,
+                "Name": "Ice fall",
+                "Description": "English expression"
+            },
+            {
+                "Id": 99,
+                "Name": "Autre(utiliser le commentaire)",
+                "Description": null
+            }
+        ],
+        "Snow_DangerSignKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Aucune obs d'instabilité",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Avalanches récentes",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Whoumpf(s) entendu(s)",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "Importantes chutes de neige",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "Température : variation rapide",
+                "Description": null
+            },
+            {
+                "Id": 8,
+                "Name": "Beaucoup d'eau dans la neige",
+                "Description": null
+            },
+            {
+                "Id": 9,
+                "Name": "Jeune accumulation due au vent",
+                "Description": null
+            },
+            {
+                "Id": 14,
+                "Name": "Fissures",
+                "Description": null
+            },
+            {
+                "Id": 15,
+                "Name": "Fissures de glissement",
+                "Description": null
+            },
+            {
+                "Id": 99,
+                "Name": "Autre signe d'instabilité",
+                "Description": null
+            }
+        ],
+        "Snow_ActivityInfluencedKDV": [
+            {
+                "Id": 100,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 111,
+                "Name": "Ski de randonnée",
+                "Description": null
+            },
+            {
+                "Id": 112,
+                "Name": "Domaine skiable",
+                "Description": null
+            },
+            {
+                "Id": 113,
+                "Name": "Hors-piste en domaine skiable",
+                "Description": null
+            },
+            {
+                "Id": 114,
+                "Name": "Ski nordique",
+                "Description": null
+            },
+            {
+                "Id": 115,
+                "Name": "Ski de fond",
+                "Description": null
+            },
+            {
+                "Id": 116,
+                "Name": "Escalade",
+                "Description": null
+            },
+            {
+                "Id": 117,
+                "Name": "À pied",
+                "Description": null
+            },
+            {
+                "Id": 120,
+                "Name": "Route",
+                "Description": null
+            },
+            {
+                "Id": 130,
+                "Name": "Motoneige",
+                "Description": null
+            },
+            {
+                "Id": 140,
+                "Name": "Chemin de fer",
+                "Description": null
+            },
+            {
+                "Id": 160,
+                "Name": "Bâtiment",
+                "Description": null
+            },
+            {
+                "Id": 190,
+                "Name": "Autre",
+                "Description": null
+            }
+        ],
+        "Snow_AvalancheKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "Avalanche de neige humide",
+                "Description": null
+            },
+            {
+                "Id": 12,
+                "Name": "Avalanche de neige sèche",
+                "Description": null
+            },
+            {
+                "Id": 21,
+                "Name": "Avalanche de plaque humide",
+                "Description": null
+            },
+            {
+                "Id": 22,
+                "Name": "Avalanche de plaque sèche",
+                "Description": null
+            },
+            {
+                "Id": 27,
+                "Name": "Avalanche de glissement",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Avalanche de slush",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Chute de corniche",
+                "Description": null
+            },
+            {
+                "Id": 99,
+                "Name": "Inconnu",
+                "Description": null
+            }
+        ],
+        "Snow_AvalancheDangerKDV": [
+            {
+                "Id": 0,
+                "Name": "0 Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "1 Faible",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "2 Limité",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "3 Marqué",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "4 Fort",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "5 Très fort",
+                "Description": null
+            }
+        ],
+        "Snow_AvalancheExtKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Avalanche de neige sèche sans cohésion",
+                "Description": null
+            },
+            {
+                "Id": 15,
+                "Name": "Avalanche de neige humide",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Avalanche de plaque sèche",
+                "Description": null
+            },
+            {
+                "Id": 25,
+                "Name": "Avalanche de plaque humide",
+                "Description": null
+            },
+            {
+                "Id": 27,
+                "Name": "Avalanche de glissement",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Avalanche de neige très mouillée (slush)",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Corniche",
+                "Description": null
+            }
+        ],
+        "Snow_AvalCauseKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": "Non renseigné"
+            },
+            {
+                "Id": 10,
+                "Name": "Couche fragile de neige fraîche/récente",
+                "Description": "Couche fragile de neige fraîche/récente"
+            },
+            {
+                "Id": 11,
+                "Name": "Couche fragile de givre de surface",
+                "Description": "Couche fragile de givre de surface"
+            },
+            {
+                "Id": 13,
+                "Name": "Couche fragile de grains anguleux",
+                "Description": "Couche fragile de grains anguleux"
+            },
+            {
+                "Id": 14,
+                "Name": "Mauvaise adhérence avec la croûte",
+                "Description": "Mauvaise adhérence avec la croûte"
+            },
+            {
+                "Id": 15,
+                "Name": "Faible cohésion entre les différentes couches de neige ventée",
+                "Description": "Faible cohésion entre les différentes couches de neige ventée"
+            },
+            {
+                "Id": 16,
+                "Name": "Couche de grains anguleux enfouie près du sol",
+                "Description": "Couche de grains anguleux enfouie près du sol"
+            },
+            {
+                "Id": 18,
+                "Name": "Grains anguleux au-dessus d'une croûte",
+                "Description": "Grains anguleux au-dessus d'une croûte"
+            },
+            {
+                "Id": 19,
+                "Name": "Couche de grains anguleux enfouie sous une croûte",
+                "Description": "Couche de grains anguleux enfouie sous une croûte"
+            },
+            {
+                "Id": 20,
+                "Name": "Fonte près du sol",
+                "Description": "Fonte près du sol"
+            },
+            {
+                "Id": 22,
+                "Name": "Accumulation d'eau au-dessus de couches de neige",
+                "Description": "Accumulation d'eau au-dessus de couches de neige"
+            },
+            {
+                "Id": 24,
+                "Name": "Neige sans cohésion",
+                "Description": "Neige sans cohésion"
+            }
+        ],
+        "Snow_AvalCauseDepthKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "À moins d'un demi-mètre",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "À moins d'un mètre",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "À plus (+) d'un mètre",
+                "Description": null
+            }
+        ],
+        "Snow_AvalCauseAttributeFlags": [
+            {
+                "Id": 1,
+                "Name": "La couche fragile s'effondre facilement et proprement (propagation facile).",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "La couche fragile qui s'effondre est fine < 3 cm.",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "La plaque sus-jacente est friable (aspect poudreux)",
+                "Description": null
+            },
+            {
+                "Id": 8,
+                "Name": "Identification aisée et grande taille des grains de la couche fragile",
+                "Description": null
+            }
+        ],
+        "Snow_AvalProbabilityKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Peu probable",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Possible",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "Probable",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "Très probable",
+                "Description": null
+            }
+        ],
+        "Snow_AvalPropagationKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Rares pentes raides localisées",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Pentes raides spécifiques",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Pentes raides généralisées",
+                "Description": null
+            }
+        ],
+        "Snow_AvalReleaseHeightKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Dans la neige récente",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Entre ancienne&nouvelle neige",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Au niveau du sol",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Dans la vieille neige",
+                "Description": null
+            },
+            {
+                "Id": 6,
+                "Name": "Manteau neigeux humide",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "Manteau neigeux saturé en eau",
+                "Description": null
+            },
+            {
+                "Id": 8,
+                "Name": "Uniquement dans vieille neige",
+                "Description": null
+            }
+        ],
+        "Snow_AvalTriggerSimpleKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 22,
+                "Name": "Départ spontané",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Très difficile à déclencher",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Difficile à déclencher",
+                "Description": null
+            },
+            {
+                "Id": 50,
+                "Name": "Facile à déclencher",
+                "Description": null
+            },
+            {
+                "Id": 60,
+                "Name": "Très facile à déclencher",
+                "Description": null
+            }
+        ],
+        "Snow_DestructiveSizeKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "1 - Coulée",
+                "Description": "Ensevelissement peu probable (mais risque de chute)"
+            },
+            {
+                "Id": 2,
+                "Name": "2 - Avalanche moyenne",
+                "Description": "Peut ensevelir, blesser ou tuer une personne"
+            },
+            {
+                "Id": 3,
+                "Name": "3 - Grande avalanche",
+                "Description": "Peut emporter et détruire une voiture, endommager un camion, détraire un petit bâtiments ou casser quelques arbres"
+            },
+            {
+                "Id": 4,
+                "Name": "4- Très grande avalanche",
+                "Description": "Peut emporter et détruire un wagon de train, un camion, plusieurs bâtiments ou une partie de forêt"
+            },
+            {
+                "Id": 5,
+                "Name": "5 -D'ampleur exceptionnelle",
+                "Description": "Peut défigurer le paysage ; important potentiel de destruction"
+            },
+            {
+                "Id": 9,
+                "Name": "Inconnu",
+                "Description": null
+            }
+        ],
+        "Snow_SnowDriftKDV": [
+            {
+                "Id": 0,
+                "Name": "Non observé",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Pas de transport par le vent",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Un peu de transport / le vent",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Du transport de neige/ le vent",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Fort transport par le vent",
+                "Description": null
+            }
+        ],
+        "Snow_EstimatedNumKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Pas d'activité avalancheuse",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Une (1)",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Peu (2 à 5)",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Plusieurs (6 à 10)",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "Nombreuses (10 ou plus)",
+                "Description": null
+            }
+        ],
+        "Snow_ExposedHeightComboKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Bottom white",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Bottom black",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Middle white",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Middle black",
+                "Description": null
+            }
+        ],
+        "Snow_ForecastCorrectKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Prévisions correctes",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Prévisions trop faibles",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Prévisions trop élevées",
+                "Description": null
+            }
+        ],
+        "Snow_PrecipitationKDV": [
+            {
+                "Id": 0,
+                "Name": "Pas observé",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Pas de précipitation",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Bruine",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Pluie",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Grésil",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "Neige",
+                "Description": null
+            },
+            {
+                "Id": 6,
+                "Name": "Grêle",
+                "Description": null
+            },
+            {
+                "Id": 8,
+                "Name": "Pluie verglaçante",
+                "Description": null
+            }
+        ],
+        "Snow_AvalancheTriggerKDV": [
+            {
+                "Id": 0,
+                "Name": "Non renseigné",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Départ spontané",
+                "Description": null
+            },
+            {
+                "Id": 22,
+                "Name": "Déclenchement à distance",
+                "Description": null
+            },
+            {
+                "Id": 23,
+                "Name": "Test à ski positif de la pente",
+                "Description": null
+            },
+            {
+                "Id": 25,
+                "Name": "Déclenchement par explosifs",
+                "Description": null
+            },
+            {
+                "Id": 26,
+                "Name": "Déclenchement humain",
+                "Description": null
+            },
+            {
+                "Id": 27,
+                "Name": "Déclenchement par motoneige",
+                "Description": null
+            },
+            {
+                "Id": 99,
+                "Name": "Inconnu",
+                "Description": null
+            }
+        ],
+        "Snow_TerrainStartZoneKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Pente raide",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Sous le vent",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Près des crêtes",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Couloir ou forme concave",
+                "Description": null
+            },
+            {
+                "Id": 50,
+                "Name": "Plaque",
+                "Description": null
+            },
+            {
+                "Id": 60,
+                "Name": "Cuvette",
+                "Description": null
+            },
+            {
+                "Id": 70,
+                "Name": "Forêt",
+                "Description": null
+            },
+            {
+                "Id": 75,
+                "Name": "Zone d'exploitation forestière",
+                "Description": null
+            },
+            {
+                "Id": 95,
+                "Name": "Partout",
+                "Description": null
+            },
+            {
+                "Id": 99,
+                "Name": "Inconnu",
+                "Description": null
+            }
+        ],
+        "Snow_SnowSurfaceKDV": [
+            {
+                "Id": 0,
+                "Name": "Non observé",
+                "Description": null
+            },
+            {
+                "Id": 50,
+                "Name": "Grains facettés proches de la surface",
+                "Description": null
+            },
+            {
+                "Id": 61,
+                "Name": "Givre de surface reposant sur une surface dure",
+                "Description": null
+            },
+            {
+                "Id": 62,
+                "Name": "Givre de surface reposant sur une surface molle",
+                "Description": null
+            },
+            {
+                "Id": 101,
+                "Name": "Quantité importante de neige fraîche (> 30 cm)",
+                "Description": null
+            },
+            {
+                "Id": 102,
+                "Name": "Neige fraîche ( 10 à 30 cm)",
+                "Description": null
+            },
+            {
+                "Id": 103,
+                "Name": "Peu de neige fraîche ( 1 à 10 cm)",
+                "Description": null
+            },
+            {
+                "Id": 104,
+                "Name": "Neige humide",
+                "Description": null
+            },
+            {
+                "Id": 105,
+                "Name": "Plaque dure",
+                "Description": null
+            },
+            {
+                "Id": 106,
+                "Name": "Plaque friable (d'aspect poudreux)",
+                "Description": null
+            },
+            {
+                "Id": 107,
+                "Name": "Croûte",
+                "Description": null
+            },
+            {
+                "Id": 108,
+                "Name": "Autre",
+                "Description": null
+            }
+        ],
+        "Snow_SurfaceWaterContentKDV": [
+            {
+                "Id": 0,
+                "Name": "Non observé",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Pas de neige",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Sèche",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Humide",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Mouillée",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "Très mouillée",
+                "Description": null
+            },
+            {
+                "Id": 6,
+                "Name": "Neige fondue (slush)",
+                "Description": null
+            }
+        ],
+        "Snow_StabilityEvalKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Bonne stabilité",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Stabilité moyenne",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Mauvaise stabilité",
+                "Description": null
+            }
+        ],
+        "Snow_ComprTestFractureKDV": [
+            {
+                "Id": 0,
+                "Name": "Non spécifié",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Q1 (rupture lisse et rapide)",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Q2 (rupture intermédiaire)",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Q3 ( rupture irrégulière)",
+                "Description": null
+            }
+        ],
+        "Snow_PropagationKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "LBT",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "CTV- Effondrement à la découpe",
+                "Description": null
+            },
+            {
+                "Id": 12,
+                "Name": "CTE - Série poignet 1 à 10",
+                "Description": null
+            },
+            {
+                "Id": 13,
+                "Name": "CTM - Série coude 11 à 20",
+                "Description": null
+            },
+            {
+                "Id": 14,
+                "Name": "CTH - Série épaule 21 à 30",
+                "Description": null
+            },
+            {
+                "Id": 15,
+                "Name": "CTN - Négatif pas de fracture",
+                "Description": null
+            },
+            {
+                "Id": 21,
+                "Name": "ECTPV-Propag. tot à la découpe",
+                "Description": null
+            },
+            {
+                "Id": 22,
+                "Name": "ECTP-Propagation tot. à n coup",
+                "Description": null
+            },
+            {
+                "Id": 23,
+                "Name": "ECTN -Pas de prog. totale en 1",
+                "Description": null
+            },
+            {
+                "Id": 24,
+                "Name": "ECTX - Negatif pas de fracture",
+                "Description": null
+            }
+        ],
+        "Snow_WetnessKDV": [
+            {
+                "Id": 0,
+                "Name": " - ",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Sèche",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Entre Sèche/ Légèrement humide",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Légèrement humide",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Entre Légèrement humide/Humide",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "Humide",
+                "Description": null
+            },
+            {
+                "Id": 6,
+                "Name": "Entre Humide et Mouillée",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "Très mouillée",
+                "Description": null
+            },
+            {
+                "Id": 8,
+                "Name": "Entre Mouillée et Très mouillé",
+                "Description": null
+            },
+            {
+                "Id": 9,
+                "Name": "Sèche",
+                "Description": null
+            }
+        ],
+        "Snow_HardnessKDV": [
+            {
+                "Id": 0,
+                "Name": "-",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Poing -",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Très tendre : Poing (DUR 1)",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Poing +",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Entre le poing et 4 doigts",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "4 doigts -",
+                "Description": null
+            },
+            {
+                "Id": 6,
+                "Name": "Tendre : 4 doigts (DUR 2)",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "4 doigts +",
+                "Description": null
+            },
+            {
+                "Id": 8,
+                "Name": "Entre 4 doigts et 1 doigt",
+                "Description": null
+            },
+            {
+                "Id": 9,
+                "Name": "1 doigt -",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Dure : 1 doigt (DUR 3)",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "1 doigt +",
+                "Description": null
+            },
+            {
+                "Id": 12,
+                "Name": "Entre 1 doigt et poing",
+                "Description": null
+            },
+            {
+                "Id": 13,
+                "Name": "Crayon -",
+                "Description": null
+            },
+            {
+                "Id": 14,
+                "Name": "Très dure : Crayon (DUR 4)",
+                "Description": null
+            },
+            {
+                "Id": 15,
+                "Name": "Crayon +",
+                "Description": null
+            },
+            {
+                "Id": 16,
+                "Name": "Entre crayon et couteau",
+                "Description": null
+            },
+            {
+                "Id": 17,
+                "Name": "Couteau -",
+                "Description": null
+            },
+            {
+                "Id": 18,
+                "Name": "Compacte : Couteau (DUR 5)",
+                "Description": null
+            },
+            {
+                "Id": 19,
+                "Name": "Couteau +",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Entre Couteau et Glace",
+                "Description": null
+            },
+            {
+                "Id": 21,
+                "Name": "Glace pure",
+                "Description": null
+            }
+        ],
+        "Snow_GrainFormKDV": [
+            {
+                "Id": 0,
+                "Name": " - ",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "PP",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "PPco",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "PPnd",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "PPpl",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "PPsd",
+                "Description": null
+            },
+            {
+                "Id": 6,
+                "Name": "PPir",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "PPgp",
+                "Description": null
+            },
+            {
+                "Id": 8,
+                "Name": "PPhl",
+                "Description": null
+            },
+            {
+                "Id": 9,
+                "Name": "PPip",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "PPrm",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "MM",
+                "Description": null
+            },
+            {
+                "Id": 12,
+                "Name": "MMrp",
+                "Description": null
+            },
+            {
+                "Id": 13,
+                "Name": "MMci",
+                "Description": null
+            },
+            {
+                "Id": 14,
+                "Name": "DF",
+                "Description": null
+            },
+            {
+                "Id": 15,
+                "Name": "DFdc",
+                "Description": null
+            },
+            {
+                "Id": 16,
+                "Name": "DFbk",
+                "Description": null
+            },
+            {
+                "Id": 17,
+                "Name": "RG",
+                "Description": null
+            },
+            {
+                "Id": 18,
+                "Name": "RGsr",
+                "Description": null
+            },
+            {
+                "Id": 19,
+                "Name": "RGlr",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "RGwp",
+                "Description": null
+            },
+            {
+                "Id": 21,
+                "Name": "RGxf",
+                "Description": null
+            },
+            {
+                "Id": 22,
+                "Name": "FC",
+                "Description": null
+            },
+            {
+                "Id": 23,
+                "Name": "FCso",
+                "Description": null
+            },
+            {
+                "Id": 24,
+                "Name": "FCsf",
+                "Description": null
+            },
+            {
+                "Id": 25,
+                "Name": "FCxr",
+                "Description": null
+            },
+            {
+                "Id": 26,
+                "Name": "DH",
+                "Description": null
+            },
+            {
+                "Id": 27,
+                "Name": "DHcp",
+                "Description": null
+            },
+            {
+                "Id": 28,
+                "Name": "DHpr",
+                "Description": null
+            },
+            {
+                "Id": 29,
+                "Name": "DHch",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "DHla",
+                "Description": null
+            },
+            {
+                "Id": 31,
+                "Name": "DHxr",
+                "Description": null
+            },
+            {
+                "Id": 32,
+                "Name": "SH",
+                "Description": null
+            },
+            {
+                "Id": 33,
+                "Name": "SHsu",
+                "Description": null
+            },
+            {
+                "Id": 34,
+                "Name": "SHcv",
+                "Description": null
+            },
+            {
+                "Id": 35,
+                "Name": "SHxr",
+                "Description": null
+            },
+            {
+                "Id": 36,
+                "Name": "MF",
+                "Description": null
+            },
+            {
+                "Id": 37,
+                "Name": "MFcl",
+                "Description": null
+            },
+            {
+                "Id": 38,
+                "Name": "MFpc",
+                "Description": null
+            },
+            {
+                "Id": 39,
+                "Name": "MFsl",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "MFcr",
+                "Description": null
+            },
+            {
+                "Id": 41,
+                "Name": "IF",
+                "Description": null
+            },
+            {
+                "Id": 42,
+                "Name": "IFil",
+                "Description": null
+            },
+            {
+                "Id": 43,
+                "Name": "IFic",
+                "Description": null
+            },
+            {
+                "Id": 44,
+                "Name": "IFbi",
+                "Description": null
+            },
+            {
+                "Id": 45,
+                "Name": "IFrc",
+                "Description": null
+            },
+            {
+                "Id": 46,
+                "Name": "IFsc",
+                "Description": null
+            }
+        ],
+        "Snow_CriticalLayerKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "Partie supérieure",
+                "Description": null
+            },
+            {
+                "Id": 12,
+                "Name": "Partie inférieure",
+                "Description": null
+            },
+            {
+                "Id": 13,
+                "Name": "Couche entière",
+                "Description": null
+            }
+        ],
+        "Snow_SkiConditionsKDV": [
+            {
+                "Id": 0,
+                "Name": "Not given",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Bad",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Ok",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Good",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Very Good",
+                "Description": null
+            },
+            {
+                "Id": 50,
+                "Name": "Perfect",
+                "Description": null
+            }
+        ],
+        "Water_DangerSignKDV": [
+            {
+                "Id": 600,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 601,
+                "Name": "Aucune obs d'instabilité",
+                "Description": null
+            },
+            {
+                "Id": 611,
+                "Name": "Chéneaux bloqués par la glace",
+                "Description": null
+            },
+            {
+                "Id": 612,
+                "Name": "Voie d'eau obstruée / sédiment",
+                "Description": null
+            },
+            {
+                "Id": 621,
+                "Name": "Montée modérée du niveau d'eau",
+                "Description": null
+            },
+            {
+                "Id": 622,
+                "Name": "Montée subite du niveau d'eau",
+                "Description": null
+            },
+            {
+                "Id": 623,
+                "Name": "Niveau d'eau élevé. Inondation",
+                "Description": null
+            },
+            {
+                "Id": 699,
+                "Name": "Autre (veuillez préciser)",
+                "Description": null
+            }
+        ],
+        "Water_ActivityInfluencedKDV": [
+            {
+                "Id": 600,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 610,
+                "Name": "Activité de loisirs",
+                "Description": null
+            },
+            {
+                "Id": 615,
+                "Name": "Intrumentation",
+                "Description": null
+            },
+            {
+                "Id": 620,
+                "Name": "Routes",
+                "Description": null
+            },
+            {
+                "Id": 640,
+                "Name": "Chemins de fer",
+                "Description": null
+            },
+            {
+                "Id": 660,
+                "Name": "Bâtiments",
+                "Description": null
+            },
+            {
+                "Id": 690,
+                "Name": "Autres",
+                "Description": null
+            }
+        ],
+        "Water_WaterLevelRefKDV": [
+            {
+                "Id": 100,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 110,
+                "Name": "Relevé sur la jauge.",
+                "Description": null
+            },
+            {
+                "Id": 120,
+                "Name": "Point de repère bien connu",
+                "Description": null
+            },
+            {
+                "Id": 130,
+                "Name": "Monument - crues historiques",
+                "Description": null
+            },
+            {
+                "Id": 140,
+                "Name": "Voir la photo jointe",
+                "Description": null
+            },
+            {
+                "Id": 200,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 210,
+                "Name": "Relevé sur la jauge.",
+                "Description": null
+            },
+            {
+                "Id": 211,
+                "Name": "Repère",
+                "Description": null
+            },
+            {
+                "Id": 212,
+                "Name": "Marque MinMax pour le contrôle",
+                "Description": null
+            },
+            {
+                "Id": 220,
+                "Name": "Point de repère bien connu",
+                "Description": null
+            },
+            {
+                "Id": 221,
+                "Name": "Monument - crues historiques",
+                "Description": null
+            },
+            {
+                "Id": 240,
+                "Name": "Voir la photo jointe",
+                "Description": null
+            }
+        ],
+        "Water_WaterLevelStateKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Diminution de la hauteur de l'eau",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Augmentation de la hauteur de l'eau",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Hauteur de l'eau stable",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Impossible de déterminer la hauteur de l'eau",
+                "Description": null
+            }
+        ],
+        "Water_WaterAstrayKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Oui",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Non",
+                "Description": null
+            }
+        ],
+        "Water_ObservationTimingKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": "Inconnu"
+            },
+            {
+                "Id": 1,
+                "Name": "Trace de l'eau précédemment",
+                "Description": "Trace de l'eau précédemment"
+            },
+            {
+                "Id": 2,
+                "Name": "Niveau d'eau courant",
+                "Description": "Niveau d'eau courant"
+            }
+        ],
+        "Water_WaterLevelMethodKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Relevé de repère(s) sur la hauteur de l'eau",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Mesure de la hauteur de l'eau",
+                "Description": null
+            }
+        ],
+        "Water_MeasurementTypeKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": "Inconnu"
+            },
+            {
+                "Id": 1,
+                "Name": "Relativement à la marque",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Bâton de mesure",
+                "Description": "Bâton de mesure"
+            },
+            {
+                "Id": 3,
+                "Name": "Instrument de mesure",
+                "Description": "Instrument de mesure"
+            }
+        ],
+        "Water_MeasurementReferenceKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": "Inconnu"
+            },
+            {
+                "Id": 1,
+                "Name": "Sol",
+                "Description": "Sol"
+            },
+            {
+                "Id": 2,
+                "Name": "Digue de protection",
+                "Description": "Digue de protection"
+            },
+            {
+                "Id": 3,
+                "Name": "Sol",
+                "Description": "Sol"
+            },
+            {
+                "Id": 4,
+                "Name": "Pont",
+                "Description": "Pont"
+            },
+            {
+                "Id": 5,
+                "Name": "D'autre",
+                "Description": "D'autre"
+            }
+        ],
+        "Water_MarkingReferenceKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Sur le terrain",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Sur un pont",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Sur des ouvrages anti-inondations",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "sur la bâtiment",
+                "Description": "Bâtiment"
+            },
+            {
+                "Id": 5,
+                "Name": "Sur le pieu",
+                "Description": "Sur le pieu"
+            },
+            {
+                "Id": 6,
+                "Name": "sur autre chose",
+                "Description": "sur autre chose"
+            }
+        ],
+        "Water_MarkingTypeKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Bombe de peinture (spray)",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Marqueur",
+                "Description": "Marqueur"
+            },
+            {
+                "Id": 3,
+                "Name": "Clou",
+                "Description": "Clou"
+            },
+            {
+                "Id": 4,
+                "Name": "Gravé",
+                "Description": "Gravé"
+            },
+            {
+                "Id": 5,
+                "Name": "D'autre",
+                "Description": "D'autre"
+            }
+        ],
+        "Water_DamageTypeKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Bâtiments et actifs",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Infrastructure",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Terres cultivées",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Terrains",
+                "Description": null
+            },
+            {
+                "Id": 5,
+                "Name": "Personne(s)",
+                "Description": null
+            },
+            {
+                "Id": 6,
+                "Name": "Autre",
+                "Description": null
+            },
+            {
+                "Id": 7,
+                "Name": "Pas de dégât observé",
+                "Description": null
+            }
+        ],
+        "AnticipatedObservationTimeKDV": [
+            {
+                "Id": 0,
+                "Name": "0",
+                "Description": "Non spécifié"
+            },
+            {
+                "Id": 10,
+                "Name": "480",
+                "Description": "08:00"
+            },
+            {
+                "Id": 20,
+                "Name": "540",
+                "Description": "09:00"
+            },
+            {
+                "Id": 30,
+                "Name": "600",
+                "Description": "10:00"
+            },
+            {
+                "Id": 40,
+                "Name": "660",
+                "Description": "11:00"
+            },
+            {
+                "Id": 50,
+                "Name": "720",
+                "Description": "12:00"
+            },
+            {
+                "Id": 60,
+                "Name": "780",
+                "Description": "13:00"
+            },
+            {
+                "Id": 70,
+                "Name": "840",
+                "Description": "14:00"
+            },
+            {
+                "Id": 80,
+                "Name": "900",
+                "Description": "15:00"
+            },
+            {
+                "Id": 90,
+                "Name": "960",
+                "Description": "16:00"
+            },
+            {
+                "Id": 100,
+                "Name": "1080",
+                "Description": "18:00"
+            },
+            {
+                "Id": 110,
+                "Name": "1200",
+                "Description": "20:00"
+            },
+            {
+                "Id": 120,
+                "Name": "1320",
+                "Description": "22:00"
+            }
+        ],
+        "ForecastAccurateKDV": [
+            {
+                "Id": 0,
+                "Name": "Non spécifié",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Bulletin non émis",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Risque du bulletin sous-estimé",
+                "Description": null
+            },
+            {
+                "Id": 3,
+                "Name": "Risque du bulletin bien évalué",
+                "Description": null
+            },
+            {
+                "Id": 4,
+                "Name": "Risque du bulletin sur-estimé",
+                "Description": null
+            },
+            {
+                "Id": 9,
+                "Name": "Pas au courant de l'alerte",
+                "Description": null
+            }
+        ],
+        "DamageExtentKDV": [
+            {
+                "Id": 0,
+                "Name": "Non spécifié",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "N'a rien affecté",
+                "Description": null
+            },
+            {
+                "Id": 13,
+                "Name": "Recherche et sauvetage lancés",
+                "Description": null
+            },
+            {
+                "Id": 15,
+                "Name": "Circulation interrompue",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Dégâts matériels uniquement",
+                "Description": null
+            },
+            {
+                "Id": 25,
+                "Name": "Évacuation",
+                "Description": null
+            },
+            {
+                "Id": 27,
+                "Name": "Pas d'enseveli, mais de peu",
+                "Description": null
+            },
+            {
+                "Id": 28,
+                "Name": "Personne ensevelie non blessée",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Personnes blessées",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Personnes décédées",
+                "Description": null
+            },
+            {
+                "Id": 99,
+                "Name": "Autre",
+                "Description": null
+            }
+        ],
+        "CompetenceLevelKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": "Compétence non renseignée"
+            },
+            {
+                "Id": 100,
+                "Name": "-",
+                "Description": "Compétence en nivologie non renseignée"
+            },
+            {
+                "Id": 105,
+                "Name": "Automatique",
+                "Description": "Service automatique"
+            },
+            {
+                "Id": 110,
+                "Name": "*",
+                "Description": "L'observateur possède les compétences de base pour évaluer le risque d'avalanche. L'observateur n'est pas formé à la manière dont RegObs et Varsom communiquent le risque d'avalanche."
+            },
+            {
+                "Id": 115,
+                "Name": "**",
+                "Description": "L'observateur expérimenté mais il n'est pas formé à la manière dont RegObs et Varsom communiquent le risque d'avalanche."
+            },
+            {
+                "Id": 120,
+                "Name": "***",
+                "Description": "L'observateur est formé et possède des compétences avancées dans l'évaluation du risque d'avalanche. L'observateur a reçu un cours de base sur la manière dont RegObs et Varsom communiquent le risque d'avalanche."
+            },
+            {
+                "Id": 130,
+                "Name": "****",
+                "Description": "L'observateur est formé et possède des compétences avancées dans l'évaluation du risque d'avalanche. L'observateur a reçu un cours approfondi sur la manière dont RegObs et Varsom communiquent le risque d'avalanche."
+            },
+            {
+                "Id": 150,
+                "Name": "*****",
+                "Description": "L'observateur est un prévisionniste avalanche."
+            },
+            {
+                "Id": 200,
+                "Name": "-",
+                "Description": "Compétence en nivologie non renseignée"
+            },
+            {
+                "Id": 210,
+                "Name": "*",
+                "Description": "L’observateur a soumis des observations pertinentes."
+            },
+            {
+                "Id": 220,
+                "Name": "**",
+                "Description": "L’observateur a soumis des observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 230,
+                "Name": "***",
+                "Description": "Professionnel avec plusieurs observations pertinentes."
+            },
+            {
+                "Id": 240,
+                "Name": "****",
+                "Description": "Professionnel expérimenté ayant soumis plusieurs observations pertinentes en utilisant correctement les formulaires Regobs"
+            },
+            {
+                "Id": 250,
+                "Name": "*****",
+                "Description": "Professionnel du NVE ou équivalent ayant soumis plusieurs observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 300,
+                "Name": "-",
+                "Description": "Compétence en nivologie non renseignée"
+            },
+            {
+                "Id": 310,
+                "Name": "*",
+                "Description": "L’observateur a soumis des observations pertinentes."
+            },
+            {
+                "Id": 320,
+                "Name": "**",
+                "Description": "L’observateur a soumis des observations pertinentes en utilisant correctement les formulaires Regobs"
+            },
+            {
+                "Id": 330,
+                "Name": "***",
+                "Description": "Professionnel avec plusieurs observations pertinentes."
+            },
+            {
+                "Id": 340,
+                "Name": "****",
+                "Description": "Professionnel expérimenté ayant soumis plusieurs observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 350,
+                "Name": "*****",
+                "Description": "Professionnel du NVE ou équivalent ayant soumis plusieurs observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 400,
+                "Name": "-",
+                "Description": "Compétence non renseignée"
+            },
+            {
+                "Id": 410,
+                "Name": "*",
+                "Description": "L’observateur a soumis des observations pertinentes."
+            },
+            {
+                "Id": 420,
+                "Name": "**",
+                "Description": "L’observateur a soumis des observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 430,
+                "Name": "***",
+                "Description": "Professionnel avec plusieurs observations pertinentes."
+            },
+            {
+                "Id": 440,
+                "Name": "****",
+                "Description": "Professionnel expérimenté ayant soumis plusieurs observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 450,
+                "Name": "*****",
+                "Description": "Professionnel du NVE ou équivalent ayant soumis plusieurs observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 600,
+                "Name": "-",
+                "Description": "Compétence non renseignée"
+            },
+            {
+                "Id": 610,
+                "Name": "*",
+                "Description": "L’observateur a soumis des observations pertinentes."
+            },
+            {
+                "Id": 620,
+                "Name": "**",
+                "Description": "L’observateur a soumis des observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 630,
+                "Name": "***",
+                "Description": "Professionnel avec plusieurs observations pertinentes."
+            },
+            {
+                "Id": 640,
+                "Name": "****",
+                "Description": "Professionnel expérimenté ayant soumis plusieurs observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 650,
+                "Name": "*****",
+                "Description": "Professionnel du NVE ou équivalent ayant soumis plusieurs observations pertinentes en utilisant correctement les formulaires RegObs"
+            },
+            {
+                "Id": 700,
+                "Name": "-",
+                "Description": "Compétence non renseignée pour la glace"
+            },
+            {
+                "Id": 710,
+                "Name": "*",
+                "Description": "Débutant."
+            },
+            {
+                "Id": 720,
+                "Name": "**",
+                "Description": "Observateur expérimenté."
+            },
+            {
+                "Id": 730,
+                "Name": "***",
+                "Description": "Observateur formé ayant une expérience de terrain."
+            },
+            {
+                "Id": 740,
+                "Name": "****",
+                "Description": "Personnel formé"
+            },
+            {
+                "Id": 750,
+                "Name": "*****",
+                "Description": "Personnel formé/qualifié par le NVE ou équivalent"
+            }
+        ],
+        "UTMSourceKDV": [
+            {
+                "Id": 0,
+                "Name": null,
+                "Description": "Inconnu"
+            },
+            {
+                "Id": 10,
+                "Name": null,
+                "Description": "Déduit à partir d'un GPS"
+            },
+            {
+                "Id": 20,
+                "Name": null,
+                "Description": "Déduit à partir d'une carte"
+            },
+            {
+                "Id": 30,
+                "Name": null,
+                "Description": "Cliquez sur la carte dans l'application Regobs"
+            },
+            {
+                "Id": 35,
+                "Name": null,
+                "Description": "Cliquez sur la carte dans l'application RegObs"
+            },
+            {
+                "Id": 40,
+                "Name": null,
+                "Description": "Position GPS du smartphone"
+            },
+            {
+                "Id": 45,
+                "Name": null,
+                "Description": "Dernier endroit enregistré par le smartphone"
+            },
+            {
+                "Id": 50,
+                "Name": null,
+                "Description": "NVDB (base de données des routes nationales)"
+            },
+            {
+                "Id": 60,
+                "Name": null,
+                "Description": "HydraII"
+            }
+        ],
+        "TripTypeKDV": [
+            {
+                "Id": 0,
+                "Name": "Inconnu",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Tâche de routine dans le cadre de la PRA",
+                "Description": null
+            },
+            {
+                "Id": 30,
+                "Name": "Tâche exceptionnelle dans le cadre de la PRA",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Tâche demandée dans le cadre de la PRA",
+                "Description": null
+            },
+            {
+                "Id": 50,
+                "Name": "Employé",
+                "Description": null
+            },
+            {
+                "Id": 55,
+                "Name": "Formation et cours",
+                "Description": null
+            },
+            {
+                "Id": 60,
+                "Name": "Sortie privée",
+                "Description": null
+            },
+            {
+                "Id": 70,
+                "Name": "Encadrement professionnel",
+                "Description": null
+            }
+        ],
+        "GeoHazardKDV": [
+            {
+                "Id": 0,
+                "Name": "Non spécifié",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Neige",
+                "Description": "Avalanche"
+            },
+            {
+                "Id": 20,
+                "Name": "Sol",
+                "Description": "Glissement de terrain"
+            },
+            {
+                "Id": 30,
+                "Name": "Sols humides",
+                "Description": "Glissement de terrain - inondation"
+            },
+            {
+                "Id": 33,
+                "Name": "Argile",
+                "Description": null
+            },
+            {
+                "Id": 36,
+                "Name": "Neige fondue (slush)",
+                "Description": null
+            },
+            {
+                "Id": 40,
+                "Name": "Rochers",
+                "Description": "Chute de blocs"
+            },
+            {
+                "Id": 50,
+                "Name": "Cascade de glace",
+                "Description": null
+            },
+            {
+                "Id": 60,
+                "Name": "Hydrologie",
+                "Description": "Inondation"
+            },
+            {
+                "Id": 70,
+                "Name": "Glace",
+                "Description": "Glace non portante"
+            },
+            {
+                "Id": 100,
+                "Name": "Événement sur glacier",
+                "Description": null
+            },
+            {
+                "Id": 110,
+                "Name": "Crue éclair-origine glaciaire",
+                "Description": null
+            },
+            {
+                "Id": 200,
+                "Name": "Sécheresse",
+                "Description": null
+            },
+            {
+                "Id": 999,
+                "Name": "Inconnu",
+                "Description": null
+            }
+        ],
+        "UsageFlagKDV": [
+            {
+                "Id": 0,
+                "Name": "Aucun drapeau attribué",
+                "Description": null
+            },
+            {
+                "Id": 1,
+                "Name": "Prêt pour la BdD historique",
+                "Description": null
+            },
+            {
+                "Id": 2,
+                "Name": "Transmis à la BdD historique",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Approuvé par l'administrateur",
+                "Description": null
+            },
+            {
+                "Id": 51,
+                "Name": "Supprimé par l'utilisateur",
+                "Description": null
+            },
+            {
+                "Id": 52,
+                "Name": "Supprimé par l'administrateur",
+                "Description": null
+            },
+            {
+                "Id": 61,
+                "Name": "Refusé par l'administrateur",
+                "Description": null
+            },
+            {
+                "Id": 101,
+                "Name": "À des fins administratives",
+                "Description": null
+            }
+        ],
+        "RegistrationKDV": [
+            {
+                "Id": 10,
+                "Name": "Remarques/notes",
+                "Description": null
+            },
+            {
+                "Id": 11,
+                "Name": "Incident",
+                "Description": null
+            },
+            {
+                "Id": 13,
+                "Name": "Signe d'instabilité",
+                "Description": null
+            },
+            {
+                "Id": 14,
+                "Name": "Dégâts",
+                "Description": null
+            },
+            {
+                "Id": 21,
+                "Name": "Météo",
+                "Description": null
+            },
+            {
+                "Id": 22,
+                "Name": "Couverture de neige",
+                "Description": null
+            },
+            {
+                "Id": 25,
+                "Name": "Tests",
+                "Description": null
+            },
+            {
+                "Id": 26,
+                "Name": "Observation avalanche",
+                "Description": null
+            },
+            {
+                "Id": 31,
+                "Name": "Évaluation du risque avalanche",
+                "Description": null
+            },
+            {
+                "Id": 32,
+                "Name": "Situation avalancheuse typique",
+                "Description": null
+            },
+            {
+                "Id": 33,
+                "Name": "Activité avalancheuse",
+                "Description": null
+            },
+            {
+                "Id": 36,
+                "Name": "Profil du manteau neigeux",
+                "Description": null
+            },
+            {
+                "Id": 50,
+                "Name": "Épaisseur de glace",
+                "Description": null
+            },
+            {
+                "Id": 51,
+                "Name": "Couverture de glace",
+                "Description": null
+            },
+            {
+                "Id": 62,
+                "Name": "Niveau des cours d'eau",
+                "Description": null
+            },
+            {
+                "Id": 71,
+                "Name": "Glissement de terrain",
+                "Description": null
+            },
+            {
+                "Id": 80,
+                "Name": "Incidents",
+                "Description": null
+            },
+            {
+                "Id": 81,
+                "Name": "Avalanche& signe d'instabilité",
+                "Description": null
+            },
+            {
+                "Id": 82,
+                "Name": "Couverture neigeuse et météo",
+                "Description": null
+            },
+            {
+                "Id": 83,
+                "Name": "Évaluations et problèmes",
+                "Description": null
+            }
+        ],
+        "SourceKDV": [
+            {
+                "Id": 0,
+                "Name": "Non donné",
+                "Description": null
+            },
+            {
+                "Id": 10,
+                "Name": "Constaté par mes propres yeux",
+                "Description": null
+            },
+            {
+                "Id": 20,
+                "Name": "Évènement rapporté par un tiers",
+                "Description": null
+            },
+            {
+                "Id": 21,
+                "Name": "Lu dans les actualités/reportages/rapport",
+                "Description": null
+            },
+            {
+                "Id": 22,
+                "Name": "Vu sur photo/ webcam/ image satellite",
+                "Description": null
+            },
+            {
+                "Id": 23,
+                "Name": "Supposé / simulé",
+                "Description": null
+            }
+        ]
+    },
+    "ViewRepositories": {
+        "AvalancheProblemMenu3V": [
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 0
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 10
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 11
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 13
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 14
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 15
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 16
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 18
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 19
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 20
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 22
+            },
+            {
+                "AvalancheExtTID": 0,
+                "AvalCauseTID": 24
+            },
+            {
+                "AvalancheExtTID": 10,
+                "AvalCauseTID": 0
+            },
+            {
+                "AvalancheExtTID": 10,
+                "AvalCauseTID": 24
+            },
+            {
+                "AvalancheExtTID": 15,
+                "AvalCauseTID": 0
+            },
+            {
+                "AvalancheExtTID": 15,
+                "AvalCauseTID": 20
+            },
+            {
+                "AvalancheExtTID": 15,
+                "AvalCauseTID": 24
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 0
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 10
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 11
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 13
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 14
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 15
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 16
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 18
+            },
+            {
+                "AvalancheExtTID": 20,
+                "AvalCauseTID": 19
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 0
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 10
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 11
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 13
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 14
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 15
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 16
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 18
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 19
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 20
+            },
+            {
+                "AvalancheExtTID": 25,
+                "AvalCauseTID": 22
+            }
+        ],
+        "RegistrationTypesV": {
+            "10": [
+                {
+                    "Id": 80,
+                    "Name": "Incidents",
+                    "SubTypes": [
+                        {
+                            "Id": 26,
+                            "Name": "Observation avalanche",
+                            "SortOrder": 12
+                        },
+                        {
+                            "Id": 11,
+                            "Name": "Incident",
+                            "SortOrder": 97
+                        }
+                    ],
+                    "SortOrder": 80
+                },
+                {
+                    "Id": 81,
+                    "Name": "Avalanche& signe d'instabilité",
+                    "SubTypes": [
+                        {
+                            "Id": 13,
+                            "Name": "Signe d'instabilité",
+                            "SortOrder": 10
+                        },
+                        {
+                            "Id": 26,
+                            "Name": "Observation avalanche",
+                            "SortOrder": 12
+                        },
+                        {
+                            "Id": 33,
+                            "Name": "Activité avalancheuse",
+                            "SortOrder": 13
+                        }
+                    ],
+                    "SortOrder": 81
+                },
+                {
+                    "Id": 82,
+                    "Name": "Couverture neigeuse et météo",
+                    "SubTypes": [
+                        {
+                            "Id": 22,
+                            "Name": "Couverture de neige",
+                            "SortOrder": 14
+                        },
+                        {
+                            "Id": 21,
+                            "Name": "Météo",
+                            "SortOrder": 14
+                        },
+                        {
+                            "Id": 25,
+                            "Name": "Tests",
+                            "SortOrder": 16
+                        },
+                        {
+                            "Id": 36,
+                            "Name": "Profil du manteau neigeux",
+                            "SortOrder": 36
+                        }
+                    ],
+                    "SortOrder": 82
+                },
+                {
+                    "Id": 83,
+                    "Name": "Évaluations et problèmes",
+                    "SubTypes": [
+                        {
+                            "Id": 32,
+                            "Name": "Situation avalancheuse typique",
+                            "SortOrder": 17
+                        },
+                        {
+                            "Id": 31,
+                            "Name": "Évaluation du risque avalanche",
+                            "SortOrder": 18
+                        }
+                    ],
+                    "SortOrder": 83
+                },
+                {
+                    "Id": 10,
+                    "Name": "Remarques/notes",
+                    "SubTypes": [],
+                    "SortOrder": 98
+                }
+            ],
+            "20": [
+                {
+                    "Id": 13,
+                    "Name": "Signe d'instabilité",
+                    "SubTypes": [],
+                    "SortOrder": 10
+                },
+                {
+                    "Id": 71,
+                    "Name": "Glissement de terrain",
+                    "SubTypes": [],
+                    "SortOrder": 71
+                },
+                {
+                    "Id": 10,
+                    "Name": "Remarques/notes",
+                    "SubTypes": [],
+                    "SortOrder": 98
+                }
+            ],
+            "60": [
+                {
+                    "Id": 13,
+                    "Name": "Signe d'instabilité",
+                    "SubTypes": [],
+                    "SortOrder": 10
+                },
+                {
+                    "Id": 14,
+                    "Name": "Dégâts",
+                    "SubTypes": [],
+                    "SortOrder": 14
+                },
+                {
+                    "Id": 62,
+                    "Name": "Niveau des cours d'eau",
+                    "SubTypes": [],
+                    "SortOrder": 62
+                },
+                {
+                    "Id": 11,
+                    "Name": "Incident",
+                    "SubTypes": [],
+                    "SortOrder": 97
+                },
+                {
+                    "Id": 10,
+                    "Name": "Remarques/notes",
+                    "SubTypes": [],
+                    "SortOrder": 98
+                }
+            ],
+            "70": [
+                {
+                    "Id": 51,
+                    "Name": "Couverture de glace",
+                    "SubTypes": [],
+                    "SortOrder": 7
+                },
+                {
+                    "Id": 50,
+                    "Name": "Épaisseur de glace",
+                    "SubTypes": [],
+                    "SortOrder": 8
+                },
+                {
+                    "Id": 13,
+                    "Name": "Signe d'instabilité",
+                    "SubTypes": [],
+                    "SortOrder": 10
+                },
+                {
+                    "Id": 11,
+                    "Name": "Incident",
+                    "SubTypes": [],
+                    "SortOrder": 97
+                },
+                {
+                    "Id": 10,
+                    "Name": "Remarques/notes",
+                    "SubTypes": [],
+                    "SortOrder": 98
+                }
+            ]
+        }
+    }
+}

--- a/src/assets/json/kdvelements.nb.json
+++ b/src/assets/json/kdvelements.nb.json
@@ -22,8 +22,13 @@
         "Description": null
       },
       {
-        "Id": 212,
-        "Name": "Snødekke med mye vann",
+        "Id": 204,
+        "Name": "Overvann i terreng",
+        "Description": null
+      },
+      {
+        "Id": 205,
+        "Name": "Utilstrekkelig drenering",
         "Description": null
       },
       {
@@ -37,26 +42,6 @@
         "Description": null
       },
       {
-        "Id": 230,
-        "Name": "Erosjon langs bekker/elver",
-        "Description": null
-      },
-      {
-        "Id": 214,
-        "Name": "Bekker tar nye løp",
-        "Description": null
-      },
-      {
-        "Id": 204,
-        "Name": "Overvann i terreng",
-        "Description": null
-      },
-      {
-        "Id": 205,
-        "Name": "Utilstrekkelig drenering",
-        "Description": null
-      },
-      {
         "Id": 208,
         "Name": "Sprekker/sig i terrenget",
         "Description": null
@@ -64,6 +49,16 @@
       {
         "Id": 209,
         "Name": "Observert jordskred",
+        "Description": null
+      },
+      {
+        "Id": 212,
+        "Name": "Snødekke med mye vann",
+        "Description": null
+      },
+      {
+        "Id": 214,
+        "Name": "Bekker tar nye løp",
         "Description": null
       },
       {
@@ -75,6 +70,11 @@
         "Id": 223,
         "Name": "\"Fulle trær\"",
         "Description": "Tre som bøyer seg"
+      },
+      {
+        "Id": 230,
+        "Name": "Erosjon langs bekker/elver",
+        "Description": null
       },
       {
         "Id": 299,
@@ -89,6 +89,11 @@
         "Description": null
       },
       {
+        "Id": 211,
+        "Name": "Personer",
+        "Description": null
+      },
+      {
         "Id": 220,
         "Name": "Veg",
         "Description": null
@@ -99,18 +104,13 @@
         "Description": null
       },
       {
-        "Id": 260,
-        "Name": "Bebyggelse",
-        "Description": null
-      },
-      {
-        "Id": 211,
-        "Name": "Personer",
-        "Description": null
-      },
-      {
         "Id": 251,
         "Name": "Skog og landbruk areal",
+        "Description": null
+      },
+      {
+        "Id": 260,
+        "Name": "Bebyggelse",
         "Description": null
       },
       {
@@ -141,11 +141,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Steinskred",
-        "Description": null
-      },
-      {
         "Id": 6,
         "Name": "Steinsprang",
         "Description": null
@@ -163,6 +158,11 @@
       {
         "Id": 10,
         "Name": "Kvikkleireskred",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Steinskred",
         "Description": null
       }
     ],
@@ -284,11 +284,6 @@
         "Description": null
       },
       {
-        "Id": 714,
-        "Name": "Isfisker",
-        "Description": null
-      },
-      {
         "Id": 711,
         "Name": "Skøyteløper",
         "Description": null
@@ -304,8 +299,8 @@
         "Description": null
       },
       {
-        "Id": 719,
-        "Name": "Personskade v/isgang",
+        "Id": 714,
+        "Name": "Isfisker",
         "Description": null
       },
       {
@@ -324,9 +319,24 @@
         "Description": null
       },
       {
-        "Id": 725,
-        "Name": "Sparkstøtting",
+        "Id": 719,
+        "Name": "Personskade v/isgang",
         "Description": null
+      },
+      {
+        "Id": 720,
+        "Name": "Snøskuter på isen",
+        "Description": null
+      },
+      {
+        "Id": 721,
+        "Name": "Bil på isen",
+        "Description": null
+      },
+      {
+        "Id": 722,
+        "Name": "ATV",
+        "Description": "All Terrain Vehicle"
       },
       {
         "Id": 723,
@@ -339,18 +349,8 @@
         "Description": null
       },
       {
-        "Id": 720,
-        "Name": "Snøskuter på isen",
-        "Description": null
-      },
-      {
-        "Id": 722,
-        "Name": "ATV",
-        "Description": "All Terrain Vehicle"
-      },
-      {
-        "Id": 721,
-        "Name": "Bil på isen",
+        "Id": 725,
+        "Name": "Sparkstøtting",
         "Description": null
       },
       {
@@ -386,7 +386,22 @@
       {
         "Id": 774,
         "Name": "Drivis",
-        "Description": null
+        "Description": "Is på innsjøer som løsner og driver avgårde. Kan gi skader langs land."
+      },
+      {
+        "Id": 775,
+        "Name": "Bunnisdam",
+        "Description": "Isdam som dannes når drivende sarr fester seg på elvebunnen. Kan gi oversvømmelser."
+      },
+      {
+        "Id": 776,
+        "Name": "Sarr/is tetter elveløpet",
+        "Description": "Drivende sarr og isflak samler seg under et isdekke og reduserer elveløpet slik at vann må renne på oversiden av isdekket. Gir ofte skader langs land eller på elvebunnen."
+      },
+      {
+        "Id": 777,
+        "Name": "Ispropp",
+        "Description": "En isgang har stanset og sperrer en del av elveløpet"
       },
       {
         "Id": 790,
@@ -406,11 +421,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Islegging langs land",
-        "Description": null
-      },
-      {
         "Id": 2,
         "Name": "Delvis islagt på målestedet",
         "Description": null
@@ -421,13 +431,13 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "Hele sjøen islagt",
+        "Id": 10,
+        "Name": "Isløsning langs land, is utpå",
         "Description": null
       },
       {
-        "Id": 10,
-        "Name": "Isløsning langs land",
+        "Id": 11,
+        "Name": "Islegging ved land, åpent utpå",
         "Description": null
       },
       {
@@ -436,13 +446,18 @@
         "Description": null
       },
       {
-        "Id": 41,
-        "Name": "Drivende sarr på elv",
+        "Id": 21,
+        "Name": "Hele sjøen islagt",
         "Description": null
       },
       {
         "Id": 40,
         "Name": "Isgang i elv",
+        "Description": null
+      },
+      {
+        "Id": 41,
+        "Name": "Drivende sarr på elv",
         "Description": null
       },
       {
@@ -458,14 +473,14 @@
         "Description": null
       },
       {
-        "Id": 2,
-        "Name": "Isfritt, nå første is ved land",
-        "Description": "Ingen is hittil denne sesongen. I dag is langs land."
-      },
-      {
         "Id": 1,
         "Name": "Isfritt, nå første is målested",
         "Description": "Ingen is på målestedet før i dag. Det kan ha vært is langs land. Målested er som regel noe utpå vannet."
+      },
+      {
+        "Id": 2,
+        "Name": "Isfritt, nå første is ved land",
+        "Description": "Ingen is hittil denne sesongen. I dag is langs land."
       },
       {
         "Id": 3,
@@ -479,7 +494,7 @@
       },
       {
         "Id": 99,
-        "Name": "Brudd - Ukjent før nå",
+        "Name": "Ukjent isdekke før nå",
         "Description": "Det er brudd i målingene. Isforholdene fra forrige måling er neppe gyldige til i går."
       }
     ],
@@ -626,6 +641,11 @@
         "Description": null
       },
       {
+        "Id": 60,
+        "Name": "Isnedfall",
+        "Description": "Is som faller fra en skråning/berg, eller fra en installasjon. Kan også brukes om is som løsner fra en brefront."
+      },
+      {
         "Id": 99,
         "Name": "Annet (bruk kommentar)",
         "Description": null
@@ -653,11 +673,6 @@
         "Description": null
       },
       {
-        "Id": 4,
-        "Name": "Ferske sprekker",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "Stort snøfall",
         "Description": "Brukes i elrapp"
@@ -678,6 +693,16 @@
         "Description": null
       },
       {
+        "Id": 14,
+        "Name": "Skytende sprekker",
+        "Description": null
+      },
+      {
+        "Id": 15,
+        "Name": "Ferske glidesprekker",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Annet faretegn (spesifiser)",
         "Description": null
@@ -695,13 +720,13 @@
         "Description": null
       },
       {
-        "Id": 113,
-        "Name": "Ski offpist",
+        "Id": 112,
+        "Name": "Ski i anlegg",
         "Description": null
       },
       {
-        "Id": 112,
-        "Name": "Ski i anlegg",
+        "Id": 113,
+        "Name": "Ski offpist",
         "Description": null
       },
       {
@@ -725,13 +750,13 @@
         "Description": null
       },
       {
-        "Id": 130,
-        "Name": "Snøskuter",
+        "Id": 120,
+        "Name": "Vei",
         "Description": null
       },
       {
-        "Id": 120,
-        "Name": "Vei",
+        "Id": 130,
+        "Name": "Snøskuter",
         "Description": null
       },
       {
@@ -757,23 +782,23 @@
         "Description": null
       },
       {
-        "Id": 12,
-        "Name": "Tørt løssnøskred",
-        "Description": null
-      },
-      {
         "Id": 11,
         "Name": "Vått løssnøskred",
         "Description": null
       },
       {
-        "Id": 22,
-        "Name": "Tørt flakskred",
+        "Id": 12,
+        "Name": "Tørt løssnøskred",
         "Description": null
       },
       {
         "Id": 21,
         "Name": "Vått flakskred",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Tørt flakskred",
         "Description": null
       },
       {
@@ -904,28 +929,28 @@
       },
       {
         "Id": 16,
-        "Name": "Kantkornet ved bakken",
-        "Description": "Kantkornet ved bakken"
-      },
-      {
-        "Id": 19,
-        "Name": "Kantkornet under skare",
-        "Description": "Kantkornet under skare"
+        "Name": "Kantkornet snø ved bakken",
+        "Description": "Kantkornet snø ved bakken"
       },
       {
         "Id": 18,
-        "Name": "Kantkornet over skare",
-        "Description": "Kantkornet over skare"
+        "Name": "Kantkornet snø over skare",
+        "Description": "Kantkornet snø over skare"
       },
       {
-        "Id": 22,
-        "Name": "Opphopning av vann over lag",
-        "Description": "Opphopning av vann over lag"
+        "Id": 19,
+        "Name": "Kantkornet snø under skare",
+        "Description": "Kantkornet snø under skare"
       },
       {
         "Id": 20,
         "Name": "Smelting fra bakken",
         "Description": "Smelting fra bakken"
+      },
+      {
+        "Id": 22,
+        "Name": "Opphopning av vann over lag",
+        "Description": "Opphopning av vann over lag"
       },
       {
         "Id": 24,
@@ -1075,6 +1100,11 @@
         "Description": null
       },
       {
+        "Id": 22,
+        "Name": "Naturlig utløst",
+        "Description": null
+      },
+      {
         "Id": 30,
         "Name": "Svært vanskelig å løse ut",
         "Description": null
@@ -1092,11 +1122,6 @@
       {
         "Id": 60,
         "Name": "Svært lett å løse ut",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "Naturlig utløst",
         "Description": null
       }
     ],
@@ -1299,16 +1324,6 @@
         "Description": null
       },
       {
-        "Id": 26,
-        "Name": "Personutløst",
-        "Description": null
-      },
-      {
-        "Id": 27,
-        "Name": "Skuterutløst",
-        "Description": null
-      },
-      {
         "Id": 22,
         "Name": "Fjernutløst",
         "Description": null
@@ -1321,6 +1336,16 @@
       {
         "Id": 25,
         "Name": "Utløst med sprengstoff",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Personutløst",
+        "Description": null
+      },
+      {
+        "Id": 27,
+        "Name": "Skuterutløst",
         "Description": null
       },
       {
@@ -1393,6 +1418,21 @@
         "Description": null
       },
       {
+        "Id": 50,
+        "Name": "Overflatekantkorn",
+        "Description": null
+      },
+      {
+        "Id": 61,
+        "Name": "Rim på hardt underlag",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Rim på mykt underlag",
+        "Description": null
+      },
+      {
         "Id": 101,
         "Name": "Svært mye tørr løssnø (>30cm)",
         "Description": null
@@ -1408,23 +1448,8 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Rim på hardt underlag",
-        "Description": null
-      },
-      {
-        "Id": 62,
-        "Name": "Rim på mykt underlag",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Overflatekantkorn",
-        "Description": null
-      },
-      {
-        "Id": 107,
-        "Name": "Skare",
+        "Id": 104,
+        "Name": "Våt løssnø",
         "Description": null
       },
       {
@@ -1438,8 +1463,8 @@
         "Description": null
       },
       {
-        "Id": 104,
-        "Name": "Våt løssnø",
+        "Id": 107,
+        "Name": "Skare",
         "Description": null
       },
       {
@@ -1536,26 +1561,6 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "ECTPV",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "ECTP",
-        "Description": null
-      },
-      {
-        "Id": 23,
-        "Name": "ECTN",
-        "Description": null
-      },
-      {
-        "Id": 24,
-        "Name": "ECTX",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "LBT",
         "Description": null
@@ -1583,6 +1588,26 @@
       {
         "Id": 15,
         "Name": "CTN",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "ECTPV",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "ECTP",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "ECTN",
+        "Description": null
+      },
+      {
+        "Id": 24,
+        "Name": "ECTX",
         "Description": null
       }
     ],
@@ -2006,6 +2031,38 @@
       {
         "Id": 13,
         "Name": "Hele laget",
+        "Description": null
+      }
+    ],
+    "Snow_SkiConditionsKDV": [
+      {
+        "Id": 0,
+        "Name": "Ikke gitt",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Dårlig",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Greit",
+        "Description": null
+      },
+      {
+        "Id": 30,
+        "Name": "Bra",
+        "Description": null
+      },
+      {
+        "Id": 40,
+        "Name": "Veldig bra",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Perfekt",
         "Description": null
       }
     ],
@@ -2514,13 +2571,13 @@
         "Description": null
       },
       {
-        "Id": 25,
-        "Name": "Evakuering",
+        "Id": 20,
+        "Name": "Kun materielle skader",
         "Description": null
       },
       {
-        "Id": 20,
-        "Name": "Kun materielle skader",
+        "Id": 25,
+        "Name": "Evakuering",
         "Description": null
       },
       {
@@ -2561,6 +2618,11 @@
         "Description": "Ukjent kompetanse på snø."
       },
       {
+        "Id": 105,
+        "Name": "A",
+        "Description": "Automatisert tjeneste"
+      },
+      {
         "Id": 110,
         "Name": "*",
         "Description": "Observatøren kan det grunnleggende for å vurdere snøskredfare. Observatøren er ikke kurset om hvordan regObs og Varsom formidler snøskredfare. Kompetansen tilsvarer NVE sitt nivå 4a."
@@ -2584,11 +2646,6 @@
         "Id": 150,
         "Name": "*****",
         "Description": "Observatøren tilhører en varslingstjeneste. Kompetansen tilsvarer NVE sitt nivå 4c."
-      },
-      {
-        "Id": 105,
-        "Name": "A",
-        "Description": "Automatisert tjeneste"
       },
       {
         "Id": 200,
@@ -2795,26 +2852,6 @@
         "Description": null
       },
       {
-        "Id": 60,
-        "Name": "Privat tur",
-        "Description": null
-      },
-      {
-        "Id": 55,
-        "Name": "Undervisning og kurs",
-        "Description": null
-      },
-      {
-        "Id": 70,
-        "Name": "Føring og guiding",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Oppdrag for arbeidsgiver",
-        "Description": null
-      },
-      {
         "Id": 20,
         "Name": "Ordinært oppdrag for skredvarslinga",
         "Description": null
@@ -2827,6 +2864,26 @@
       {
         "Id": 40,
         "Name": "Bestilt oppdrag for skredvarslinga",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Oppdrag for arbeidsgiver",
+        "Description": null
+      },
+      {
+        "Id": 55,
+        "Name": "Undervisning og kurs",
+        "Description": null
+      },
+      {
+        "Id": 60,
+        "Name": "Privat tur",
+        "Description": null
+      },
+      {
+        "Id": 70,
+        "Name": "Føring og guiding",
         "Description": null
       }
     ],
@@ -2929,19 +2986,153 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Underkjent av dataforvalter",
+        "Id": 52,
+        "Name": "Slettet av admin",
         "Description": null
       },
       {
-        "Id": 52,
-        "Name": "Slettet av admin",
+        "Id": 61,
+        "Name": "Underkjent av dataforvalter",
         "Description": null
       },
       {
         "Id": 101,
         "Name": "Til administrativ bruk",
         "Description": "Observasjon eller gruppe har en admin funksjon. Den skjules som om den er slettet."
+      }
+    ],
+    "RegistrationKDV": [
+      {
+        "Id": 10,
+        "Name": "Notater",
+        "Description": "Tabellen brukes av alle (GeoHazardTID 10,20,30,40,60,70)"
+      },
+      {
+        "Id": 11,
+        "Name": "Ulykke/hendelse",
+        "Description": "Tabellen brukes av GeoHazardTID 10,60,70"
+      },
+      {
+        "Id": 13,
+        "Name": "Faretegn",
+        "Description": "Tabellen brukes av alle (GeoHazardTID 10,20,30,40,60,70)"
+      },
+      {
+        "Id": 14,
+        "Name": "Skader",
+        "Description": "Gjelder alle geohazard. Brukes kun av vann foreløpig."
+      },
+      {
+        "Id": 21,
+        "Name": "Vær",
+        "Description": "Tabellen brukes av snø (GeohazardTID = 10)"
+      },
+      {
+        "Id": 22,
+        "Name": "Snødekke",
+        "Description": "Tabellen brukes av snø (GeohazardTID = 10)"
+      },
+      {
+        "Id": 25,
+        "Name": "Tester",
+        "Description": "Tabellen brukes av snø (GeohazardTID = 10)"
+      },
+      {
+        "Id": 26,
+        "Name": "Skredhendelse",
+        "Description": "Tabellen brukes av snø (GeohazardTID = 10)"
+      },
+      {
+        "Id": 31,
+        "Name": "Skredfarevurdering",
+        "Description": "Tabellen brukes av snø (GeohazardTID = 10)"
+      },
+      {
+        "Id": 32,
+        "Name": "Skredproblem",
+        "Description": "Tabellen brukes av snø (GeohazardTID = 10)"
+      },
+      {
+        "Id": 33,
+        "Name": "Skredaktivitet",
+        "Description": "Tabellen brukes av snø (GeohazardTID = 10)"
+      },
+      {
+        "Id": 36,
+        "Name": "Snøprofil",
+        "Description": "Snøprofil topp-node"
+      },
+      {
+        "Id": 50,
+        "Name": "Istykkelse",
+        "Description": "Tabellen brukes av is (GeohazardTID = 70)"
+      },
+      {
+        "Id": 51,
+        "Name": "Isdekning",
+        "Description": "Tabellen brukes av is (GeohazardTID = 70)"
+      },
+      {
+        "Id": 62,
+        "Name": "Vannstand",
+        "Description": "nye vannstand skjema for flom database prosjektet."
+      },
+      {
+        "Id": 71,
+        "Name": "Skredhendelse",
+        "Description": "Tabellen brukes av jord (GeohazardTID = 20,30og40)"
+      },
+      {
+        "Id": 80,
+        "Name": "Hendelser",
+        "Description": "Grupperings type - Hendelser"
+      },
+      {
+        "Id": 81,
+        "Name": "Skred og faretegn",
+        "Description": "Grupperings type - Skred og faretegn"
+      },
+      {
+        "Id": 82,
+        "Name": "Snødekke og vær",
+        "Description": "Grupperings type - Snødekke og vær"
+      },
+      {
+        "Id": 83,
+        "Name": "Vurderinger og problemer",
+        "Description": "Grupperings type - Vurderinger og problemer"
+      }
+    ],
+    "SourceKDV": [
+      {
+        "Id": 0,
+        "Name": "Ikke gitt",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Har selv sett dette",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Har blitt fortalt",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "Lest i avis/rapport",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Sett bilde/webkamera/satellitt",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "Antatt/modellert",
+        "Description": null
       }
     ]
   },
@@ -3095,6 +3286,183 @@
         "AvalancheExtTID": 25,
         "AvalCauseTID": 22
       }
-    ]
+    ],
+    "RegistrationTypesV": {
+      "10": [
+        {
+          "Id": 80,
+          "Name": "Hendelser",
+          "SubTypes": [
+            {
+              "Id": 26,
+              "Name": "Skredhendelse",
+              "SortOrder": 12
+            },
+            {
+              "Id": 11,
+              "Name": "Ulykke/hendelse",
+              "SortOrder": 97
+            }
+          ],
+          "SortOrder": 80
+        },
+        {
+          "Id": 81,
+          "Name": "Skred og faretegn",
+          "SubTypes": [
+            {
+              "Id": 13,
+              "Name": "Faretegn",
+              "SortOrder": 10
+            },
+            {
+              "Id": 26,
+              "Name": "Skredhendelse",
+              "SortOrder": 12
+            },
+            {
+              "Id": 33,
+              "Name": "Skredaktivitet",
+              "SortOrder": 13
+            }
+          ],
+          "SortOrder": 81
+        },
+        {
+          "Id": 82,
+          "Name": "Snødekke og vær",
+          "SubTypes": [
+            {
+              "Id": 22,
+              "Name": "Snødekke",
+              "SortOrder": 14
+            },
+            {
+              "Id": 21,
+              "Name": "Vær",
+              "SortOrder": 14
+            },
+            {
+              "Id": 25,
+              "Name": "Tester",
+              "SortOrder": 16
+            },
+            {
+              "Id": 36,
+              "Name": "Snøprofil",
+              "SortOrder": 36
+            }
+          ],
+          "SortOrder": 82
+        },
+        {
+          "Id": 83,
+          "Name": "Vurderinger og problemer",
+          "SubTypes": [
+            {
+              "Id": 32,
+              "Name": "Skredproblem",
+              "SortOrder": 17
+            },
+            {
+              "Id": 31,
+              "Name": "Skredfarevurdering",
+              "SortOrder": 18
+            }
+          ],
+          "SortOrder": 83
+        },
+        {
+          "Id": 10,
+          "Name": "Notater",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "20": [
+        {
+          "Id": 13,
+          "Name": "Faretegn",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 71,
+          "Name": "Skredhendelse",
+          "SubTypes": [],
+          "SortOrder": 71
+        },
+        {
+          "Id": 10,
+          "Name": "Notater",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "60": [
+        {
+          "Id": 13,
+          "Name": "Faretegn",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 14,
+          "Name": "Skader",
+          "SubTypes": [],
+          "SortOrder": 14
+        },
+        {
+          "Id": 62,
+          "Name": "Vannstand",
+          "SubTypes": [],
+          "SortOrder": 62
+        },
+        {
+          "Id": 11,
+          "Name": "Ulykke/hendelse",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Notater",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "70": [
+        {
+          "Id": 51,
+          "Name": "Isdekning",
+          "SubTypes": [],
+          "SortOrder": 7
+        },
+        {
+          "Id": 50,
+          "Name": "Istykkelse",
+          "SubTypes": [],
+          "SortOrder": 8
+        },
+        {
+          "Id": 13,
+          "Name": "Faretegn",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 11,
+          "Name": "Ulykke/hendelse",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Notater",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ]
+    }
   }
 }

--- a/src/assets/json/kdvelements.nn.json
+++ b/src/assets/json/kdvelements.nn.json
@@ -22,8 +22,13 @@
         "Description": null
       },
       {
-        "Id": 212,
-        "Name": "Snødekke med mykje vatn",
+        "Id": 204,
+        "Name": "Overvatn i terreng",
+        "Description": null
+      },
+      {
+        "Id": 205,
+        "Name": "Utilstrekkeleg drenering",
         "Description": null
       },
       {
@@ -37,26 +42,6 @@
         "Description": null
       },
       {
-        "Id": 230,
-        "Name": "Erosjon langs bekkar/elver",
-        "Description": null
-      },
-      {
-        "Id": 214,
-        "Name": "Bekkar tek nye løp",
-        "Description": null
-      },
-      {
-        "Id": 204,
-        "Name": "Overvatn i terreng",
-        "Description": null
-      },
-      {
-        "Id": 205,
-        "Name": "Utilstrekkeleg drenering",
-        "Description": null
-      },
-      {
         "Id": 208,
         "Name": "Sprekker/sig i terrenget",
         "Description": null
@@ -67,6 +52,16 @@
         "Description": null
       },
       {
+        "Id": 212,
+        "Name": "Snødekke med mykje vatn",
+        "Description": null
+      },
+      {
+        "Id": 214,
+        "Name": "Bekkar tek nye løp",
+        "Description": null
+      },
+      {
         "Id": 222,
         "Name": "Masserørsle langs skredkant",
         "Description": null
@@ -74,6 +69,11 @@
       {
         "Id": 223,
         "Name": "\"Fulle tre\"",
+        "Description": null
+      },
+      {
+        "Id": 230,
+        "Name": "Erosjon langs bekkar/elver",
         "Description": null
       },
       {
@@ -89,6 +89,11 @@
         "Description": null
       },
       {
+        "Id": 211,
+        "Name": "Personar",
+        "Description": null
+      },
+      {
         "Id": 220,
         "Name": "Veg",
         "Description": null
@@ -99,18 +104,13 @@
         "Description": null
       },
       {
-        "Id": 260,
-        "Name": "Busetnad",
-        "Description": null
-      },
-      {
-        "Id": 211,
-        "Name": "Personar",
-        "Description": null
-      },
-      {
         "Id": 251,
         "Name": "Skog- og landbrukareal",
+        "Description": null
+      },
+      {
+        "Id": 260,
+        "Name": "Busetnad",
         "Description": null
       },
       {
@@ -141,11 +141,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Steinskred",
-        "Description": null
-      },
-      {
         "Id": 6,
         "Name": "Steinsprang",
         "Description": null
@@ -163,6 +158,11 @@
       {
         "Id": 10,
         "Name": "Kvikkleireskred",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Steinskred",
         "Description": null
       }
     ],
@@ -284,11 +284,6 @@
         "Description": null
       },
       {
-        "Id": 714,
-        "Name": "Isfiskar",
-        "Description": null
-      },
-      {
         "Id": 711,
         "Name": "Skøytelaupar",
         "Description": null
@@ -300,12 +295,12 @@
       },
       {
         "Id": 713,
-        "Name": "Skiseiling/Kiting",
+        "Name": "Skisegling/Kiting",
         "Description": null
       },
       {
-        "Id": 719,
-        "Name": "Personskade av isgang",
+        "Id": 714,
+        "Name": "Isfiskar",
         "Description": null
       },
       {
@@ -324,13 +319,8 @@
         "Description": null
       },
       {
-        "Id": 723,
-        "Name": "Sykkel",
-        "Description": null
-      },
-      {
-        "Id": 724,
-        "Name": "\nMotorsykkel",
+        "Id": 719,
+        "Name": "Personskade av isgang",
         "Description": null
       },
       {
@@ -339,13 +329,28 @@
         "Description": null
       },
       {
+        "Id": 721,
+        "Name": "Bil på isen",
+        "Description": null
+      },
+      {
         "Id": 722,
         "Name": "ATV",
         "Description": "All Terrain Vehicle"
       },
       {
-        "Id": 721,
-        "Name": "Bil på isen",
+        "Id": 723,
+        "Name": "Sykkel",
+        "Description": null
+      },
+      {
+        "Id": 724,
+        "Name": "Motorsykkel",
+        "Description": null
+      },
+      {
+        "Id": 725,
+        "Name": "Sparkstøtting",
         "Description": null
       },
       {
@@ -381,7 +386,22 @@
       {
         "Id": 774,
         "Name": "Drivis",
-        "Description": null
+        "Description": "Is på innsjøar som løsnar og driv avgarde. Kan øydelegge langs land."
+      },
+      {
+        "Id": 775,
+        "Name": "Botnis dam",
+        "Description": "Isdam som vert laga når drivande sarr festar seg på elvebotnen. Kan gi overfløyming."
+      },
+      {
+        "Id": 776,
+        "Name": "Sarr/is tettar elveløpet",
+        "Description": "Drivande sarr og isflak samlar seg under eit isdekke og snevrar inn elveløpet slik at vatn må renne på oversida av isdekket. Gir ofte skadar langs land eller på elvebotnen."
+      },
+      {
+        "Id": 777,
+        "Name": "Ispropp",
+        "Description": "Ein isgang har stansa og sperrar ein del av elveløpet"
       },
       {
         "Id": 790,
@@ -401,11 +421,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Islegging langs land",
-        "Description": null
-      },
-      {
         "Id": 2,
         "Name": "Delvis islagd på målestad",
         "Description": null
@@ -416,13 +431,13 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "Heile sjøen islagd",
+        "Id": 10,
+        "Name": "Isløysing langs land, is utpå",
         "Description": null
       },
       {
-        "Id": 10,
-        "Name": "Isløysing langs land",
+        "Id": 11,
+        "Name": "Islegging ved land, ope utpå",
         "Description": null
       },
       {
@@ -431,13 +446,18 @@
         "Description": null
       },
       {
-        "Id": 41,
-        "Name": "Drivande sarr på elv",
+        "Id": 21,
+        "Name": "Heile sjøen islagd",
         "Description": null
       },
       {
         "Id": 40,
         "Name": "Isgang i elv",
+        "Description": null
+      },
+      {
+        "Id": 41,
+        "Name": "Drivande sarr på elv",
         "Description": null
       },
       {
@@ -453,14 +473,14 @@
         "Description": null
       },
       {
-        "Id": 2,
-        "Name": "Isfritt, no første is ved land",
-        "Description": "Ingen is tidlegare denne sesongen. I dag is langs land."
+        "Id": 1,
+        "Name": "Isfritt, no fyrste is målestad",
+        "Description": "Ingen is på målestaden før i dag. Det kan ha vore is langs land. Målestad er vanlegvis noko utpå vatnet."
       },
       {
-        "Id": 1,
-        "Name": "Isfritt, no første is målestad",
-        "Description": "Ingen is på målestaden før i dag. Det kan ha vore is langs land. Målestad er vanlegvis noko utpå vatnet."
+        "Id": 2,
+        "Name": "Isfritt, no fyrste is ved land",
+        "Description": "Ingen is tidlegare denne sesongen. I dag is langs land."
       },
       {
         "Id": 3,
@@ -474,7 +494,7 @@
       },
       {
         "Id": 99,
-        "Name": "Brot - Ukjent før no",
+        "Name": "Ukjent istilhøve før no",
         "Description": "Brot i målingane. Istilhøve frå førre måling er neppe gyldige til i går."
       }
     ],
@@ -621,6 +641,11 @@
         "Description": null
       },
       {
+        "Id": 60,
+        "Name": "Isnedfall",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Anna (bruk kommentar)",
         "Description": null
@@ -648,11 +673,6 @@
         "Description": null
       },
       {
-        "Id": 4,
-        "Name": "Ferske sprekker",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "Stort snøfall",
         "Description": "Brukes i elrapp"
@@ -669,7 +689,17 @@
       },
       {
         "Id": 9,
-        "Name": "Fersk vindtransporter snø",
+        "Name": "Fersk vindtransportert snø",
+        "Description": null
+      },
+      {
+        "Id": 14,
+        "Name": "Skytande sprekkar",
+        "Description": null
+      },
+      {
+        "Id": 15,
+        "Name": "Ferske glidesprekkar",
         "Description": null
       },
       {
@@ -690,13 +720,13 @@
         "Description": null
       },
       {
-        "Id": 113,
-        "Name": "Ski, offpiste",
+        "Id": 112,
+        "Name": "Ski i anlegg",
         "Description": null
       },
       {
-        "Id": 112,
-        "Name": "Ski i anlegg",
+        "Id": 113,
+        "Name": "Ski, offpiste",
         "Description": null
       },
       {
@@ -720,13 +750,13 @@
         "Description": null
       },
       {
-        "Id": 130,
-        "Name": "Snøskuter",
+        "Id": 120,
+        "Name": "Veg",
         "Description": null
       },
       {
-        "Id": 120,
-        "Name": "Veg",
+        "Id": 130,
+        "Name": "Snøskuter",
         "Description": null
       },
       {
@@ -752,23 +782,23 @@
         "Description": null
       },
       {
-        "Id": 12,
-        "Name": "Tørt laussnøskred",
-        "Description": null
-      },
-      {
         "Id": 11,
         "Name": "Vått laussnøskred",
         "Description": null
       },
       {
-        "Id": 22,
-        "Name": "Tørt flakskred",
+        "Id": 12,
+        "Name": "Tørt laussnøskred",
         "Description": null
       },
       {
         "Id": 21,
         "Name": "Vått flakskred",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Tørt flakskred",
         "Description": null
       },
       {
@@ -874,58 +904,58 @@
       },
       {
         "Id": 10,
-        "Name": null,
-        "Description": null
+        "Name": "Nedføyka løs nysnø",
+        "Description": "Nedføyka løs nysnø"
       },
       {
         "Id": 11,
-        "Name": null,
-        "Description": null
+        "Name": "Nedsnødd overflaterim",
+        "Description": "Nedsnødd overflaterim"
       },
       {
         "Id": 13,
-        "Name": null,
-        "Description": null
+        "Name": "Nedsnødd kantkorna snø",
+        "Description": "Nedsnødd kantkorna snø"
       },
       {
         "Id": 14,
-        "Name": null,
-        "Description": null
+        "Name": "Dårleg binding mot skare",
+        "Description": "Dårleg binding mot skare"
       },
       {
         "Id": 15,
-        "Name": null,
-        "Description": null
+        "Name": "Dårleg binding i fokksnøen",
+        "Description": "Dårleg binding i fokksnøen"
       },
       {
         "Id": 16,
-        "Name": null,
-        "Description": null
-      },
-      {
-        "Id": 19,
-        "Name": null,
-        "Description": null
+        "Name": "Kantkorna snø ved bakken",
+        "Description": "Kantkorna snø ved bakken"
       },
       {
         "Id": 18,
-        "Name": null,
-        "Description": null
+        "Name": "Kantkorna snø over skare",
+        "Description": "Kantkorna snø over skare"
       },
       {
-        "Id": 22,
-        "Name": null,
-        "Description": null
+        "Id": 19,
+        "Name": "Kantkorna snø under skare",
+        "Description": "Kantkorna snø under skare"
       },
       {
         "Id": 20,
-        "Name": null,
-        "Description": null
+        "Name": "Smelting frå bakken",
+        "Description": "Smelting frå bakken"
+      },
+      {
+        "Id": 22,
+        "Name": "Opphoping av vatn over lag",
+        "Description": "Opphoping av vatn over lag"
       },
       {
         "Id": 24,
-        "Name": null,
-        "Description": null
+        "Name": "Ubunden snø",
+        "Description": "Ubunden snø"
       }
     ],
     "Snow_AvalCauseDepthKDV": [
@@ -968,7 +998,7 @@
       },
       {
         "Id": 8,
-        "Name": "Stor krystall som er lett å identifisere i det svake laget. ",
+        "Name": "Stor krystall som er lett å kjenne igjen i det svake laget. ",
         "Description": null
       }
     ],
@@ -1054,7 +1084,7 @@
       },
       {
         "Id": 7,
-        "Name": "Snøen er overmettet med vatn",
+        "Name": "Snøen er overmetta med vatn",
         "Description": null
       },
       {
@@ -1067,6 +1097,11 @@
       {
         "Id": 0,
         "Name": "Ikkje gitt",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Naturleg utløyst",
         "Description": null
       },
       {
@@ -1087,11 +1122,6 @@
       {
         "Id": 60,
         "Name": "Svært lett å løyse ut",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "Naturleg utløyst",
         "Description": null
       }
     ],
@@ -1294,16 +1324,6 @@
         "Description": null
       },
       {
-        "Id": 26,
-        "Name": "Personutløyst",
-        "Description": null
-      },
-      {
-        "Id": 27,
-        "Name": "Skuterutløyst",
-        "Description": null
-      },
-      {
         "Id": 22,
         "Name": "Fjernutløyst",
         "Description": null
@@ -1316,6 +1336,16 @@
       {
         "Id": 25,
         "Name": "Utløyst med sprengstoff",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Personutløyst",
+        "Description": null
+      },
+      {
+        "Id": 27,
+        "Name": "Skuterutløyst",
         "Description": null
       },
       {
@@ -1388,6 +1418,21 @@
         "Description": null
       },
       {
+        "Id": 50,
+        "Name": "Overflatekantkorn",
+        "Description": null
+      },
+      {
+        "Id": 61,
+        "Name": "Rim på hardt underlag",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Rim på mjukt underlag",
+        "Description": null
+      },
+      {
         "Id": 101,
         "Name": "Svært mykje tørr laussnø (>30cm)",
         "Description": null
@@ -1403,23 +1448,8 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Rim på hardt underlag",
-        "Description": null
-      },
-      {
-        "Id": 62,
-        "Name": "Rim på mjukt underlag",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Overflatekantkorn",
-        "Description": null
-      },
-      {
-        "Id": 107,
-        "Name": "Skare",
+        "Id": 104,
+        "Name": "Våt laussnø",
         "Description": null
       },
       {
@@ -1433,8 +1463,8 @@
         "Description": null
       },
       {
-        "Id": 104,
-        "Name": "Våt laussnø",
+        "Id": 107,
+        "Name": "Skare",
         "Description": null
       },
       {
@@ -1531,26 +1561,6 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "ECTPV",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "ECTP",
-        "Description": null
-      },
-      {
-        "Id": 23,
-        "Name": "ECTN",
-        "Description": null
-      },
-      {
-        "Id": 24,
-        "Name": "ECTX",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "LBT",
         "Description": null
@@ -1578,6 +1588,26 @@
       {
         "Id": 15,
         "Name": "CTN",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "ECTPV",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "ECTP",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "ECTN",
+        "Description": null
+      },
+      {
+        "Id": 24,
+        "Name": "ECTX",
         "Description": null
       }
     ],
@@ -1748,7 +1778,7 @@
     "Snow_GrainFormKDV": [
       {
         "Id": 0,
-        "Name": "-",
+        "Name": " - ",
         "Description": null
       },
       {
@@ -1973,7 +2003,7 @@
       },
       {
         "Id": 45,
-        "Name": "Ifrc",
+        "Name": "IFrc",
         "Description": null
       },
       {
@@ -2001,6 +2031,38 @@
       {
         "Id": 13,
         "Name": "Heile laget",
+        "Description": null
+      }
+    ],
+    "Snow_SkiConditionsKDV": [
+      {
+        "Id": 0,
+        "Name": "Not given",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Bad",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Ok",
+        "Description": null
+      },
+      {
+        "Id": 30,
+        "Name": "Good",
+        "Description": null
+      },
+      {
+        "Id": 40,
+        "Name": "Very Good",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Perfect",
         "Description": null
       }
     ],
@@ -2101,7 +2163,7 @@
       },
       {
         "Id": 130,
-        "Name": "Flomstøtte",
+        "Name": "Flaumstøtte",
         "Description": null
       },
       {
@@ -2393,6 +2455,66 @@
         "Id": 0,
         "Name": "0",
         "Description": "Ikkje gitt"
+      },
+      {
+        "Id": 10,
+        "Name": "480",
+        "Description": "08:00"
+      },
+      {
+        "Id": 20,
+        "Name": "540",
+        "Description": "09:00"
+      },
+      {
+        "Id": 30,
+        "Name": "600",
+        "Description": "10:00"
+      },
+      {
+        "Id": 40,
+        "Name": "660",
+        "Description": "11:00"
+      },
+      {
+        "Id": 50,
+        "Name": "720",
+        "Description": "12:00"
+      },
+      {
+        "Id": 60,
+        "Name": "780",
+        "Description": "13:00"
+      },
+      {
+        "Id": 70,
+        "Name": "840",
+        "Description": "14:00"
+      },
+      {
+        "Id": 80,
+        "Name": "900",
+        "Description": "15:00"
+      },
+      {
+        "Id": 90,
+        "Name": "960",
+        "Description": "16:00"
+      },
+      {
+        "Id": 100,
+        "Name": "1080",
+        "Description": "18:00"
+      },
+      {
+        "Id": 110,
+        "Name": "1200",
+        "Description": "20:00"
+      },
+      {
+        "Id": 120,
+        "Name": "1320",
+        "Description": "22:00"
       }
     ],
     "ForecastAccurateKDV": [
@@ -2413,7 +2535,7 @@
       },
       {
         "Id": 3,
-        "Name": "Varselet stemte",
+        "Name": "Varsel stemte",
         "Description": null
       },
       {
@@ -2435,7 +2557,7 @@
       },
       {
         "Id": 10,
-        "Name": "Påvirka ikkje noko",
+        "Name": "Påverka ikkje noko",
         "Description": null
       },
       {
@@ -2449,13 +2571,13 @@
         "Description": null
       },
       {
-        "Id": 25,
-        "Name": "Evakuering",
+        "Id": 20,
+        "Name": "Berre materielle skadar",
         "Description": null
       },
       {
-        "Id": 20,
-        "Name": "Berre materielle skadar",
+        "Id": 25,
+        "Name": "Evakuering",
         "Description": null
       },
       {
@@ -2496,6 +2618,11 @@
         "Description": "Ukjent kompetanse på snø."
       },
       {
+        "Id": 105,
+        "Name": "A",
+        "Description": "Automatisert tjeneste"
+      },
+      {
         "Id": 110,
         "Name": "*",
         "Description": "Observatøren kan det grunnleggande for å vurdere snøskredfare. Observatøren er ikkje kursa om korleis regObs og Varsom formidlar snøskredfare. Kompetansen tilsvarar NVE sitt nivå 4a."
@@ -2519,11 +2646,6 @@
         "Id": 150,
         "Name": "*****",
         "Description": "Observatøren tilhøyrar ein varslingstjeneste. Kompetansen tilsvarar NVE sitt nivå 4c."
-      },
-      {
-        "Id": 105,
-        "Name": "A",
-        "Description": "Automatisert tjeneste"
       },
       {
         "Id": 200,
@@ -2730,26 +2852,6 @@
         "Description": null
       },
       {
-        "Id": 60,
-        "Name": "Privat tur",
-        "Description": null
-      },
-      {
-        "Id": 55,
-        "Name": "Undervising og kurs",
-        "Description": null
-      },
-      {
-        "Id": 70,
-        "Name": "Føring og guiding",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Oppdrag for arbeidsgjevar",
-        "Description": null
-      },
-      {
         "Id": 20,
         "Name": "Ordinært oppdrag for skredvarslinga",
         "Description": null
@@ -2762,6 +2864,26 @@
       {
         "Id": 40,
         "Name": "Tinga oppdrag for skredvarslinga",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Oppdrag for arbeidsgjevar",
+        "Description": null
+      },
+      {
+        "Id": 55,
+        "Name": "Undervising og kurs",
+        "Description": null
+      },
+      {
+        "Id": 60,
+        "Name": "Privat tur",
+        "Description": null
+      },
+      {
+        "Id": 70,
+        "Name": "Føring og guiding",
         "Description": null
       }
     ],
@@ -2864,18 +2986,152 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Underkjent av dataforvaltar",
-        "Description": null
-      },
-      {
         "Id": 52,
         "Name": "Sletta av admin",
         "Description": null
       },
       {
+        "Id": 61,
+        "Name": "Underkjent av dataforvaltar",
+        "Description": null
+      },
+      {
         "Id": 101,
         "Name": "Til administrativt bruk",
+        "Description": null
+      }
+    ],
+    "RegistrationKDV": [
+      {
+        "Id": 10,
+        "Name": "Notat",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Ulykke/hending",
+        "Description": null
+      },
+      {
+        "Id": 13,
+        "Name": "Fareteikn",
+        "Description": null
+      },
+      {
+        "Id": 14,
+        "Name": "Skadar",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "Vêr",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Snødekke",
+        "Description": null
+      },
+      {
+        "Id": 25,
+        "Name": "Testar",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Skredhending",
+        "Description": null
+      },
+      {
+        "Id": 31,
+        "Name": "Skredfarevurdering",
+        "Description": null
+      },
+      {
+        "Id": 32,
+        "Name": "Skredproblem",
+        "Description": null
+      },
+      {
+        "Id": 33,
+        "Name": "Skredaktivitet",
+        "Description": null
+      },
+      {
+        "Id": 36,
+        "Name": "Snøprofil",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Istjukkleik",
+        "Description": null
+      },
+      {
+        "Id": 51,
+        "Name": "Isdekking",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Vasstand",
+        "Description": "ny vannstandsobservasjon for flomdatabaseprosjekt"
+      },
+      {
+        "Id": 71,
+        "Name": "Skredhending",
+        "Description": null
+      },
+      {
+        "Id": 80,
+        "Name": "Hendingar",
+        "Description": null
+      },
+      {
+        "Id": 81,
+        "Name": "Skred og fareteikn",
+        "Description": null
+      },
+      {
+        "Id": 82,
+        "Name": "Snødekke og vêr",
+        "Description": null
+      },
+      {
+        "Id": 83,
+        "Name": "Vurderingar og problem",
+        "Description": "Grupperings type - Vurderinger og problemer"
+      }
+    ],
+    "SourceKDV": [
+      {
+        "Id": 0,
+        "Name": "Ikkje gitt",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Har sett dette sjølv",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Har blitt fortalt",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "Les i avis / rapport",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Sett bilde / webkamera / satellitt",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "Anteke/modellert",
         "Description": null
       }
     ]
@@ -3030,6 +3286,183 @@
         "AvalancheExtTID": 25,
         "AvalCauseTID": 22
       }
-    ]
+    ],
+    "RegistrationTypesV": {
+      "10": [
+        {
+          "Id": 80,
+          "Name": "Hendingar",
+          "SubTypes": [
+            {
+              "Id": 26,
+              "Name": "Skredhending",
+              "SortOrder": 12
+            },
+            {
+              "Id": 11,
+              "Name": "Ulykke/hending",
+              "SortOrder": 97
+            }
+          ],
+          "SortOrder": 80
+        },
+        {
+          "Id": 81,
+          "Name": "Skred og fareteikn",
+          "SubTypes": [
+            {
+              "Id": 13,
+              "Name": "Fareteikn",
+              "SortOrder": 10
+            },
+            {
+              "Id": 26,
+              "Name": "Skredhending",
+              "SortOrder": 12
+            },
+            {
+              "Id": 33,
+              "Name": "Skredaktivitet",
+              "SortOrder": 13
+            }
+          ],
+          "SortOrder": 81
+        },
+        {
+          "Id": 82,
+          "Name": "Snødekke og vêr",
+          "SubTypes": [
+            {
+              "Id": 21,
+              "Name": "Vêr",
+              "SortOrder": 14
+            },
+            {
+              "Id": 22,
+              "Name": "Snødekke",
+              "SortOrder": 14
+            },
+            {
+              "Id": 25,
+              "Name": "Testar",
+              "SortOrder": 16
+            },
+            {
+              "Id": 36,
+              "Name": "Snøprofil",
+              "SortOrder": 36
+            }
+          ],
+          "SortOrder": 82
+        },
+        {
+          "Id": 83,
+          "Name": "Vurderingar og problem",
+          "SubTypes": [
+            {
+              "Id": 32,
+              "Name": "Skredproblem",
+              "SortOrder": 17
+            },
+            {
+              "Id": 31,
+              "Name": "Skredfarevurdering",
+              "SortOrder": 18
+            }
+          ],
+          "SortOrder": 83
+        },
+        {
+          "Id": 10,
+          "Name": "Notat",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "20": [
+        {
+          "Id": 13,
+          "Name": "Fareteikn",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 71,
+          "Name": "Skredhending",
+          "SubTypes": [],
+          "SortOrder": 71
+        },
+        {
+          "Id": 10,
+          "Name": "Notat",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "60": [
+        {
+          "Id": 13,
+          "Name": "Fareteikn",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 14,
+          "Name": "Skadar",
+          "SubTypes": [],
+          "SortOrder": 14
+        },
+        {
+          "Id": 62,
+          "Name": "Vasstand",
+          "SubTypes": [],
+          "SortOrder": 62
+        },
+        {
+          "Id": 11,
+          "Name": "Ulykke/hending",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Notat",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "70": [
+        {
+          "Id": 51,
+          "Name": "Isdekking",
+          "SubTypes": [],
+          "SortOrder": 7
+        },
+        {
+          "Id": 50,
+          "Name": "Istjukkleik",
+          "SubTypes": [],
+          "SortOrder": 8
+        },
+        {
+          "Id": 13,
+          "Name": "Fareteikn",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 11,
+          "Name": "Ulykke/hending",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Notat",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ]
+    }
   }
 }

--- a/src/assets/json/kdvelements.sl.json
+++ b/src/assets/json/kdvelements.sl.json
@@ -3,7 +3,7 @@
     "Dirt_DangerSignKDV": [
       {
         "Id": 200,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -22,8 +22,13 @@
         "Description": null
       },
       {
-        "Id": 212,
-        "Name": "Snežna odeja z veliko vode",
+        "Id": 204,
+        "Name": "Površinski odtok",
+        "Description": null
+      },
+      {
+        "Id": 205,
+        "Name": "Nezadostno odvodnjavanje",
         "Description": null
       },
       {
@@ -37,26 +42,6 @@
         "Description": null
       },
       {
-        "Id": 230,
-        "Name": "Erozija ob potokih/rekah",
-        "Description": null
-      },
-      {
-        "Id": 214,
-        "Name": "Potoki najdejo nove poti",
-        "Description": null
-      },
-      {
-        "Id": 204,
-        "Name": "Površinski odtok",
-        "Description": null
-      },
-      {
-        "Id": 205,
-        "Name": "Nezadostno odvodnjavanje",
-        "Description": null
-      },
-      {
         "Id": 208,
         "Name": "Razpoke/drobir na terenu",
         "Description": null
@@ -64,6 +49,16 @@
       {
         "Id": 209,
         "Name": "Opažen zemeljski plaz",
+        "Description": null
+      },
+      {
+        "Id": 212,
+        "Name": "Snežna odeja z veliko vode",
+        "Description": null
+      },
+      {
+        "Id": 214,
+        "Name": "Potoki najdejo nove poti",
         "Description": null
       },
       {
@@ -77,6 +72,11 @@
         "Description": null
       },
       {
+        "Id": 230,
+        "Name": "Erozija ob potokih/rekah",
+        "Description": null
+      },
+      {
         "Id": 299,
         "Name": "Drugi znaki nevarnosti-kateri",
         "Description": null
@@ -85,7 +85,12 @@
     "Dirt_ActivityInfluencedKDV": [
       {
         "Id": 200,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
+        "Description": null
+      },
+      {
+        "Id": 211,
+        "Name": "Ljudje",
         "Description": null
       },
       {
@@ -99,18 +104,13 @@
         "Description": null
       },
       {
-        "Id": 260,
-        "Name": "Zgradbe",
-        "Description": null
-      },
-      {
-        "Id": 211,
-        "Name": "Ljudje",
-        "Description": null
-      },
-      {
         "Id": 251,
         "Name": "Kmetijske površine",
+        "Description": null
+      },
+      {
+        "Id": 260,
+        "Name": "Zgradbe",
         "Description": null
       },
       {
@@ -122,7 +122,7 @@
     "Dirt_LandSlideKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -138,11 +138,6 @@
       {
         "Id": 4,
         "Name": "Drobirski tok",
-        "Description": null
-      },
-      {
-        "Id": 11,
-        "Name": "Kamniti plaz",
         "Description": null
       },
       {
@@ -164,12 +159,17 @@
         "Id": 10,
         "Name": "Blatni tok",
         "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Kamniti plaz",
+        "Description": null
       }
     ],
     "Dirt_LandSlideTriggerKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -196,7 +196,7 @@
     "Dirt_LandSlideSizeKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -223,7 +223,7 @@
     "Ice_DangerSignKDV": [
       {
         "Id": 700,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -275,17 +275,12 @@
     "Ice_ActivityInfluencedKDV": [
       {
         "Id": 700,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
         "Id": 710,
         "Name": "Pohodništvo",
-        "Description": null
-      },
-      {
-        "Id": 714,
-        "Name": "Ribolov na ledu",
         "Description": null
       },
       {
@@ -304,8 +299,8 @@
         "Description": null
       },
       {
-        "Id": 719,
-        "Name": "Oseba, ki jo je poškodoval led",
+        "Id": 714,
+        "Name": "Ribolov na ledu",
         "Description": null
       },
       {
@@ -324,9 +319,24 @@
         "Description": null
       },
       {
-        "Id": 725,
-        "Name": "Potisne sani",
+        "Id": 719,
+        "Name": "Oseba, ki jo je poškodoval led",
         "Description": null
+      },
+      {
+        "Id": 720,
+        "Name": "Motorne sani na ledu",
+        "Description": null
+      },
+      {
+        "Id": 721,
+        "Name": "Avto na ledu",
+        "Description": null
+      },
+      {
+        "Id": 722,
+        "Name": "ATV",
+        "Description": "Terensko vozilo"
       },
       {
         "Id": 723,
@@ -339,18 +349,8 @@
         "Description": null
       },
       {
-        "Id": 720,
-        "Name": "Motorne sani na ledu",
-        "Description": null
-      },
-      {
-        "Id": 722,
-        "Name": "ATV",
-        "Description": "Terensko vozilo"
-      },
-      {
-        "Id": 721,
-        "Name": "Avto na ledu",
+        "Id": 725,
+        "Name": "Potisne sani",
         "Description": null
       },
       {
@@ -389,6 +389,21 @@
         "Description": null
       },
       {
+        "Id": 775,
+        "Name": "Anchor ice dam",
+        "Description": null
+      },
+      {
+        "Id": 776,
+        "Name": "Frazil ice plugging",
+        "Description": null
+      },
+      {
+        "Id": 777,
+        "Name": "ledeni zamašek",
+        "Description": null
+      },
+      {
         "Id": 790,
         "Name": "Drugo",
         "Description": null
@@ -397,17 +412,12 @@
     "Ice_IceCoverKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
         "Id": 1,
         "Name": "Lokacija je brez ledu",
-        "Description": null
-      },
-      {
-        "Id": 11,
-        "Name": "Zaledenela obala",
         "Description": null
       },
       {
@@ -421,13 +431,13 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "Zaledenelo jezero",
+        "Id": 10,
+        "Name": "Lomljenje ledu ob obali",
         "Description": null
       },
       {
-        "Id": 10,
-        "Name": "Lomljenje ledu ob obali",
+        "Id": 11,
+        "Name": "Zaledenela obala",
         "Description": null
       },
       {
@@ -436,13 +446,18 @@
         "Description": null
       },
       {
-        "Id": 41,
-        "Name": "Plavajoči ledeni kosi na reki",
+        "Id": 21,
+        "Name": "Zaledenelo jezero",
         "Description": null
       },
       {
         "Id": 40,
         "Name": "Tok ledu po reki",
+        "Description": null
+      },
+      {
+        "Id": 41,
+        "Name": "Plavajoči ledeni kosi na reki",
         "Description": null
       },
       {
@@ -454,8 +469,13 @@
     "Ice_IceCoverBeforeKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
+      },
+      {
+        "Id": 1,
+        "Name": "Brez ledu, prvič opažen led",
+        "Description": "Pred današnjim dnem na območju opažanja ni bilo ledu. Led je morda bil ob obali. \"Območje opažanja\" je v splošnem navidezna točka na jezeru, ki ni ob obali."
       },
       {
         "Id": 2,
@@ -463,30 +483,25 @@
         "Description": "Pred današnjim dnem ob obali ni bilo ledu."
       },
       {
-        "Id": 1,
-        "Name": "Brez ledu, prvič opažen led",
-        "Description": "Pred današnjim dnem na območju opazovanja ni bilo ledu. Led je morda bil ob obali. \"Območje opazovanja\" je v splošnem navidezna točka na jezeru, ki ni ob obali."
-      },
-      {
         "Id": 3,
-        "Name": "Brez ledu, tudi danes",
+        "Name": "Brez ledu do sedaj, tudi danes",
         "Description": "Brez ledu v tekoči zimski sezoni, vključno z današnjim dnem."
       },
       {
         "Id": 10,
-        "Name": "Opazovanje veljavno do včeraj",
-        "Description": "Kontinuirana opazovanja. Lahko sklepamo, da je obseg ledene površine s prejšnjega opazovanja veljaven do včerajšnjega dne. Danes je lahko vrednost drugačna (ali pa enaka)."
+        "Name": "Opažanje veljavno do včeraj",
+        "Description": "Neprekinjena opažanja. Lahko sklepamo, da je obseg ledene površine s prejšnjega opažanja veljaven do včerajšnjega dne. Danes je lahko vrednost drugačna (ali pa enaka)."
       },
       {
         "Id": 99,
-        "Name": "Luknja - neznano do danes",
-        "Description": "Napaka pri meritvah. Opažen obseg ledene površine s prejšnjega opazovanja verjetno ne predstavlja dejanskega stanja do včeraj."
+        "Name": "Neznano predhodno stanje ledu",
+        "Description": "Napaka pri meritvah. Opažen obseg ledene površine s prejšnjega opažanja verjetno ne predstavlja dejanskega stanja do včeraj."
       }
     ],
     "Ice_IceLayerKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -538,7 +553,7 @@
     "Ice_IceSkateabilityKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -570,7 +585,7 @@
     "Ice_IceCapacityKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -597,7 +612,7 @@
     "Ice_IceProblemKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -626,6 +641,11 @@
         "Description": null
       },
       {
+        "Id": 60,
+        "Name": "Ice fall",
+        "Description": "English expression"
+      },
+      {
         "Id": 99,
         "Name": "Drugo (uporabi komentar)",
         "Description": null
@@ -634,7 +654,7 @@
     "Snow_DangerSignKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -650,11 +670,6 @@
       {
         "Id": 3,
         "Name": "Whumpf zvok",
-        "Description": null
-      },
-      {
-        "Id": 4,
-        "Name": "Sveže razpoke",
         "Description": null
       },
       {
@@ -678,6 +693,16 @@
         "Description": null
       },
       {
+        "Id": 14,
+        "Name": "Shooting cracks",
+        "Description": null
+      },
+      {
+        "Id": 15,
+        "Name": "Glide cracks",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Drugi znaki nevarnosti(navedi)",
         "Description": null
@@ -686,7 +711,7 @@
     "Snow_ActivityInfluencedKDV": [
       {
         "Id": 100,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -695,13 +720,13 @@
         "Description": null
       },
       {
-        "Id": 113,
-        "Name": "Smučanje izven urejenih prog",
+        "Id": 112,
+        "Name": "Smučišče",
         "Description": null
       },
       {
-        "Id": 112,
-        "Name": "Smučišče",
+        "Id": 113,
+        "Name": "Smučanje izven urejenih prog",
         "Description": null
       },
       {
@@ -725,13 +750,13 @@
         "Description": null
       },
       {
-        "Id": 130,
-        "Name": "Motorne sani",
+        "Id": 120,
+        "Name": "Cesta",
         "Description": null
       },
       {
-        "Id": 120,
-        "Name": "Cesta",
+        "Id": 130,
+        "Name": "Motorne sani",
         "Description": null
       },
       {
@@ -753,12 +778,7 @@
     "Snow_AvalancheKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
-        "Description": null
-      },
-      {
-        "Id": 12,
-        "Name": "Plaz suhega nesprijetega snega",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -767,13 +787,18 @@
         "Description": null
       },
       {
-        "Id": 22,
-        "Name": "Suh kložast plaz",
+        "Id": 12,
+        "Name": "Plaz suhega nesprijetega snega",
         "Description": null
       },
       {
         "Id": 21,
         "Name": "Moker kložast plaz",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Suh kložast plaz",
         "Description": null
       },
       {
@@ -800,7 +825,7 @@
     "Snow_AvalancheDangerKDV": [
       {
         "Id": 0,
-        "Name": "0 Ni določeno",
+        "Name": "0 Ni podano",
         "Description": null
       },
       {
@@ -832,7 +857,7 @@
     "Snow_AvalancheExtKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -874,8 +899,8 @@
     "Snow_AvalCauseKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
-        "Description": "Ni določeno"
+        "Name": "Ni podano",
+        "Description": "Ni podano"
       },
       {
         "Id": 10,
@@ -908,24 +933,24 @@
         "Description": "Srež blizu tal"
       },
       {
-        "Id": 19,
-        "Name": "Srež pod skorjo",
-        "Description": "Srež pod skorjo"
-      },
-      {
         "Id": 18,
         "Name": "Srež nad skorjo",
         "Description": "Srež nad skorjo"
       },
       {
-        "Id": 22,
-        "Name": "Luže nad snežnimi plastmi",
-        "Description": "Luže nad snežnimi plastmi"
+        "Id": 19,
+        "Name": "Srež pod skorjo",
+        "Description": "Srež pod skorjo"
       },
       {
         "Id": 20,
         "Name": "Taljenje blizu tal",
         "Description": "Taljenje blizu tal"
+      },
+      {
+        "Id": 22,
+        "Name": "Nabiranje vode med snežnimi plastmi",
+        "Description": "Nabiranje vode med snežnimi plastmi"
       },
       {
         "Id": 24,
@@ -936,17 +961,17 @@
     "Snow_AvalCauseDepthKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
         "Id": 1,
-        "Name": "V pol metra",
+        "Name": "Do pol metra",
         "Description": null
       },
       {
         "Id": 2,
-        "Name": "V enem metru",
+        "Name": "Do enega metra",
         "Description": null
       },
       {
@@ -958,7 +983,7 @@
     "Snow_AvalCauseAttributeFlags": [
       {
         "Id": 1,
-        "Name": "Šibka plast se zruši enostavno in čisto (enostavno širjenje).",
+        "Name": "Šibka plast se zruši enostavno in čisto (enostavno napredovanje).",
         "Description": null
       },
       {
@@ -973,14 +998,14 @@
       },
       {
         "Id": 8,
-        "Name": "Veliki, prepoznavni kristali v šibki plasti.",
+        "Name": "Velika, prepoznavna zrna v šibki plasti.",
         "Description": null
       }
     ],
     "Snow_AvalProbabilityKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1007,7 +1032,7 @@
     "Snow_AvalPropagationKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1029,7 +1054,7 @@
     "Snow_AvalReleaseHeightKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1071,7 +1096,12 @@
     "Snow_AvalTriggerSimpleKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Spontano proženje",
         "Description": null
       },
       {
@@ -1093,17 +1123,12 @@
         "Id": 60,
         "Name": "Zelo lahko sprožiti",
         "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "Spontano proženje",
-        "Description": null
       }
     ],
     "Snow_DestructiveSizeKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1140,7 +1165,7 @@
     "Snow_SnowDriftKDV": [
       {
         "Id": 0,
-        "Name": "Ni opaziti",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1155,7 +1180,7 @@
       },
       {
         "Id": 3,
-        "Name": "Znatno napihanega snega",
+        "Name": "Znatno veliko napihanega snega",
         "Description": null
       },
       {
@@ -1167,7 +1192,7 @@
     "Snow_EstimatedNumKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1199,7 +1224,7 @@
     "Snow_ExposedHeightComboKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1226,7 +1251,7 @@
     "Snow_ForecastCorrectKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1248,7 +1273,7 @@
     "Snow_PrecipitationKDV": [
       {
         "Id": 0,
-        "Name": "Ni opaziti",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1290,22 +1315,12 @@
     "Snow_AvalancheTriggerKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
         "Id": 10,
         "Name": "Spontano sproženje",
-        "Description": null
-      },
-      {
-        "Id": 26,
-        "Name": "Sprožil človek",
-        "Description": null
-      },
-      {
-        "Id": 27,
-        "Name": "Sprožile snežne sani",
         "Description": null
       },
       {
@@ -1324,6 +1339,16 @@
         "Description": null
       },
       {
+        "Id": 26,
+        "Name": "Sprožil človek",
+        "Description": null
+      },
+      {
+        "Id": 27,
+        "Name": "Sprožile snežne sani",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Neznano",
         "Description": null
@@ -1332,7 +1357,7 @@
     "Snow_TerrainStartZoneKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1389,7 +1414,22 @@
     "Snow_SnowSurfaceKDV": [
       {
         "Id": 0,
-        "Name": "Ni opaziti",
+        "Name": "Ni podano",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Plast oglatih zrn blizu površja snežne odeje",
+        "Description": null
+      },
+      {
+        "Id": 61,
+        "Name": "Površinski srež na trdi podlagi",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Površinski srež na mehki podlagi",
         "Description": null
       },
       {
@@ -1408,23 +1448,8 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Površinski srež na trdi podlagi",
-        "Description": null
-      },
-      {
-        "Id": 62,
-        "Name": "Površinski srež na mehki podlagi",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Plast oglatih kristalov blizu površja snežne odeje",
-        "Description": null
-      },
-      {
-        "Id": 107,
-        "Name": "Skorja",
+        "Id": 104,
+        "Name": "Moker nesprijet sneg",
         "Description": null
       },
       {
@@ -1438,8 +1463,8 @@
         "Description": null
       },
       {
-        "Id": 104,
-        "Name": "Moker nesprijet sneg",
+        "Id": 107,
+        "Name": "Skorja",
         "Description": null
       },
       {
@@ -1451,7 +1476,7 @@
     "Snow_SurfaceWaterContentKDV": [
       {
         "Id": 0,
-        "Name": "Ni opaziti",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1461,34 +1486,34 @@
       },
       {
         "Id": 2,
-        "Name": "Suh",
+        "Name": "Suha",
         "Description": null
       },
       {
         "Id": 3,
-        "Name": "Vlažen",
+        "Name": "Rahlo vlažna",
         "Description": null
       },
       {
         "Id": 4,
-        "Name": "Moker",
+        "Name": "Vlažna",
         "Description": null
       },
       {
         "Id": 5,
-        "Name": "Zelo moker",
+        "Name": "Mokra",
         "Description": null
       },
       {
         "Id": 6,
-        "Name": "Plundra",
+        "Name": "Zelo mokra",
         "Description": null
       }
     ],
     "Snow_StabilityEvalKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -1510,79 +1535,79 @@
     "Snow_ComprTestFractureKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
         "Id": 1,
-        "Name": "Q1",
+        "Name": "Q1 (čist,gladek, hiter prelom)",
         "Description": null
       },
       {
         "Id": 2,
-        "Name": "Q2",
+        "Name": "Q2 (večinoma gladek prelom)",
         "Description": null
       },
       {
         "Id": 3,
-        "Name": "Q3",
+        "Name": "Q3 (nepravilen, hrapav prelom)",
         "Description": null
       }
     ],
     "Snow_PropagationKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
-        "Description": null
-      },
-      {
-        "Id": 21,
-        "Name": "ECTPV",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "ECTP",
-        "Description": null
-      },
-      {
-        "Id": 23,
-        "Name": "ECTN",
-        "Description": null
-      },
-      {
-        "Id": 24,
-        "Name": "ECTX",
+        "Name": "Ni podano",
         "Description": null
       },
       {
         "Id": 5,
-        "Name": "Preizkus majhne klade (KBT)",
+        "Name": "Majhen snežni blok (KBT)",
         "Description": null
       },
       {
         "Id": 11,
-        "Name": "CTV",
+        "Name": "CTV(porušitev med pripravo)",
         "Description": null
       },
       {
         "Id": 12,
-        "Name": "CTE",
+        "Name": "CTE(porušitev, lahki udarci)",
         "Description": null
       },
       {
         "Id": 13,
-        "Name": "CTM",
+        "Name": "CTM(porušitev, zmerni udarci)",
         "Description": null
       },
       {
         "Id": 14,
-        "Name": "CTH",
+        "Name": "CTH(porušitev, močni udarci)",
         "Description": null
       },
       {
         "Id": 15,
-        "Name": "CTN",
+        "Name": "CTN(ni porušitve)",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "ECTPV(porušitev med pripravo)",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "ECTP(razpoka napreduje)",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "ECTN(razpoka ne napreduje)",
+        "Description": null
+      },
+      {
+        "Id": 24,
+        "Name": "ECTX(ni porušitve)",
         "Description": null
       }
     ],
@@ -1594,47 +1619,47 @@
       },
       {
         "Id": 1,
-        "Name": "D",
+        "Name": "suh sneg (D)",
         "Description": null
       },
       {
         "Id": 2,
-        "Name": "D-M",
+        "Name": "suh - rahlo vlažen sneg (D-M)",
         "Description": null
       },
       {
         "Id": 3,
-        "Name": "M",
+        "Name": "rahlo vlažen sneg (M)",
         "Description": null
       },
       {
         "Id": 4,
-        "Name": "M-W",
+        "Name": "rahlo vlažen - vlažen (M-W)",
         "Description": null
       },
       {
         "Id": 5,
-        "Name": "W",
+        "Name": "vlažen sneg (W)",
         "Description": null
       },
       {
         "Id": 6,
-        "Name": "W-V",
+        "Name": "vlažen - moker sneg (W-V)",
         "Description": null
       },
       {
         "Id": 7,
-        "Name": "V",
+        "Name": "moker sneg (V)",
         "Description": null
       },
       {
         "Id": 8,
-        "Name": "V-S",
+        "Name": "moker - zelo moker sneg (V-S)",
         "Description": null
       },
       {
         "Id": 9,
-        "Name": "S",
+        "Name": "zelo moker sneg (S)",
         "Description": null
       }
     ],
@@ -1646,107 +1671,107 @@
       },
       {
         "Id": 1,
-        "Name": "F-",
+        "Name": "pest- (F-)",
         "Description": null
       },
       {
         "Id": 2,
-        "Name": "F",
+        "Name": "pest (F)",
         "Description": null
       },
       {
         "Id": 3,
-        "Name": "F+",
+        "Name": "pest+ (F+)",
         "Description": null
       },
       {
         "Id": 4,
-        "Name": " F-4F",
+        "Name": "pest-štirje prsti (F-4F)",
         "Description": null
       },
       {
         "Id": 5,
-        "Name": "4F-",
+        "Name": "štirje prsti- (4F-)",
         "Description": null
       },
       {
         "Id": 6,
-        "Name": "4F",
+        "Name": "štirje prsti (4F)",
         "Description": null
       },
       {
         "Id": 7,
-        "Name": "4F+",
+        "Name": "štirje prsti+ (4F+)",
         "Description": null
       },
       {
         "Id": 8,
-        "Name": "4F-1F",
+        "Name": "štirje prsti-en prst (4F-1F)",
         "Description": null
       },
       {
         "Id": 9,
-        "Name": "1F-",
+        "Name": "en prst- (1F-)",
         "Description": null
       },
       {
         "Id": 10,
-        "Name": "1F",
+        "Name": "en prst (1F)",
         "Description": null
       },
       {
         "Id": 11,
-        "Name": "1F+",
+        "Name": "en prst+ (1F+)",
         "Description": null
       },
       {
         "Id": 12,
-        "Name": "1F-P",
+        "Name": "en prst-svinčnik (1F-P)",
         "Description": null
       },
       {
         "Id": 13,
-        "Name": "P-",
+        "Name": "svinčnik- (P-)",
         "Description": null
       },
       {
         "Id": 14,
-        "Name": "P",
+        "Name": "svinčnik (P)",
         "Description": null
       },
       {
         "Id": 15,
-        "Name": "P+",
+        "Name": "svinčnik+ (P+)",
         "Description": null
       },
       {
         "Id": 16,
-        "Name": "P-K",
+        "Name": "svinčnik-nož (P-K)",
         "Description": null
       },
       {
         "Id": 17,
-        "Name": "K-",
+        "Name": "nož- (K-)",
         "Description": null
       },
       {
         "Id": 18,
-        "Name": "K",
+        "Name": "nož (K)",
         "Description": null
       },
       {
         "Id": 19,
-        "Name": "K+",
+        "Name": "nož+ (K+)",
         "Description": null
       },
       {
         "Id": 20,
-        "Name": "K-I",
+        "Name": "nož-led (K-I)",
         "Description": null
       },
       {
         "Id": 21,
-        "Name": "I",
+        "Name": "led (I)",
         "Description": null
       }
     ],
@@ -1990,7 +2015,7 @@
     "Snow_CriticalLayerKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -2009,10 +2034,42 @@
         "Description": null
       }
     ],
+    "Snow_SkiConditionsKDV": [
+      {
+        "Id": 0,
+        "Name": "Not given",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Bad",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Ok",
+        "Description": null
+      },
+      {
+        "Id": 30,
+        "Name": "Good",
+        "Description": null
+      },
+      {
+        "Id": 40,
+        "Name": "Very Good",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Perfect",
+        "Description": null
+      }
+    ],
     "Water_DangerSignKDV": [
       {
         "Id": 600,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -2054,7 +2111,7 @@
     "Water_ActivityInfluencedKDV": [
       {
         "Id": 600,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -2091,7 +2148,7 @@
     "Water_WaterLevelRefKDV": [
       {
         "Id": 100,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -2116,7 +2173,7 @@
       },
       {
         "Id": 200,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -2268,7 +2325,7 @@
       },
       {
         "Id": 3,
-        "Name": "Na poplavni obelisk",
+        "Name": "Poplavni obelisk",
         "Description": "Na poplavnem obelisku"
       },
       {
@@ -2463,7 +2520,7 @@
     "ForecastAccurateKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -2495,7 +2552,7 @@
     "DamageExtentKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -2514,13 +2571,13 @@
         "Description": null
       },
       {
-        "Id": 25,
-        "Name": "Evakuacija",
+        "Id": 20,
+        "Name": "Le materialna škoda",
         "Description": null
       },
       {
-        "Id": 20,
-        "Name": "Le materialna škoda",
+        "Id": 25,
+        "Name": "Evakuacija",
         "Description": null
       },
       {
@@ -2553,12 +2610,17 @@
       {
         "Id": 0,
         "Name": "Neznano",
-        "Description": "Kompetence niso znane."
+        "Description": "Neznana usposobljenost."
       },
       {
         "Id": 100,
         "Name": "-",
-        "Description": "Kompetence za sneg niso znane."
+        "Description": "Neznano za sneg."
+      },
+      {
+        "Id": 105,
+        "Name": "A",
+        "Description": "Samodejna storitev"
       },
       {
         "Id": 110,
@@ -2586,134 +2648,129 @@
         "Description": "Opazovalec je prognostik v plazovni službi."
       },
       {
-        "Id": 105,
-        "Name": "A",
-        "Description": "Samodejna storitev"
-      },
-      {
         "Id": 200,
         "Name": "-",
-        "Description": "Kompetence niso znane."
+        "Description": "Neznana usposobljenost."
       },
       {
         "Id": 210,
         "Name": "*",
-        "Description": "Opazovalec je oddal relevantno opazovanje."
+        "Description": "Opazovalec je oddal ustrezna opažanja."
       },
       {
         "Id": 220,
         "Name": "**",
-        "Description": "Opazovalec je oddal relevantno opazovanje s pravilno uporabo obrazcev Regobs."
+        "Description": "Opazovalec je oddal ustrezna opažanja s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 230,
         "Name": "***",
-        "Description": "Strokovnjak z več relevantnimi opazovanji."
+        "Description": "Strokovnjak z več ustreznimi opažanji."
       },
       {
         "Id": 240,
         "Name": "****",
-        "Description": "Izkušen strokovnjak z več relevantnimi opazovanji, oddanimi s pravilno uporabo obrazcev Regobs."
+        "Description": "Izkušen strokovnjak z več ustreznimi opažanji, oddanimi s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 250,
         "Name": "*****",
-        "Description": "Strokovnjak z NVE z več relevantnimi opazovanji, oddanimi s pravilno uporabo obrazcev Regobs."
+        "Description": "Strokovnjak iz pristojnih služb, z več ustreznimi opažanji, oddanimi s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 300,
         "Name": "-",
-        "Description": "Kompetence niso znane."
+        "Description": "Neznana usposobljenost."
       },
       {
         "Id": 310,
         "Name": "*",
-        "Description": "Opazovalec je oddal relevantna opazovanja."
+        "Description": "Opazovalec je oddal ustrezna opažanja."
       },
       {
         "Id": 320,
         "Name": "**",
-        "Description": "Opazovalec je oddal relevantno opazovanje s pravilno uporabo obrazcev Regobs."
+        "Description": "Opazovalec je oddal ustrezna opažanja s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 330,
         "Name": "***",
-        "Description": "Strokovnjak z več relevantnimi opazovanji."
+        "Description": "Strokovnjak z več ustreznimi opažanji."
       },
       {
         "Id": 340,
         "Name": "****",
-        "Description": "Izkušen strokovnjak z več relevantnimi opazovanji, oddanimi s pravilno uporabo obrazcev Regobs."
+        "Description": "Izkušen strokovnjak z več ustreznimi opažanji, oddanimi s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 350,
         "Name": "*****",
-        "Description": "Strokovnjak z NVE z več relevantnimi opazovanji, oddanimi s pravilno uporabo obrazcev Regobs."
+        "Description": "Strokovnjak iz pristojnih služb, z več ustreznimi opažanji, oddanimi s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 400,
         "Name": "-",
-        "Description": "Kompetence niso znane."
+        "Description": "Neznana usposobljenost."
       },
       {
         "Id": 410,
         "Name": "*",
-        "Description": "Opazovalec je oddal relevantna opazovanja."
+        "Description": "Opazovalec je oddal ustrezna opažanja."
       },
       {
         "Id": 420,
         "Name": "**",
-        "Description": "Opazovalec je oddal relevantno opazovanje s pravilno uporabo obrazcev Regobs."
+        "Description": "Opazovalec je oddal ustrezna opažanja s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 430,
         "Name": "***",
-        "Description": "Strokovnjak z več relevantnimi opazovanji."
+        "Description": "Strokovnjak z več ustreznimi opažanji."
       },
       {
         "Id": 440,
         "Name": "****",
-        "Description": "Izkušen strokovnjak z več relevantnimi opazovanji, oddanimi s pravilno uporabo obrazcev Regobs."
+        "Description": "Izkušen strokovnjak z več ustreznimi opažanji, oddanimi s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 450,
         "Name": "*****",
-        "Description": "Strokovnjak z NVE z več relevantnimi opazovanji, oddanimi s pravilno uporabo obrazcev Regobs."
+        "Description": "Strokovnjak iz pristojnih služb, z več ustreznimi opažanji, oddanimi s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 600,
         "Name": "-",
-        "Description": "Kompetence niso znane."
+        "Description": "Neznana usposobljenost."
       },
       {
         "Id": 610,
         "Name": "*",
-        "Description": "Opazovalec je oddal relevantna opazovanja."
+        "Description": "Opazovalec je oddal ustrezna opažanja."
       },
       {
         "Id": 620,
         "Name": "**",
-        "Description": "Opazovalec je oddal relevantno opazovanje s pravilno uporabo obrazcev Regobs."
+        "Description": "Opazovalec je oddal ustrezna opažanja s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 630,
         "Name": "***",
-        "Description": "Strokovnjak z več relevantnimi opazovanji."
+        "Description": "Strokovnjak z več ustreznimi opažanji."
       },
       {
         "Id": 640,
         "Name": "****",
-        "Description": "Izkušen strokovnjak z več relevantnimi opazovanji, oddanimi s pravilno uporabo obrazcev Regobs."
+        "Description": "Izkušen strokovnjak z več ustreznimi opažanji, oddanimi s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 650,
         "Name": "*****",
-        "Description": "Strokovnjak z NVE z več relevantnimi opazovanji, oddanimi s pravilno uporabo obrazcev Regobs."
+        "Description": "Strokovnjak iz pristojnih služb, z več ustreznimi opažanji, oddanimi s pravilno uporabo obrazcev Regobs."
       },
       {
         "Id": 700,
         "Name": "-",
-        "Description": "Kompetence za led niso znane."
+        "Description": "Neznano za led."
       },
       {
         "Id": 710,
@@ -2728,17 +2785,17 @@
       {
         "Id": 730,
         "Name": "***",
-        "Description": "Izkušen opazovalec z izkušnjami s terena."
+        "Description": "Izobražen opazovalec z izkušnjami s terena."
       },
       {
         "Id": 740,
         "Name": "****",
-        "Description": "Usposobljeno osebje."
+        "Description": "Izobraženo osebje."
       },
       {
         "Id": 750,
         "Name": "*****",
-        "Description": "Osebje, usposobljeno v NVE ali podobno."
+        "Description": "Izobraženo osebje v pristojnih službah (meteoroloških, hidroloških, plazovnih)."
       }
     ],
     "UTMSourceKDV": [
@@ -2795,40 +2852,45 @@
         "Description": null
       },
       {
-        "Id": 60,
-        "Name": "Zasebno",
-        "Description": null
-      },
-      {
-        "Id": 55,
-        "Name": "Izobraževalna pot",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Zaposleni",
-        "Description": null
-      },
-      {
         "Id": 20,
-        "Name": "Vrednost ni določena",
+        "Name": "Redna naloga za potrebe plazovne službe",
         "Description": null
       },
       {
         "Id": 30,
-        "Name": "Vrednost ni določena",
+        "Name": "Izredna naloga za potrebe plazovne službe",
         "Description": null
       },
       {
         "Id": 40,
-        "Name": "Vrednost ni določena",
+        "Name": "Naročena naloga za potrebe plazovne službe",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Službena pot",
+        "Description": null
+      },
+      {
+        "Id": 55,
+        "Name": "Izobraževanje ali tečaj",
+        "Description": null
+      },
+      {
+        "Id": 60,
+        "Name": "Zasebna pot",
+        "Description": null
+      },
+      {
+        "Id": 70,
+        "Name": "Vodena pot",
         "Description": null
       }
     ],
     "GeoHazardKDV": [
       {
         "Id": 0,
-        "Name": "Ni določeno",
+        "Name": "Ni podano",
         "Description": null
       },
       {
@@ -2900,7 +2962,7 @@
     "UsageFlagKDV": [
       {
         "Id": 0,
-        "Name": "Nobena oznaka ni dana",
+        "Name": "Oznaka ni podana",
         "Description": null
       },
       {
@@ -2924,19 +2986,153 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Zavrnil skrbnik podatkov",
+        "Id": 52,
+        "Name": "Izbrisal skrbnik podatkov",
         "Description": null
       },
       {
-        "Id": 52,
-        "Name": "Izbrisal skrbnik podatkov",
+        "Id": 61,
+        "Name": "Zavrnil skrbnik podatkov",
         "Description": null
       },
       {
         "Id": 101,
         "Name": "Za administrativne namene",
         "Description": "To opažanje ali skupina ima skrbniško funkcijo. Sicer je skrita, kot bi bila izbrisana."
+      }
+    ],
+    "RegistrationKDV": [
+      {
+        "Id": 10,
+        "Name": "Opombe",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Incident",
+        "Description": null
+      },
+      {
+        "Id": 13,
+        "Name": "Znak nevarnosti",
+        "Description": null
+      },
+      {
+        "Id": 14,
+        "Name": "Škoda",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "Vreme",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Snežna odeja",
+        "Description": null
+      },
+      {
+        "Id": 25,
+        "Name": "Preizkusi",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Snežni plaz",
+        "Description": null
+      },
+      {
+        "Id": 31,
+        "Name": "Ocena plazovne nevarnosti",
+        "Description": null
+      },
+      {
+        "Id": 32,
+        "Name": "Plazovni problemi",
+        "Description": null
+      },
+      {
+        "Id": 33,
+        "Name": "Plazovna aktivnost",
+        "Description": null
+      },
+      {
+        "Id": 36,
+        "Name": "Snežni profil",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Debelina ledu",
+        "Description": null
+      },
+      {
+        "Id": 51,
+        "Name": "Ledena površina",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Vodostaj",
+        "Description": "novo opažanje vodnega nivoja za projekt poplavne baze podatkov"
+      },
+      {
+        "Id": 71,
+        "Name": "Zemeljski plaz",
+        "Description": null
+      },
+      {
+        "Id": 80,
+        "Name": "Incidenti",
+        "Description": null
+      },
+      {
+        "Id": 81,
+        "Name": "Plazovi in znaki nevarnosti",
+        "Description": null
+      },
+      {
+        "Id": 82,
+        "Name": "Snežna odeja in vreme",
+        "Description": null
+      },
+      {
+        "Id": 83,
+        "Name": "Ocene in problemi",
+        "Description": null
+      }
+    ],
+    "SourceKDV": [
+      {
+        "Id": 0,
+        "Name": "Ni podano",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Videl sem",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Povedali so mi",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "Prebral sem v novicah/poročilu",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Videl sem sliko/spletno kamero",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "Predpostavljeno",
+        "Description": null
       }
     ]
   },
@@ -3090,6 +3286,183 @@
         "AvalancheExtTID": 25,
         "AvalCauseTID": 22
       }
-    ]
+    ],
+    "RegistrationTypesV": {
+      "10": [
+        {
+          "Id": 80,
+          "Name": "Incidenti",
+          "SubTypes": [
+            {
+              "Id": 26,
+              "Name": "Snežni plaz",
+              "SortOrder": 12
+            },
+            {
+              "Id": 11,
+              "Name": "Incident",
+              "SortOrder": 97
+            }
+          ],
+          "SortOrder": 80
+        },
+        {
+          "Id": 81,
+          "Name": "Plazovi in znaki nevarnosti",
+          "SubTypes": [
+            {
+              "Id": 13,
+              "Name": "Znak nevarnosti",
+              "SortOrder": 10
+            },
+            {
+              "Id": 26,
+              "Name": "Snežni plaz",
+              "SortOrder": 12
+            },
+            {
+              "Id": 33,
+              "Name": "Plazovna aktivnost",
+              "SortOrder": 13
+            }
+          ],
+          "SortOrder": 81
+        },
+        {
+          "Id": 82,
+          "Name": "Snežna odeja in vreme",
+          "SubTypes": [
+            {
+              "Id": 21,
+              "Name": "Vreme",
+              "SortOrder": 14
+            },
+            {
+              "Id": 22,
+              "Name": "Snežna odeja",
+              "SortOrder": 14
+            },
+            {
+              "Id": 25,
+              "Name": "Preizkusi",
+              "SortOrder": 16
+            },
+            {
+              "Id": 36,
+              "Name": "Snežni profil",
+              "SortOrder": 36
+            }
+          ],
+          "SortOrder": 82
+        },
+        {
+          "Id": 83,
+          "Name": "Ocene in problemi",
+          "SubTypes": [
+            {
+              "Id": 32,
+              "Name": "Plazovni problemi",
+              "SortOrder": 17
+            },
+            {
+              "Id": 31,
+              "Name": "Ocena plazovne nevarnosti",
+              "SortOrder": 18
+            }
+          ],
+          "SortOrder": 83
+        },
+        {
+          "Id": 10,
+          "Name": "Opombe",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "20": [
+        {
+          "Id": 13,
+          "Name": "Znak nevarnosti",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 71,
+          "Name": "Zemeljski plaz",
+          "SubTypes": [],
+          "SortOrder": 71
+        },
+        {
+          "Id": 10,
+          "Name": "Opombe",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "60": [
+        {
+          "Id": 13,
+          "Name": "Znak nevarnosti",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 14,
+          "Name": "Škoda",
+          "SubTypes": [],
+          "SortOrder": 14
+        },
+        {
+          "Id": 62,
+          "Name": "Vodostaj",
+          "SubTypes": [],
+          "SortOrder": 62
+        },
+        {
+          "Id": 11,
+          "Name": "Incident",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Opombe",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "70": [
+        {
+          "Id": 51,
+          "Name": "Ledena površina",
+          "SubTypes": [],
+          "SortOrder": 7
+        },
+        {
+          "Id": 50,
+          "Name": "Debelina ledu",
+          "SubTypes": [],
+          "SortOrder": 8
+        },
+        {
+          "Id": 13,
+          "Name": "Znak nevarnosti",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 11,
+          "Name": "Incident",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Opombe",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ]
+    }
   }
 }

--- a/src/assets/json/kdvelements.sv.json
+++ b/src/assets/json/kdvelements.sv.json
@@ -22,8 +22,13 @@
         "Description": null
       },
       {
-        "Id": 212,
-        "Name": "Snötäcke med mycket vatten",
+        "Id": 204,
+        "Name": "Ytvatten i terrängen",
+        "Description": null
+      },
+      {
+        "Id": 205,
+        "Name": "Otillräcklig dränering",
         "Description": null
       },
       {
@@ -37,26 +42,6 @@
         "Description": null
       },
       {
-        "Id": 230,
-        "Name": "Erosion längs bäckar/älvar",
-        "Description": null
-      },
-      {
-        "Id": 214,
-        "Name": "Bäckar hittar nya vägar",
-        "Description": null
-      },
-      {
-        "Id": 204,
-        "Name": "Ytvatten i terrängen",
-        "Description": null
-      },
-      {
-        "Id": 205,
-        "Name": "Otillräcklig dränering",
-        "Description": null
-      },
-      {
         "Id": 208,
         "Name": "Sprickor/krypning i terräng",
         "Description": null
@@ -64,6 +49,16 @@
       {
         "Id": 209,
         "Name": "Observerat jordskred",
+        "Description": null
+      },
+      {
+        "Id": 212,
+        "Name": "Snötäcke med mycket vatten",
+        "Description": null
+      },
+      {
+        "Id": 214,
+        "Name": "Bäckar hittar nya vägar",
         "Description": null
       },
       {
@@ -75,6 +70,11 @@
         "Id": 223,
         "Name": "\"Lutande träd\"",
         "Description": "Träd som böjs"
+      },
+      {
+        "Id": 230,
+        "Name": "Erosion längs bäckar/älvar",
+        "Description": null
       },
       {
         "Id": 299,
@@ -89,6 +89,11 @@
         "Description": null
       },
       {
+        "Id": 211,
+        "Name": "Människor",
+        "Description": null
+      },
+      {
         "Id": 220,
         "Name": "Väg",
         "Description": null
@@ -99,18 +104,13 @@
         "Description": null
       },
       {
-        "Id": 260,
-        "Name": "Bebyggelse",
-        "Description": null
-      },
-      {
-        "Id": 211,
-        "Name": "Människor",
-        "Description": null
-      },
-      {
         "Id": 251,
         "Name": "Skogs- och jordbruksareal",
+        "Description": null
+      },
+      {
+        "Id": 260,
+        "Name": "Bebyggelse",
         "Description": null
       },
       {
@@ -141,11 +141,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Stenras",
-        "Description": null
-      },
-      {
         "Id": 6,
         "Name": "Stenslag",
         "Description": null
@@ -163,6 +158,11 @@
       {
         "Id": 10,
         "Name": "Kvicklera-skred",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Stenras",
         "Description": null
       }
     ],
@@ -284,11 +284,6 @@
         "Description": null
       },
       {
-        "Id": 714,
-        "Name": "Isfiskare",
-        "Description": null
-      },
-      {
         "Id": 711,
         "Name": "Skridskoåkare",
         "Description": null
@@ -304,8 +299,8 @@
         "Description": null
       },
       {
-        "Id": 719,
-        "Name": "Person skadad av islossning",
+        "Id": 714,
+        "Name": "Isfiskare",
         "Description": null
       },
       {
@@ -324,9 +319,24 @@
         "Description": null
       },
       {
-        "Id": 725,
-        "Name": "Sparkstötting",
+        "Id": 719,
+        "Name": "Person skadad av islossning",
         "Description": null
+      },
+      {
+        "Id": 720,
+        "Name": "Snöskoter på isen",
+        "Description": null
+      },
+      {
+        "Id": 721,
+        "Name": "Bil på isen",
+        "Description": null
+      },
+      {
+        "Id": 722,
+        "Name": "ATV",
+        "Description": "All Terrain Vehicle"
       },
       {
         "Id": 723,
@@ -339,18 +349,8 @@
         "Description": null
       },
       {
-        "Id": 720,
-        "Name": "Snöskoter på isen",
-        "Description": null
-      },
-      {
-        "Id": 722,
-        "Name": "ATV",
-        "Description": "All Terrain Vehicle"
-      },
-      {
-        "Id": 721,
-        "Name": "Bil på isen",
+        "Id": 725,
+        "Name": "Sparkstötting",
         "Description": null
       },
       {
@@ -389,6 +389,21 @@
         "Description": null
       },
       {
+        "Id": 775,
+        "Name": "Anchor ice dam",
+        "Description": null
+      },
+      {
+        "Id": 776,
+        "Name": "Frazil ice plugging",
+        "Description": null
+      },
+      {
+        "Id": 777,
+        "Name": "Ispropp",
+        "Description": null
+      },
+      {
         "Id": 790,
         "Name": "Annat",
         "Description": null
@@ -406,11 +421,6 @@
         "Description": null
       },
       {
-        "Id": 11,
-        "Name": "Is längs land",
-        "Description": null
-      },
-      {
         "Id": 2,
         "Name": "Delvis istäckt vid mätpunkten",
         "Description": null
@@ -421,13 +431,13 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "Hela sjön istäckt",
+        "Id": 10,
+        "Name": "Islossning längs land",
         "Description": null
       },
       {
-        "Id": 10,
-        "Name": "Islossning längs land",
+        "Id": 11,
+        "Name": "Is längs land",
         "Description": null
       },
       {
@@ -436,13 +446,18 @@
         "Description": null
       },
       {
-        "Id": 41,
-        "Name": "Drivande kravis på älven",
+        "Id": 21,
+        "Name": "Hela sjön istäckt",
         "Description": null
       },
       {
         "Id": 40,
         "Name": "Isrörelse i älv",
+        "Description": null
+      },
+      {
+        "Id": 41,
+        "Name": "Drivande kravis på älven",
         "Description": null
       },
       {
@@ -458,14 +473,14 @@
         "Description": null
       },
       {
-        "Id": 2,
-        "Name": "Förr ingen is, nu vid stranden",
-        "Description": "Ingen is hittills den här säsongen. Idag är längs land."
-      },
-      {
         "Id": 1,
         "Name": "Isfritt, nu först vid mätplats",
         "Description": "Ingen is på mätplatsen före idag. Det kan ha varit is längs stranden. Mätplatsen är vanligtvis något ute på vattnet."
+      },
+      {
+        "Id": 2,
+        "Name": "Förr ingen is, nu vid stranden",
+        "Description": "Ingen is hittills den här säsongen. Idag är längs land."
       },
       {
         "Id": 3,
@@ -539,32 +554,32 @@
       {
         "Id": 0,
         "Name": "Ej angivet",
-        "Description": ""
+        "Description": null
       },
       {
         "Id": 10,
         "Name": "Ej åkbar",
-        "Description": ""
+        "Description": null
       },
       {
         "Id": 20,
         "Name": "Tvivelaktiga förhållanden",
-        "Description": ""
+        "Description": null
       },
       {
         "Id": 30,
         "Name": "Normala förhållanden",
-        "Description": ""
+        "Description": null
       },
       {
         "Id": 40,
         "Name": "Mycket goda förhållanden",
-        "Description": ""
+        "Description": null
       },
       {
         "Id": 50,
         "Name": "Drömförhållanden",
-        "Description": ""
+        "Description": null
       }
     ],
     "Ice_IceCapacityKDV": [
@@ -626,6 +641,11 @@
         "Description": null
       },
       {
+        "Id": 60,
+        "Name": "Isnedfall",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Annat (skriv kommentar)",
         "Description": null
@@ -653,11 +673,6 @@
         "Description": null
       },
       {
-        "Id": 4,
-        "Name": "Färska sprickor",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "Stort snöfall",
         "Description": "Används i elrapp"
@@ -678,6 +693,16 @@
         "Description": null
       },
       {
+        "Id": 14,
+        "Name": "Shooting cracks",
+        "Description": null
+      },
+      {
+        "Id": 15,
+        "Name": "Glide cracks",
+        "Description": null
+      },
+      {
         "Id": 99,
         "Name": "Annat (skriv kommentar)",
         "Description": null
@@ -695,13 +720,13 @@
         "Description": null
       },
       {
-        "Id": 113,
-        "Name": "Offpistskidåkning",
+        "Id": 112,
+        "Name": "Skidåkning i anläggning",
         "Description": null
       },
       {
-        "Id": 112,
-        "Name": "Skidåkning i anläggning",
+        "Id": 113,
+        "Name": "Offpistskidåkning",
         "Description": null
       },
       {
@@ -725,13 +750,13 @@
         "Description": null
       },
       {
-        "Id": 130,
-        "Name": "Snöskoteråkning",
+        "Id": 120,
+        "Name": "Väg",
         "Description": null
       },
       {
-        "Id": 120,
-        "Name": "Väg",
+        "Id": 130,
+        "Name": "Snöskoteråkning",
         "Description": null
       },
       {
@@ -757,23 +782,23 @@
         "Description": null
       },
       {
-        "Id": 12,
-        "Name": "Torr lössnölavin",
-        "Description": null
-      },
-      {
         "Id": 11,
         "Name": "Våt lössnölavin",
         "Description": null
       },
       {
-        "Id": 22,
-        "Name": "Torr flaklavin",
+        "Id": 12,
+        "Name": "Torr lössnölavin",
         "Description": null
       },
       {
         "Id": 21,
         "Name": "Våt flaklavin",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Torr flaklavin",
         "Description": null
       },
       {
@@ -908,24 +933,24 @@
         "Description": "Facetterad snö nära marken"
       },
       {
-        "Id": 19,
-        "Name": "Fasetterad snö under skare",
-        "Description": "Fasetterad snö under skare"
-      },
-      {
         "Id": 18,
         "Name": "Facetterad snö över skare",
         "Description": "Facetterad snö över skare"
       },
       {
-        "Id": 22,
-        "Name": "Ackumulering av vatten över lager",
-        "Description": "Ackumulering av vatten över lager"
+        "Id": 19,
+        "Name": "Fasetterad snö under skare",
+        "Description": "Fasetterad snö under skare"
       },
       {
         "Id": 20,
         "Name": "Smälter nära marken",
         "Description": "Smälter nära marken"
+      },
+      {
+        "Id": 22,
+        "Name": "Ackumulering av vatten över lager",
+        "Description": "Ackumulering av vatten över lager"
       },
       {
         "Id": 24,
@@ -1075,6 +1100,11 @@
         "Description": null
       },
       {
+        "Id": 22,
+        "Name": "Naturligt utlöst",
+        "Description": null
+      },
+      {
         "Id": 30,
         "Name": "Mycket svårt att utlösa",
         "Description": null
@@ -1092,11 +1122,6 @@
       {
         "Id": 60,
         "Name": "Mycket lätt att utlösa",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "Naturligt utlöst",
         "Description": null
       }
     ],
@@ -1299,16 +1324,6 @@
         "Description": null
       },
       {
-        "Id": 26,
-        "Name": "Mänskligt utlöst",
-        "Description": null
-      },
-      {
-        "Id": 27,
-        "Name": "Utlöst av snöskoter",
-        "Description": null
-      },
-      {
         "Id": 22,
         "Name": "Fjärrutlöst",
         "Description": null
@@ -1321,6 +1336,16 @@
       {
         "Id": 25,
         "Name": "Utlöst med sprängämnen",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Mänskligt utlöst",
+        "Description": null
+      },
+      {
+        "Id": 27,
+        "Name": "Utlöst av snöskoter",
         "Description": null
       },
       {
@@ -1393,6 +1418,21 @@
         "Description": null
       },
       {
+        "Id": 50,
+        "Name": "Ytliga facetter",
+        "Description": null
+      },
+      {
+        "Id": 61,
+        "Name": "Frostkristaller på hård yta",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Fostkristaller på mjuk yta",
+        "Description": null
+      },
+      {
         "Id": 101,
         "Name": "Väldigt mycket lössnö (> 30 cm)",
         "Description": null
@@ -1408,23 +1448,8 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Frostkristaller på hård yta",
-        "Description": null
-      },
-      {
-        "Id": 62,
-        "Name": "Fostkristaller på mjuk yta",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Ytliga facetter",
-        "Description": null
-      },
-      {
-        "Id": 107,
-        "Name": "Skare",
+        "Id": 104,
+        "Name": "Våt lössnö",
         "Description": null
       },
       {
@@ -1438,8 +1463,8 @@
         "Description": null
       },
       {
-        "Id": 104,
-        "Name": "Våt lössnö",
+        "Id": 107,
+        "Name": "Skare",
         "Description": null
       },
       {
@@ -1536,26 +1561,6 @@
         "Description": null
       },
       {
-        "Id": 21,
-        "Name": "ECTPV",
-        "Description": null
-      },
-      {
-        "Id": 22,
-        "Name": "ECTP",
-        "Description": null
-      },
-      {
-        "Id": 23,
-        "Name": "ECTN",
-        "Description": null
-      },
-      {
-        "Id": 24,
-        "Name": "ECTX",
-        "Description": null
-      },
-      {
         "Id": 5,
         "Name": "LBT",
         "Description": null
@@ -1583,6 +1588,26 @@
       {
         "Id": 15,
         "Name": "CTN",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "ECTPV",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "ECTP",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "ECTN",
+        "Description": null
+      },
+      {
+        "Id": 24,
+        "Name": "ECTX",
         "Description": null
       }
     ],
@@ -2006,6 +2031,38 @@
       {
         "Id": 13,
         "Name": "Hela lagret",
+        "Description": null
+      }
+    ],
+    "Snow_SkiConditionsKDV": [
+      {
+        "Id": 0,
+        "Name": "Ej angivet",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Dåligt",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Ok",
+        "Description": null
+      },
+      {
+        "Id": 30,
+        "Name": "Bra",
+        "Description": null
+      },
+      {
+        "Id": 40,
+        "Name": "Mycket bra",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Perfekt",
         "Description": null
       }
     ],
@@ -2514,13 +2571,13 @@
         "Description": null
       },
       {
-        "Id": 25,
-        "Name": "Evakuering",
+        "Id": 20,
+        "Name": "Endast materiell skada",
         "Description": null
       },
       {
-        "Id": 20,
-        "Name": "Endast materiell skada",
+        "Id": 25,
+        "Name": "Evakuering",
         "Description": null
       },
       {
@@ -2561,6 +2618,11 @@
         "Description": "Okänd kompetens om snö."
       },
       {
+        "Id": 105,
+        "Name": "A",
+        "Description": "Automatiserad service."
+      },
+      {
         "Id": 110,
         "Name": "*",
         "Description": "Observatören har grundläggande färdigheter för att bedöma lavinfaran. Observatören är inte utbildad i hur regObs och Varsom kommunicerar lavinfara."
@@ -2584,11 +2646,6 @@
         "Id": 150,
         "Name": "*****",
         "Description": "Observatören tillhör en varningstjänst."
-      },
-      {
-        "Id": 105,
-        "Name": "A",
-        "Description": "Automatiserad service."
       },
       {
         "Id": 200,
@@ -2795,26 +2852,6 @@
         "Description": null
       },
       {
-        "Id": 60,
-        "Name": "Privat tur",
-        "Description": null
-      },
-      {
-        "Id": 55,
-        "Name": "Undervisning och kurser",
-        "Description": null
-      },
-      {
-        "Id": 70,
-        "Name": "Guidning",
-        "Description": null
-      },
-      {
-        "Id": 50,
-        "Name": "Uppdrag för arbetsgivaren",
-        "Description": null
-      },
-      {
         "Id": 20,
         "Name": "Vanligt uppdrag för lavinvarningstjänsten",
         "Description": null
@@ -2827,6 +2864,26 @@
       {
         "Id": 40,
         "Name": "Beställt uppdrag för lavinvarningstjänsten",
+        "Description": null
+      },
+      {
+        "Id": 50,
+        "Name": "Uppdrag för arbetsgivaren",
+        "Description": null
+      },
+      {
+        "Id": 55,
+        "Name": "Undervisning och kurser",
+        "Description": null
+      },
+      {
+        "Id": 60,
+        "Name": "Privat tur",
+        "Description": null
+      },
+      {
+        "Id": 70,
+        "Name": "Guidning",
         "Description": null
       }
     ],
@@ -2929,19 +2986,153 @@
         "Description": null
       },
       {
-        "Id": 61,
-        "Name": "Underkänd av datahanteraren",
+        "Id": 52,
+        "Name": "Raderad av admin",
         "Description": null
       },
       {
-        "Id": 52,
-        "Name": "Raderad av admin",
+        "Id": 61,
+        "Name": "Underkänd av datahanteraren",
         "Description": null
       },
       {
         "Id": 101,
         "Name": "För administrativt bruk",
         "Description": "Observation eller grupp har en admin-funktion. Det är dold som om det raderades."
+      }
+    ],
+    "RegistrationKDV": [
+      {
+        "Id": 10,
+        "Name": "Anteckningar",
+        "Description": null
+      },
+      {
+        "Id": 11,
+        "Name": "Olycka / tillbud",
+        "Description": null
+      },
+      {
+        "Id": 13,
+        "Name": "Tecken på fara",
+        "Description": null
+      },
+      {
+        "Id": 14,
+        "Name": "Skador",
+        "Description": "Gäller alla geohazards. Används bara för vatten för närvarande."
+      },
+      {
+        "Id": 21,
+        "Name": "Väder",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Snötäcke",
+        "Description": null
+      },
+      {
+        "Id": 25,
+        "Name": "Test",
+        "Description": null
+      },
+      {
+        "Id": 26,
+        "Name": "Lavinaktivitet",
+        "Description": null
+      },
+      {
+        "Id": 31,
+        "Name": "Bedömning av lavinfara",
+        "Description": null
+      },
+      {
+        "Id": 32,
+        "Name": "Lavinproblem",
+        "Description": null
+      },
+      {
+        "Id": 33,
+        "Name": "Lavinaktivitet",
+        "Description": null
+      },
+      {
+        "Id": 36,
+        "Name": "Snöprofil",
+        "Description": "Snöprofil"
+      },
+      {
+        "Id": 50,
+        "Name": "istjocklek",
+        "Description": null
+      },
+      {
+        "Id": 51,
+        "Name": "Istäckningsgrad",
+        "Description": null
+      },
+      {
+        "Id": 62,
+        "Name": "Vattennivå",
+        "Description": "Ny vattennivå för översvämningsdatabasprojekt"
+      },
+      {
+        "Id": 71,
+        "Name": "Jordskred",
+        "Description": null
+      },
+      {
+        "Id": 80,
+        "Name": "Händelser",
+        "Description": "Händelser"
+      },
+      {
+        "Id": 81,
+        "Name": "Laviner och tecken på fara",
+        "Description": "Laviner och tecken på fara"
+      },
+      {
+        "Id": 82,
+        "Name": "Snötäcke och väder",
+        "Description": "Snötäcke och väder"
+      },
+      {
+        "Id": 83,
+        "Name": "Bedömningar och problem",
+        "Description": "Bedömningar och problem"
+      }
+    ],
+    "SourceKDV": [
+      {
+        "Id": 0,
+        "Name": "Ej angivet",
+        "Description": null
+      },
+      {
+        "Id": 10,
+        "Name": "Jag har sett detta",
+        "Description": null
+      },
+      {
+        "Id": 20,
+        "Name": "Jag har hört detta",
+        "Description": null
+      },
+      {
+        "Id": 21,
+        "Name": "Jag har läst i nyheterna",
+        "Description": null
+      },
+      {
+        "Id": 22,
+        "Name": "Jag har sett bild/webkamera",
+        "Description": null
+      },
+      {
+        "Id": 23,
+        "Name": "Antagen/simulerad",
+        "Description": null
       }
     ]
   },
@@ -3095,6 +3286,183 @@
         "AvalancheExtTID": 25,
         "AvalCauseTID": 22
       }
-    ]
+    ],
+    "RegistrationTypesV": {
+      "10": [
+        {
+          "Id": 80,
+          "Name": "Händelser",
+          "SubTypes": [
+            {
+              "Id": 26,
+              "Name": "Lavinaktivitet",
+              "SortOrder": 12
+            },
+            {
+              "Id": 11,
+              "Name": "Olycka / tillbud",
+              "SortOrder": 97
+            }
+          ],
+          "SortOrder": 80
+        },
+        {
+          "Id": 81,
+          "Name": "Laviner och tecken på fara",
+          "SubTypes": [
+            {
+              "Id": 13,
+              "Name": "Tecken på fara",
+              "SortOrder": 10
+            },
+            {
+              "Id": 26,
+              "Name": "Lavinaktivitet",
+              "SortOrder": 12
+            },
+            {
+              "Id": 33,
+              "Name": "Lavinaktivitet",
+              "SortOrder": 13
+            }
+          ],
+          "SortOrder": 81
+        },
+        {
+          "Id": 82,
+          "Name": "Snötäcke och väder",
+          "SubTypes": [
+            {
+              "Id": 22,
+              "Name": "Snötäcke",
+              "SortOrder": 14
+            },
+            {
+              "Id": 21,
+              "Name": "Väder",
+              "SortOrder": 14
+            },
+            {
+              "Id": 25,
+              "Name": "Test",
+              "SortOrder": 16
+            },
+            {
+              "Id": 36,
+              "Name": "Snöprofil",
+              "SortOrder": 36
+            }
+          ],
+          "SortOrder": 82
+        },
+        {
+          "Id": 83,
+          "Name": "Bedömningar och problem",
+          "SubTypes": [
+            {
+              "Id": 32,
+              "Name": "Lavinproblem",
+              "SortOrder": 17
+            },
+            {
+              "Id": 31,
+              "Name": "Bedömning av lavinfara",
+              "SortOrder": 18
+            }
+          ],
+          "SortOrder": 83
+        },
+        {
+          "Id": 10,
+          "Name": "Anteckningar",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "20": [
+        {
+          "Id": 13,
+          "Name": "Tecken på fara",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 71,
+          "Name": "Jordskred",
+          "SubTypes": [],
+          "SortOrder": 71
+        },
+        {
+          "Id": 10,
+          "Name": "Anteckningar",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "60": [
+        {
+          "Id": 13,
+          "Name": "Tecken på fara",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 14,
+          "Name": "Skador",
+          "SubTypes": [],
+          "SortOrder": 14
+        },
+        {
+          "Id": 62,
+          "Name": "Vattennivå",
+          "SubTypes": [],
+          "SortOrder": 62
+        },
+        {
+          "Id": 11,
+          "Name": "Olycka / tillbud",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Anteckningar",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ],
+      "70": [
+        {
+          "Id": 51,
+          "Name": "Istäckningsgrad",
+          "SubTypes": [],
+          "SortOrder": 7
+        },
+        {
+          "Id": 50,
+          "Name": "istjocklek",
+          "SubTypes": [],
+          "SortOrder": 8
+        },
+        {
+          "Id": 13,
+          "Name": "Tecken på fara",
+          "SubTypes": [],
+          "SortOrder": 10
+        },
+        {
+          "Id": 11,
+          "Name": "Olycka / tillbud",
+          "SubTypes": [],
+          "SortOrder": 97
+        },
+        {
+          "Id": 10,
+          "Name": "Anteckningar",
+          "SubTypes": [],
+          "SortOrder": 98
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
Valg for rullgardiner etc. (såkalte KDV-elementer) hentes fra API'et  og mellomlagres i appen. Hvis dette feiler, har vi distribuert noen json-filer med appen som inneholder de samme dataene. Disse var ikke oppdatert på lenge, derfor ble ikke skiføre vist. KDV-elementer på fransk manglet fullstendig.

Har også laget bedre feilhåndtering hvis et sett med KDV-elementer mangler fullstendig, for det var mange skjema som kræsjet ganske stygt hvis dette skjedde.