### PR TITLE
Søkeknappen får kartet til å låse seg

### DIFF
--- a/src/app/modules/map/components/map-controls/map-search/map-search.component.html
+++ b/src/app/modules/map/components/map-controls/map-search/map-search.component.html
@@ -1,5 +1,10 @@
 <ion-fab>
-  <ion-fab-button color="varsom-dark-blue" class="map-control-fab" (click)="presentModal()">
-    <ion-icon name="search"></ion-icon>
-  </ion-fab-button>
+  <ion-button id='open-modal' expand='block' color='varsom-dark-blue' class='map-control-fab'>
+    <ion-icon name='search'></ion-icon>
+  </ion-button>
+  <ion-modal trigger='open-modal'>
+    <ng-template>
+      <app-modal-search></app-modal-search>
+    </ng-template>
+  </ion-modal>
 </ion-fab>

--- a/src/app/modules/map/components/map-controls/map-search/map-search.component.html
+++ b/src/app/modules/map/components/map-controls/map-search/map-search.component.html
@@ -1,7 +1,7 @@
 <ion-fab>
-  <ion-button id='open-modal' expand='block' color='varsom-dark-blue' class='map-control-fab'>
+  <ion-fab-button id='open-modal' color='varsom-dark-blue' class='map-control-fab'>
     <ion-icon name='search'></ion-icon>
-  </ion-button>
+  </ion-fab-button>
   <ion-modal trigger='open-modal'>
     <ng-template>
       <app-modal-search></app-modal-search>

--- a/src/app/modules/map/components/map-controls/map-search/map-search.component.ts
+++ b/src/app/modules/map/components/map-controls/map-search/map-search.component.ts
@@ -1,7 +1,5 @@
-import { Component } from '@angular/core';
-import { ModalController } from '@ionic/angular';
-import { CustomAnimation } from '../../../../../core/animations/custom.animation';
-import { ModalSearchPage } from '../../../pages/modal-search/modal-search.page';
+import { Component, ViewChild } from '@angular/core';
+import { IonModal } from '@ionic/angular';
 
 @Component({
   selector: 'app-map-search',
@@ -9,15 +7,5 @@ import { ModalSearchPage } from '../../../pages/modal-search/modal-search.page';
   styleUrls: ['./map-search.component.scss']
 })
 export class MapSearchComponent {
-  constructor(private modalController: ModalController) {}
-
-  async presentModal() {
-    const modal = await this.modalController.create({
-      component: ModalSearchPage,
-      keyboardClose: true,
-      enterAnimation: CustomAnimation.slideInFromRight,
-      leaveAnimation: CustomAnimation.slideOutToRight
-    });
-    return await modal.present();
-  }
+  @ViewChild(IonModal) modal: IonModal;
 }

--- a/src/app/modules/map/components/map-controls/map-search/map-search.component.ts
+++ b/src/app/modules/map/components/map-controls/map-search/map-search.component.ts
@@ -1,5 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
-import { IonModal } from '@ionic/angular';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-map-search',
@@ -7,5 +6,4 @@ import { IonModal } from '@ionic/angular';
   styleUrls: ['./map-search.component.scss']
 })
 export class MapSearchComponent {
-  @ViewChild(IonModal) modal: IonModal;
 }

--- a/src/app/modules/map/pages/modal-search/modal-search.module.ts
+++ b/src/app/modules/map/pages/modal-search/modal-search.module.ts
@@ -14,7 +14,10 @@ import { StartsWithHighlightPipe } from '../../pipes/starts-with-highlight.pipe'
     IonicModule,
     TranslateModule
   ],
-  declarations: [ModalSearchPage, StartsWithHighlightPipe]
+  declarations: [ModalSearchPage, StartsWithHighlightPipe],
+  exports: [
+    ModalSearchPage
+  ]
 })
 export class ModalSearchPageModule {
 }

--- a/src/app/modules/map/pages/modal-search/modal-search.page.html
+++ b/src/app/modules/map/pages/modal-search/modal-search.page.html
@@ -5,7 +5,7 @@
         <ion-item>
           <ion-icon slot='start' name='search'></ion-icon>
           <ion-input placeholder="{{'MAP_SEARCH.SEARCH_TEXT'|translate}}" [formControl]='searchField' #searchInput
-            (ionBlur)='doSearch()' autofocus='true'></ion-input>
+            (ionBlur)='doSearch()'></ion-input>
           <ion-icon slot='end' name='close' (click)='closeModal()'></ion-icon>
         </ion-item>
       </ion-list>

--- a/src/app/modules/map/pages/modal-search/modal-search.page.html
+++ b/src/app/modules/map/pages/modal-search/modal-search.page.html
@@ -1,36 +1,36 @@
 <ion-header>
