### PR TITLE
Search and filter POC

### DIFF
--- a/src/app/core/services/observation/observation-base.service.ts
+++ b/src/app/core/services/observation/observation-base.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { LangKey } from 'src/app/modules/common-core/models';
+import { RegistrationViewModel, SearchCriteriaRequestDto } from 'src/app/modules/common-regobs-api';
+import { SearchCriteriaService } from '../search-criteria/search-criteria.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export abstract class ObservationBaseService {
+
+  // NEW, but private..
+  // A service that can provide relevant search criteria
+  // Should be used to apply filtering when searching for observations.
+  protected abstract readonly searchCriteriaService: SearchCriteriaService;
+
+  // OLD
+  // Contains filtered observations. Should listen to searchCriteriaService.searchCriteria$
+  // and emit a new list of observations when it updates.
+  public abstract readonly observations$: Observable<RegistrationViewModel[]>;
+
+  // NEW
+  // Emits the datetime for when data for the current search criteria was last fetched from the regobs API
+  public abstract readonly lastUpdated$: Observable<Date>;
+
+  // OLD
+  // TODO: We may possibly need this to support the same API as the old ObservationService
+  // abstract readonly dataLoad$: Observable<string>;
+
+  // OLD
+  // Force update of data. Should always try fetching fresh data from regobs API.
+  // Old ObservationService has two public methods with this purpose (se below),
+  // but we should try to eliminate one of them.
+  // If possible we should also remove the cancel promise, not sure why that is needed.
+  public abstract updateObservations(cancel?: Promise<any>): Promise<void>
+
+  // OLD
+  // TODO: Se comment above, remove this one?
+  // public abstract forceUpdateObservationsForCurrentGeoHazard(cancel?: Promise<any>): Promise<void>
+
+  // OLD
+  // TODO: Can we use a property for this one? See lastUpdated$ above. If so, remove it?
+  // public abstract getLastUpdatedForCurrentGeoHazardAsObservable(): Observable<Date>;
+
+  // OLD, but renamed from "uniqueObservation" - not specific enough
+  // TODO: Not using any class functionality, this could also be moved to stand alone utility function
+  public getUniqueObservationKey(obs: RegistrationViewModel, langKey: LangKey): string {
+    return `${obs.RegId}_${langKey}_${obs.DtChangeTime}`;
+  }
+
+  // OLD
+  // TODO: Can this be removed?
+  //   A custom search criteria with the current user can be provided to my observations
+  // public getObservationsForCurrentUser(
+  //   langKey: LangKey,
+  //   pageNr?: number,
+  //   numberOfRecords?: number  // NB: Default 10 in old implementation
+  // ): Observable<RegistrationViewModel>
+
+  // OLD
+  // TODO: Can this be removed?
+  //  A custom search criteria with RegID set can be provided to the observation detail page
+  // async getObservationById(id: number, appMode: AppMode): Promise<RegistrationViewModel>
+
+}

--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SearchCriteriaService } from './search-criteria.service';
+
+describe('SearchCriteriaService', () => {
+  let service: SearchCriteriaService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SearchCriteriaService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { SearchCriteriaRequestDto } from 'src/app/modules/common-regobs-api';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SearchCriteriaService {
+
+  // TODO: Add public methods for updating search criteria..
+
+  searchCriteria$: Observable<SearchCriteriaRequestDto>;
+}

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -30,7 +30,13 @@ const getUniqueRegistrations = (regs: RegistrationViewModel[]) => {
   selector: 'app-sent-list',
   templateUrl: './sent-list.component.html',
   styleUrls: ['./sent-list.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  // A possible solution to not having custom methods for getting a users own observations.
+  // Not sure if this works, but useFactory can be used as a backup, as a new instance is guaranteed.
+  // providers: [
+  //   { provide: SearchCriteriaService: useClass: UserPageSearchCriteriaService },
+  //   { provide: ObservationService, useClass: ObservationService }
+  // ]
 })
 export class SentListComponent implements OnDestroy {
   loadedRegistrations: RegistrationViewModel[] = [];


### PR DESCRIPTION
Se https://nveprojects.atlassian.net/browse/RO-1703 og https://nveprojects.atlassian.net/browse/RO-1911

Forslag til ny service for søk etter observasjoner.

Interfacet til `ObservationBaseService` som foreslås her har færre metoder enn gamle `ObservationService`, men alle public metoder og properties skal være kommentert i koden så det er lett å sammenligne med gammelt interface.

Jeg forslår at vi skiller ut håndtering av søkekriterier i en egen service, `SearchCriteriaService`, og at vi bruker `SearchCriteriaRequestDTO` som datamodell siden vi uansett må sende inn den til apiet. Da bør særlig web-implementasjonen av `ObservationService` bli enkel.

Oppsettet med enklere interface og en egen `SearchCriteriaService` kan brukes ganske fleksibelt, feks for "Mine observasjoner". Siden man kan sette opp hva som skal provides til enkeltkomponenter ser jeg for meg noe a la dette:

```typescript
@Component({
  selector: 'my-observations',
  ...
  providers: [
    { provide: SearchCriteriaService: useClass: UserPageSearchCriteriaService },
    { provide: ObservationService, useClass: ObservationService }
  ]
})
export class MyObservationsComponent {

  constructor(observationService: ObservationService) {}

}
```

der `UserPageSearchCriteriaService` er et superenkelt overbygg på SearchCriteriaService som også tar in `AuthService` og setter brukeren i søkekriterene + kanskje håndterer paging uten at vanlig listevinsning og kart påvirkes av dette.
Denne komponenten vil da få en egen instans av `ObservationService` som har en egen `observations$` med kun brukerens observasjoner. Ulempen med dette er at vi holder styr på to lister med observasjoner samtidig, men det gjør vi allerede i dag.

Vi har ikke noe `MyObservationsComponent` i dag, dette er bare som eksempel. Se `sent-list.component.ts` i koden der jeg har skissert dette i komponentet vi har hvor det kunne vært aktuelt.

Vi slipper da å ha egne metoder for `getObservationsForCurrentUser` , det styres heller med "konfigurasjon" og blir veldig fleksibelt.

*NB!* Jeg er ikke helt sikker på hvordan dette oppsettet vil støtte paging i listevisningen. Når offset og antall observasjoner i søkekriteriene endres, hvordan skal dette reflekteres i `observations$` ? Skal observations$ inneholde alle observasjoner totalt, også de utenfor gjeldende "paging" ?

Kom gjerne med innspill.
