### PR TITLE
Fjernet logging av Router-hendelser

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,17 +11,14 @@ import { DbHelperService } from './core/services/db-helper/db-helper.service';
 import { ScreenOrientation } from '@ionic-native/screen-orientation/ngx';
 import { ShortcutService } from './core/services/shortcut/shortcut.service';
 import { isAndroidOrIos } from './core/helpers/ionic/platform-helper';
-import { switchMap, take, concatMap, catchError, filter } from 'rxjs/operators';
+import { switchMap, take, concatMap, catchError } from 'rxjs/operators';
 import { UserSetting } from './core/models/user-settings.model';
 import { FileLoggingService } from './modules/shared/services/logging/file-logging.service';
 import { AuthService } from 'ionic-appauth';
-import { NavigationError, Router, RouterEvent } from '@angular/router';
-import { removeOauthTokenFromUrl } from './modules/shared/services/logging/url-utils';
 import { DraftToRegistrationService } from './core/services/draft/draft-to-registration.service';
 import { BreakpointService } from './core/services/breakpoint.service';
 
 const DEBUG_TAG = 'AppComponent';
-const ROUTER_DEBUG_TAG = 'Router';
 
 @Component({
   selector: 'app-root',
@@ -43,7 +40,6 @@ export class AppComponent {
     private shortcutService: ShortcutService,
     private fileLoggingService: FileLoggingService,
     private auth: AuthService,
-    private router: Router,
     private draftToRegService: DraftToRegistrationService,
     private breakpointService: BreakpointService
   ) {
@@ -136,15 +132,6 @@ export class AppComponent {
                 )
               )
             ),
-            of ( this.initRouteNavigationLogger()).pipe(
-              catchError((err) =>
-                this.loggingService.error(
-                  err,
-                  DEBUG_TAG,
-                  'Could not init route navigation logging'
-                )
-              )
-            ),
             of(this.draftToRegService.createSubscriptions()).pipe(
               catchError((err) => this.loggingService.error(err, DEBUG_TAG, 'Could not start draftToRegService'))
             )
@@ -155,18 +142,5 @@ export class AppComponent {
 
   private getUserSettings() {
     return from(this.platform.ready()).pipe(switchMap(() => this.userSettings.userSetting$.pipe(take(1))));
-  }
-
-  private async initRouteNavigationLogger(): Promise<void> {
-    this.router.events.pipe(
-      filter((e): e is RouterEvent => e instanceof RouterEvent)
-    ).subscribe((event) => {
-      const eventInfo = removeOauthTokenFromUrl(event.toString());
-      if (event instanceof NavigationError) {
-        this.loggingService.error(event.error, ROUTER_DEBUG_TAG, eventInfo);
-      } else {
-        this.loggingService.debug(eventInfo);
-      }
-    });
   }
 }


### PR DESCRIPTION
VI la til logging av dette da vi jobbet med å lokalisere en feil i rutinga. 
Dette gir logging a la noe slikt hver gang vi bruker routeren for å navigere:
```
[DEBUG] NavigationStart(id: 10, url: '/tabs/observation-list')
console-logging.service.ts:52 [DEBUG] RoutesRecognized(id: 10, url: '/tabs/observation-list', urlAfterRedirects: '/tabs/observation-list', state: Route(url:'', path:'') { Route(url:'', path:'') { Route(url:'tabs', path:'tabs') { Route(url:'observation-list', path:'observation-list') { Route(url:'', path:'') { Route(url:'', path:'') }  }  }  }  } )
console-logging.service.ts:52 [DEBUG] GuardsCheckStart(id: 10, url: '/tabs/observation-list', urlAfterRedirects: '/tabs/observation-list', state: Route(url:'', path:'') { Route(url:'', path:'') { Route(url:'tabs', path:'tabs') { Route(url:'observation-list', path:'observation-list') { Route(url:'', path:'') { Route(url:'', path:'') }  }  }  }  } )
console-logging.service.ts:52 [DEBUG] GuardsCheckEnd(id: 10, url: '/tabs/observation-list', urlAfterRedirects: '/tabs/observation-list', state: Route(url:'', path:'') { Route(url:'', path:'') { Route(url:'tabs', path:'tabs') { Route(url:'observation-list', path:'observation-list') { Route(url:'', path:'') { Route(url:'', path:'') }  }  }  }  } , shouldActivate: true)
console-logging.service.ts:52 [DEBUG] ResolveStart(id: 10, url: '/tabs/observation-list', urlAfterRedirects: '/tabs/observation-list', state: Route(url:'', path:'') { Route(url:'', path:'') { Route(url:'tabs', path:'tabs') { Route(url:'observation-list', path:'observation-list') { Route(url:'', path:'') { Route(url:'', path:'') }  }  }  }  } )
console-logging.service.ts:52 [DEBUG] ResolveEnd(id: 10, url: '/tabs/observation-list', urlAfterRedirects: '/tabs/observation-list', state: Route(url:'', path:'') { Route(url:'', path:'') { Route(url:'tabs', path:'tabs') { Route(url:'observation-list', path:'observation-list') { Route(url:'', path:'') { Route(url:'', path:'') }  }  }  }  } )
console-logging.service.ts:52 [DEBUG][AnalyticService] Tracking pageview /tabs/observation-list
console-logging.service.ts:52 [DEBUG] NavigationEnd(id: 10, url: '/tabs/observation-list', urlAfterRedirects: '/tabs/observation-list')
﻿```

Jeg synes dette støyer såpass mye at jeg har fjernet det. Vi kan alltids legge det til igjen om vi trenger det.