### PR TITLE
removed unnecessary item, and line height

### DIFF
--- a/src/app/modules/registration/components/snow/simple-snow-obs/edit-images-bar/edit-images-bar.component.html
+++ b/src/app/modules/registration/components/snow/simple-snow-obs/edit-images-bar/edit-images-bar.component.html
@@ -1,18 +1,15 @@
 <!-- If there are no attachments we skip the modal and save the user an extra click. -->
 <ng-container *ngIf="attachments$ | async as attachments">
-  <ion-item *ngIf="attachments.length == 0">
-    <app-edit-images
-      [registrationTid]="registrationTid"
-      [geoHazard]="draft.registration.GeoHazardTID"
-      [draftUuid]="draft.uuid"
-      [(existingAttachments)]="draft.registration.Attachments"
-    ></app-edit-images>
-  </ion-item>
+    <app-edit-images *ngIf="attachments.length == 0" [registrationTid]="registrationTid"
+      [geoHazard]="draft.registration.GeoHazardTID" [draftUuid]="draft.uuid"
+      [(existingAttachments)]="draft.registration.Attachments"></app-edit-images>
 
   <!-- Show thumbnails of attachments if there are any -->
-  <ion-item *ngIf="attachments?.length > 0" (click)="showEditImagesPage()">
-    <ion-icon name="camera"></ion-icon>
-    <ion-label>{{ 'REGISTRATION.ADD_IMAGES' | translate }}</ion-label>
-    <app-thumbnails [attachments]="attachments" [draftUuid]="draft.uuid"></app-thumbnails>
-  </ion-item>
+
+    <ion-item *ngIf="attachments?.length > 0" (click)="showEditImagesPage()">
+      <ion-icon name="camera"></ion-icon>
+      <ion-label>{{ 'REGISTRATION.ADD_IMAGES' | translate }}</ion-label>
+      <app-thumbnails [attachments]="attachments" [draftUuid]="draft.uuid"></app-thumbnails>
+    </ion-item>
+
 </ng-container>

--- a/src/app/modules/registration/components/snow/simple-snow-obs/edit-images-bar/edit-images-bar.component.scss
+++ b/src/app/modules/registration/components/snow/simple-snow-obs/edit-images-bar/edit-images-bar.component.scss
@@ -9,7 +9,6 @@ ion-label {
   font-style: normal;
   font-weight: 400;
   font-size: 12px;
-  line-height: 100%;
   text-overflow: unset;
 }
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -262,6 +262,10 @@ ion-modal {
   }
 }
 
+.edit-images-page-modal .modal-wrapper app-edit-images {
+  margin-bottom: 1rem;
+}
+
 ion-alert {
   button.full-width {
     width: 100%;


### PR DESCRIPTION
Jeg fjernet ion-item som wrappa app-edit-images. Var unødvendig og gjorde at det var dobbel padding på ios. app-edit-images har en ion-item inni seg allerede så det vart kanskje ikke noe poeng å ha ion-item inni ion-item. 
testet både på ios og android

Fikset også margin på modalen der hvor Legg til bilde knappen henger for langt ned.