-  <ion-toolbar mode="ios">
-    <form (ngSubmit)="doSearch()">
-      <ion-list lines="none" class="ion-no-padding ion-no-margin">
+  <ion-toolbar mode='ios'>
+    <form (ngSubmit)='doSearch()'>
+      <ion-list lines='none' class='ion-no-padding ion-no-margin'>
         <ion-item>
-          <ion-icon slot="start" name="search"></ion-icon>
-          <ion-input placeholder="{{'MAP_SEARCH.SEARCH_TEXT'|translate}}" [formControl]="searchField"
-            (ionInputDidLoad)="focusInput($event)" (ionBlur)="doSearch()"></ion-input>
-          <ion-icon slot="end" name="close" (click)="closeModal()"></ion-icon>
+          <ion-icon slot='start' name='search'></ion-icon>
+          <ion-input placeholder="{{'MAP_SEARCH.SEARCH_TEXT'|translate}}" [formControl]='searchField' #searchInput
+                     (ionBlur)='doSearch()'></ion-input>
+          <ion-icon slot='end' name='close' (click)='closeModal()'></ion-icon>
         </ion-item>
       </ion-list>
     </form>
   </ion-toolbar>
 </ion-header>
 <ion-content>
-  <ion-list *ngIf="searchResult$ | async as searchResults" lines="full" class="search-result">
-    <ion-item *ngFor="let item of searchResults" (click)="searchItemClicked(item)">
+  <ion-list *ngIf='searchResult$ | async as searchResults' lines='full' class='search-result'>
+    <ion-item *ngFor='let item of searchResults' (click)='searchItemClicked(item)'>
       <ion-label>
-        <ion-text class="search-result-name" [innerHTML]="item.name | startsWithHighlight:searchText"></ion-text>
-        <ion-text color="medium" class="search-description">{{item.description}}</ion-text>
+        <ion-text class='search-result-name' [innerHTML]='item.name | startsWithHighlight:searchText'></ion-text>
+        <ion-text color='medium' class='search-description'>{{item.description}}</ion-text>
       </ion-label>
     </ion-item>
   </ion-list>
-  <ng-container *ngIf="searchHistory$ | async as searchHistory">
-    <ion-list *ngIf="!hasResults && !loading && searchHistory.length > 0" lines="full" class="search-result">
-      <ion-list-header class="ion-text-uppercase">
+  <ng-container *ngIf='searchHistory$ | async as searchHistory'>
+    <ion-list *ngIf='!hasResults && !loading && searchHistory.length > 0' lines='full' class='search-result'>
+      <ion-list-header class='ion-text-uppercase'>
         <ion-label>{{'MAP_SEARCH.SEARCH_HISTORY_HEADER' | translate}}</ion-label>
       </ion-list-header>
-      <ion-item *ngFor="let item of searchHistory" (click)="searchItemClicked(item)">
-        <ion-icon slot="start" mode="md" name="time"></ion-icon>
+      <ion-item *ngFor='let item of searchHistory' (click)='searchItemClicked(item)'>
+        <ion-icon slot='start' mode='md' name='time'></ion-icon>
         <ion-label>
-          <ion-text class="search-result-name">{{item.name}}</ion-text>
-          <ion-text color="medium" class="search-description">{{item.description}}</ion-text>
+          <ion-text class='search-result-name'>{{item.name}}</ion-text>
+          <ion-text color='medium' class='search-description'>{{item.description}}</ion-text>
         </ion-label>
       </ion-item>
     </ion-list>

--- a/src/app/modules/map/pages/modal-search/modal-search.page.html
+++ b/src/app/modules/map/pages/modal-search/modal-search.page.html
@@ -5,7 +5,7 @@
         <ion-item>
           <ion-icon slot='start' name='search'></ion-icon>
           <ion-input placeholder="{{'MAP_SEARCH.SEARCH_TEXT'|translate}}" [formControl]='searchField' #searchInput
-                     (ionBlur)='doSearch()'></ion-input>
+            (ionBlur)='doSearch()' autofocus='true'></ion-input>
           <ion-icon slot='end' name='close' (click)='closeModal()'></ion-icon>
         </ion-item>
       </ion-list>

