### PR TITLE
Auto code signing for debug builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ npx cap open ios
 ```
 npx cap open ios vil åpne prosjektet i Xcode. Kjør appen fra XCode.
 
+[Mer info om ionic utvikling for ios.](https://ionicframework.com/docs/developing/ios)
+
 ## Build and release
 
 Use npm to make a release build:

--- a/README.md
+++ b/README.md
@@ -70,15 +70,6 @@ npx cap open ios
 ```
 npx cap open ios vil åpne prosjektet i Xcode. Kjør appen fra XCode.
 
-[Mer info](https://ionicframework.com/docs/developing/ios)
-Ikke la Xcode signere provisioning profile automatisk, men last den ned fra developer.apple.com og bruk denne i XCode.
-Du må først legge ditt utviklersertifikat inn i Provisioning profile på developer.apple.com.
-Sjekk også at dingsen du skal teste på er registrert i profilen.
-
-Det er bare debug-profil vi trenger i Xcode, fordi release bygges på byggeserver.
-"Active scheme" skal være Varsom Regobs, ikke Cordova.
-Hvis gamle ting henger igjen, kan du slette mappene platforms og plugins.
-
 ## Build and release
 
 Use npm to make a release build:

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -138,7 +138,7 @@
 					504EC3031FED79650016851F = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -393,8 +393,8 @@
 			baseConfigurationReference = FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "Apple Distribution: Norges Vassdrags- og Energidirektorat (43L5B5X2PE)";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 43L5B5X2PE;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -402,7 +402,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = no.nve.regobs4;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "regobs-dist-2022-11-25";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Endrer debug-bygg-konfigurasjonen til ios-prosjektet sånn at koden signeres automatisk.
Så vidt jeg kan se bruker release-pipelinen vår "Release"-konfigurasjonen, så det bør ikke påvirke utrulling:

https://github.com/NVE/regObs4/blob/f25dac6aeebbf0d46479429a7c7f3355450ce39f/azure-pipelines-release.yml#L133-L149

Supert om en av dere @gruble eller @amish1188 tester om dere nå kan bygge direkte i xcode uten å måtte tukle med innstillingene først.