--- a/src/app/modules/map/pages/modal-search/modal-search.page.scss
+++ b/src/app/modules/map/pages/modal-search/modal-search.page.scss
@@ -1,27 +1,33 @@
-.swipeWrapper{
-    width: 100%;
-    height: 100%;
+:host {
+  height: 100%;
+}
+
+.swipeWrapper {
+  width: 100%;
+  height: 100%;
 }
 
 ion-title {
-    padding-right: 0px;
-    padding-left: 0px;
+  padding-right: 0;
+  padding-left: 0;
 }
 
 ion-content {
-    ion-list {
-        padding-bottom: 8px;
-        margin-top: 1px;
-        margin-bottom: 0px;
-        ion-item {
-            ion-label {
-            .search-result-name {
-                padding-right: 10px;
-            }
-            .search-description {
-                font-size: 14px;
-            }
-            }       
+  ion-list {
+    padding-bottom: 8px;
+    margin-top: 1px;
+    margin-bottom: 0;
+
+    ion-item {
+      ion-label {
+        .search-result-name {
+          padding-right: 10px;
         }
+
+        .search-description {
+          font-size: 14px;
+        }
+      }
     }
+  }
 }

--- a/src/app/modules/map/pages/modal-search/modal-search.page.ts
+++ b/src/app/modules/map/pages/modal-search/modal-search.page.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, NgZone, Renderer2, OnDestroy } from '@angular/core';
-import { ModalController, IonInput, DomController } from '@ionic/angular';
+import { ModalController, DomController } from '@ionic/angular';
 import { MapSearchService } from '../../services/map-search/map-search.service';
 import { Observable } from 'rxjs';
 import { MapSearchResponse } from '../../services/map-search/map-search-response.model';
@@ -117,8 +117,8 @@ export class ModalSearchPage implements OnInit, OnDestroy {
 
   isValidLatLngArray(searchValue: string[]) {
     if (searchValue && searchValue.length === 2) {
-      const trimmedLatString = this.trimAndReplaceString(searchValue[0]);
-      const trimmedLngString = this.trimAndReplaceString(searchValue[1]);
+      const trimmedLatString = ModalSearchPage.trimAndReplaceString(searchValue[0]);
+      const trimmedLngString = ModalSearchPage.trimAndReplaceString(searchValue[1]);
       if (
         trimmedLatString &&
         trimmedLatString.length > 0 &&
@@ -137,18 +137,11 @@ export class ModalSearchPage implements OnInit, OnDestroy {
     return null;
   }
 
-  private trimAndReplaceString(input: string) {
+  private static trimAndReplaceString(input: string) {
     if (input === undefined || input === null) {
       return input;
     }
     return input.trim().replace(/,/g, '.');
-  }
-
-  focusInput(event: Event) {
-    const input: IonInput = <any>event.target;
-    setTimeout(() => {
-      (<any>input).setFocus();
-    }, 1000);
   }
 
   closeModal() {

--- a/src/app/modules/map/pages/modal-search/modal-search.page.ts
+++ b/src/app/modules/map/pages/modal-search/modal-search.page.ts
@@ -29,7 +29,6 @@ export class ModalSearchPage implements OnInit, OnDestroy {
   hasResults: boolean;
   searchHistory$: Observable<MapSearchResponse[]>;
 
-  private modalPageWrapper: Element;
   private modalTop: HTMLIonModalElement;
   private swipeOffset = 0;
   private swipePercentage = 0;
@@ -41,7 +40,8 @@ export class ModalSearchPage implements OnInit, OnDestroy {
     private ngZone: NgZone,
     private renderer: Renderer2,
     private domCtrl: DomController
-  ) {}
+  ) {
+  }
 
   ngOnInit() {
     this.searchField = new UntypedFormControl();
@@ -83,20 +83,23 @@ export class ModalSearchPage implements OnInit, OnDestroy {
 
   private async createGesture() {
     this.modalTop = await this.modalController.getTop();
-    this.gesture = createGesture({
-      el: this.modalTop,
-      gestureName: 'swipe-to-close',
-      direction: 'x',
-      disableScroll: true,
-      onMove: (ev) => this.onMoveHandler(ev),
-      onEnd: (ev) => this.onPanend()
-    });
-
-    this.gesture.enable();
+    if (this.modalTop) {
+      this.gesture = createGesture({
+        el: this.modalTop,
+        gestureName: 'swipe-to-close',
+        direction: 'x',
+        disableScroll: true,
+        onMove: (ev) => this.onMoveHandler(ev),
+        onEnd: () => this.onPanend()
+      });
+      this.gesture.enable();
+    }
   }
 
   ngOnDestroy(): void {
-    this.gesture.destroy();
+    if (this.gesture) {
+      this.gesture.destroy();
+    }
   }
 
   isValidLatLng(searchValue: string) {


### PR DESCRIPTION
Skrevet om modalen til en inline-modal istedenfor å bruke ModalController fra Ionic.

Ting som fortsatt ikke er fikset:
Søkefeltet mangler autofocus, slik at bruker nå må trykke seg dit hver gang manuelt. Dette burde kunne løses med noe slikt:
```js
@ViewChild(IonInput) searchInput: IonInput;

async ngAfterViewInit() {
    await this.searchInput.setFocus();
}
```

Det ligger mye ekstra kode i modal-search.page.ts som omhandler håndtering av gesture (swipe for å lukke osv). Vet ikke om dette er noe vi bare burde fjerne? Virker som mye ekstra kode og "risiko" for lite gevinst.