### PR TITLE
RO-1456: Fikset slik at man kan legge til bilder som har mellomrom i filnavnet

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
   </queries>
   
 
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />  
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />  
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/ios/App/App/config.xml
+++ b/ios/App/App/config.xml
@@ -14,10 +14,6 @@
     <param name="ios-package" value="CordovaHttpPlugin"/>
   </feature>
 
-  <feature name="Camera">
-    <param name="ios-package" value="CDVCamera"/>
-  </feature>
-
   <feature name="Compass">
     <param name="ios-package" value="CDVCompass"/>
   </feature>

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -13,6 +13,7 @@ def capacitor_pods
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
+  pod 'CapacitorCamera', :path => '../../node_modules/@capacitor/camera'
   pod 'CapacitorClipboard', :path => '../../node_modules/@capacitor/clipboard'
   pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'
   pod 'CapacitorGeolocation', :path => '../../node_modules/@capacitor/geolocation'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4509,6 +4509,11 @@
       "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-4.0.1.tgz",
       "integrity": "sha512-tPOA/eYDJdDeMFd+A3I8teuGfPP0GEqhWtMzH8z5r2tW40iJ/mL8qH5NgVLMZ3uvs7gN2LfQTCMNJvl0F/WdBw=="
     },
+    "@capacitor/camera": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/camera/-/camera-4.1.2.tgz",
+      "integrity": "sha512-YJMw8sflNj3aa9jSqOgSKOhjKNjc6fb1wxdVMW7Ek6SWsykbcAMWRkecOsSqPNPyDbNRBiwB8P5ZuUC8ZwRm0A=="
+    },
     "@capacitor/cli": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-4.1.0.tgz",
@@ -5048,21 +5053,6 @@
       "version": "5.36.0",
       "resolved": "https://registry.npmjs.org/@ionic-native/android-permissions/-/android-permissions-5.36.0.tgz",
       "integrity": "sha512-kwjDKOhQs9KPo47LxQbkmLJ30coZzeJewA2u7I8DFae2kyD3usvGAgjWoY+x4xPsaA1NZ3IZNklaQOH/csIW7w==",
-      "requires": {
-        "@types/cordova": "^0.0.34"
-      },
-      "dependencies": {
-        "@types/cordova": {
-          "version": "0.0.34",
-          "resolved": "https://registry.npmjs.org/@types/cordova/-/cordova-0.0.34.tgz",
-          "integrity": "sha512-rkiiTuf/z2wTd4RxFOb+clE7PF4AEJU0hsczbUdkHHBtkUmpWQpEddynNfJYKYtZFJKbq4F+brfekt1kx85IZA=="
-        }
-      }
-    },
-    "@ionic-native/camera": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/camera/-/camera-5.36.0.tgz",
-      "integrity": "sha512-68hdPn0hA7yn4YNTgmLF32x/l7arFulboGhNiyFQ35/QxqrOmppf77p4xaPOyJtNyICKHLaiStC6w1eEAtl9MA==",
       "requires": {
         "@types/cordova": "^0.0.34"
       },
@@ -9770,7 +9760,7 @@
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -10042,7 +10032,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "cacache": {
@@ -10613,7 +10603,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -11136,12 +11126,6 @@
         "q": "^1.5.1",
         "recursive-readdir": "^2.2.2"
       }
-    },
-    "cordova-plugin-camera": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-camera/-/cordova-plugin-camera-6.0.0.tgz",
-      "integrity": "sha512-FTFKep8HZI/2HkX+Gc/dUACfZGV9+k9waXlgoEOKXOiPPR/1zBw29Mw+adcz4FQUpdWyAgYDxNiaPUnP0P+H2Q==",
-      "dev": true
     },
     "cordova-plugin-device": {
       "version": "2.0.3",
@@ -12147,7 +12131,7 @@
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
     "dns-packet": {
@@ -14177,7 +14161,7 @@
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -14240,7 +14224,7 @@
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
     "http-errors": {
@@ -14365,7 +14349,7 @@
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
@@ -14429,7 +14413,7 @@
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true,
       "optional": true
     },
@@ -14688,7 +14672,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-bigint": {
@@ -14779,7 +14763,7 @@
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
     },
     "is-map": {
@@ -15417,7 +15401,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpointer": {
@@ -16094,7 +16078,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
     "lodash.get": {
@@ -17480,7 +17464,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "normalize-url": {
@@ -19873,7 +19857,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true,
       "optional": true
     },
@@ -20021,7 +20005,7 @@
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "dev": true,
       "requires": {
         "pify": "^2.3.0"
@@ -20030,7 +20014,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -20695,7 +20679,7 @@
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
     "selenium-webdriver": {
@@ -20822,7 +20806,7 @@
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -20846,7 +20830,7 @@
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
             "depd": "~1.1.2",
@@ -20858,13 +20842,13 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@capacitor/android": "^4.0.1",
     "@capacitor/app": "^4.0.1",
     "@capacitor/browser": "^4.0.1",
+    "@capacitor/camera": "^4.1.2",
     "@capacitor/clipboard": "^4.0.1",
     "@capacitor/core": "^4.0.1",
     "@capacitor/filesystem": "^4.1.0",
@@ -56,7 +57,6 @@
     "@capacitor/splash-screen": "^4.0.1",
     "@capacitor/status-bar": "^4.0.1",
     "@ionic-native/android-permissions": "^5.36.0",
-    "@ionic-native/camera": "^5.36.0",
     "@ionic-native/core": "^5.36.0",
     "@ionic-native/device-orientation": "^5.36.0",
     "@ionic-native/diagnostic": "^5.36.0",
@@ -148,7 +148,6 @@
     "cordova-plugin-android-permissions": "^1.1.2",
     "cordova-plugin-androidx": "^3.0.0",
     "cordova-plugin-androidx-adapter": "^1.1.3",
-    "cordova-plugin-camera": "^6.0.0",
     "cordova-plugin-device-orientation": "^2.0.1",
     "cordova-plugin-email-composer": "^0.9.2",
     "cordova-plugin-file": "^6.0.2",
@@ -203,9 +202,6 @@
       "cordova-plugin-androidx": {},
       "cordova-plugin-androidx-adapter": {},
       "sqli-cordova-disk-space-plugin": {},
-      "cordova-plugin-camera": {
-        "ANDROIDX_CORE_VERSION": "1.6.+"
-      },
       "cordova-plugin-advanced-http": {
         "ANDROIDBLACKLISTSECURESOCKETPROTOCOLS": "SSLv3,TLSv1"
       }

--- a/src/app/app.providers.ts
+++ b/src/app/app.providers.ts
@@ -16,7 +16,6 @@ import { AppErrorHandler } from './core/error-handler/error-handler.class';
 import { HTTP } from '@ionic-native/http/ngx';
 import { WebView } from '@ionic-native/ionic-webview/ngx';
 import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { Camera } from '@ionic-native/camera/ngx';
 import { EmailComposer } from '@ionic-native/email-composer/ngx';
 import { StartWizardGuard } from './core/guards/start-wizard.guard';
 import { DataMarshallService } from './core/services/data-marshall/data-marshall.service';
@@ -102,7 +101,6 @@ export const APP_PROVIDERS = [
   File,
   AndroidPermissions,
   Zip,
-  Camera,
   InAppBrowser,
   SafariViewController,
   HTTP,

--- a/src/app/modules/common-registration/services/add-new-attachment/file-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/file-attachment.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, firstValueFrom, from, Observable, switchMap, tap } fro
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { AttachmentType, AttachmentUploadEditModel } from '../../models/attachment-upload-edit.interface';
 import { RegistrationTid } from '../../registration.models';
-import { GetAttachmentFilterOptions, NewAttachmentService } from './new-attachment.service';
+import { NewAttachmentService } from './new-attachment.service';
 import { File } from '@ionic-native/file/ngx';
 import { Injectable } from '@angular/core';
 
@@ -17,7 +17,7 @@ const ROOT_DIR = 'attachments';
 export default class FileAttachmentService extends NewAttachmentService {
   protected DEBUG_TAG = 'FileAttachmentService';
   private hasCreatedRootFolder = false;
-  private attachmentsChanged = new BehaviorSubject<void>(undefined); //get a tick each time a registration's attachment changes
+  private attachmentsChanged = new BehaviorSubject<void>(undefined); //get a tick each time an attachment changes
 
   constructor(private file: File, protected logger: LoggingService) {
     super();

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -135,7 +135,10 @@ export class EditImagesComponent implements OnInit {
   private async getAlbumImageUrls(options: GalleryImageOptions): Promise<string[]> {
     let imageUrls: string[] = [];
     let photos: GalleryPhotos;
-    const permissionState = await Camera.checkPermissions();
+    let permissionState = await Camera.checkPermissions();
+    if (permissionState?.photos != 'granted' && permissionState?.photos != 'limited') {
+      permissionState = await Camera.requestPermissions({permissions: ['photos']});
+    }
     if (permissionState?.photos === 'limited') {
       photos = await Camera.getLimitedLibraryPhotos();
     } else if (permissionState?.photos === 'granted') {
@@ -152,7 +155,10 @@ export class EditImagesComponent implements OnInit {
   }
 
   private async takePhotoAndReturnImageUrl(options: ImageOptions): Promise<string[]> {
-    const permissionState = await Camera.checkPermissions();
+    let permissionState = await Camera.checkPermissions();
+    if (permissionState?.camera !== 'granted') {
+      permissionState = await Camera.requestPermissions({permissions: ['camera']});
+    }
     if (permissionState?.camera === 'granted') {
       const photo = await Camera.getPhoto(options);
       if (photo) {

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -143,7 +143,9 @@ export class EditImagesComponent implements OnInit {
       const arrayBuffer = await this.getArrayBuffer(imageUrl);
       await this.addImage(new Blob([arrayBuffer]), MIME_TYPE);
     } catch (err) {
-      if (err.message == 'User denied access to photos') {
+      if (err.message == 'User denied access to camera') {
+        this.showErrorToast('REGISTRATION.IMAGE_ERROR.CAMERA_PERMISSION_MISSING');
+      } else if (err.message == 'User denied access to photos') {
         this.showErrorToast('REGISTRATION.IMAGE_ERROR.ALBUM_READ_PERMISSION_MISSING');
       // we ignore errors we get if user cancels taking photo or gallery selection
       } else if (['No image picked', 'No Image Selected', 'User cancelled photos app'].indexOf(err.message) === -1) {

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -136,12 +136,10 @@ export class EditImagesComponent implements OnInit {
     let imageUrls: string[] = [];
     let photos: GalleryPhotos;
     let permissionState = await Camera.checkPermissions();
-    if (permissionState?.photos != 'granted' && permissionState?.photos != 'limited') {
+    if (!(['granted', 'limited'].includes(permissionState?.photos))) {
       permissionState = await Camera.requestPermissions({permissions: ['photos']});
     }
-    if (permissionState?.photos === 'limited') {
-      photos = await Camera.getLimitedLibraryPhotos();
-    } else if (permissionState?.photos === 'granted') {
+    if (['granted', 'limited'].includes(permissionState?.photos)) {
       photos = await Camera.pickImages(options);
     } else {
       this.showErrorToast('REGISTRATION.IMAGE_ERROR.ALBUM_READ_PERMISSION_MISSING');
@@ -193,7 +191,7 @@ export class EditImagesComponent implements OnInit {
       }
     } catch (err) {
       // we ignore errors we get if user cancels taking photo or gallery selection
-      if (ERRORS_TO_IGNORE.indexOf(err.message) === -1) {
+      if (!(ERRORS_TO_IGNORE.includes(err.message))) {
         this.logger.log('Unknown error when adding image', err, LogLevel.Warning, DEBUG_TAG, imageUrls);
         this.showErrorToast('REGISTRATION.IMAGE_ERROR.UNKNOWN');
       }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -411,6 +411,10 @@
     "IMAGES": "Images",
     "IMAGE_DESCRIPTION": "Image description",
     "IMAGE_DESCRIPTION_PLACEHOLDER": "Add a description to the image",
+    "IMAGE_ERROR": {
+      "ALBUM_READ_PERMISSION_MISSING": "To add images from library you need to give the app permission to read media",
+      "UNKNOWN": "Couldn't add image. It may be something wrong with the image file. Please try another image to check"
+    },
     "INCIDENT": {
       "ACTIVITY": "Activity",
       "COMMENT": "Description",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -414,7 +414,7 @@
     "IMAGE_ERROR": {
       "ALBUM_READ_PERMISSION_MISSING": "You need to give the app permission to read from the photo library",
       "CAMERA_PERMISSION_MISSING": "You need to give the app permission to use the camera",
-      "UNKNOWN": "Couldn't add image. It may be something wrong with the image file. Please try another image to check"
+      "UNKNOWN": "Couldn't add image(s). It may be something wrong with the image file(s). Please try another image to check"
     },
     "INCIDENT": {
       "ACTIVITY": "Activity",
@@ -424,7 +424,7 @@
       "IMAGE_PLACEHOLDER": "+ Add image description",
       "TITLE": "Accident / Incident"
     },
-    "INVALID_IMAGE": "Sorry, this is an invalid image",
+    "INVALID_IMAGE": "Sorry, only JPEG images is supported",
     "COULD_NOT_DOWNLOAD_IMAGE": "Could not download image from regobs.no.",
     "COULD_NOT_DOWNLOAD_IMAGE_NET_Q": "Are you online?",
     "IN_CM": "In centimeter",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -412,7 +412,8 @@
     "IMAGE_DESCRIPTION": "Image description",
     "IMAGE_DESCRIPTION_PLACEHOLDER": "Add a description to the image",
     "IMAGE_ERROR": {
-      "ALBUM_READ_PERMISSION_MISSING": "To add images from library you need to give the app permission to read media",
+      "ALBUM_READ_PERMISSION_MISSING": "You need to give the app permission to read from the photo library",
+      "CAMERA_PERMISSION_MISSING": "You need to give the app permission to use the camera",
       "UNKNOWN": "Couldn't add image. It may be something wrong with the image file. Please try another image to check"
     },
     "INCIDENT": {

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -411,6 +411,10 @@
     "IMAGES": "Bilder",
     "IMAGE_DESCRIPTION": "Beskrivelse av bildet",
     "IMAGE_DESCRIPTION_PLACEHOLDER": "Her kan du gi en beskrivelse av bildet",
+    "IMAGE_ERROR": {
+      "ALBUM_READ_PERMISSION_MISSING": "Du må gi appen tillatelse til å lese media for å kunne legge til bilder fra biblioteket",
+      "UNKNOWN": "Vi fikk ikke til å legge til bildet. Det kan være noe galt med bildefila eller en annen feil. Prøv gjerne et annet bilde for å sjekke"
+    },
     "INCIDENT": {
       "ACTIVITY": "Aktivitet",
       "COMMENT": "Beskrivelse",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -414,7 +414,7 @@
     "IMAGE_ERROR": {
       "ALBUM_READ_PERMISSION_MISSING": "Du må gi appen tillatelse til å lese fra fotoalbumet",
       "CAMERA_PERMISSION_MISSING": "Du må gi appen tillatelse til å bruke kameraet",
-      "UNKNOWN": "Vi fikk ikke til å legge til bildet. Det kan være noe galt med bildefila eller en annen feil. Prøv gjerne et annet bilde for å sjekke"
+      "UNKNOWN": "Vi fikk ikke til å legge til bildet/bildene. Det kan være noe galt med en bildefil eller en annen feil. Prøv gjerne et annet bilde for å sjekke"
     },
     "INCIDENT": {
       "ACTIVITY": "Aktivitet",
@@ -424,7 +424,7 @@
       "IMAGE_PLACEHOLDER": "+ Legg til en beskrivelse av bildet",
       "TITLE": "Ulykke / hendelse"
     },
-    "INVALID_IMAGE": "Beklager, ugyldig bildeformat",
+    "INVALID_IMAGE": "Beklager, ugyldig bildeformat. Kun JPEG er støttet",
     "COULD_NOT_DOWNLOAD_IMAGE": "Klarte ikke å laste bilde fra regobs.no.",
     "COULD_NOT_DOWNLOAD_IMAGE_NET_Q": "Har du nett?",
     "IN_CM": "I centimeter",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -412,7 +412,8 @@
     "IMAGE_DESCRIPTION": "Beskrivelse av bildet",
     "IMAGE_DESCRIPTION_PLACEHOLDER": "Her kan du gi en beskrivelse av bildet",
     "IMAGE_ERROR": {
-      "ALBUM_READ_PERMISSION_MISSING": "Du må gi appen tillatelse til å lese media for å kunne legge til bilder fra biblioteket",
+      "ALBUM_READ_PERMISSION_MISSING": "Du må gi appen tillatelse til å lese fra fotoalbumet",
+      "CAMERA_PERMISSION_MISSING": "Du må gi appen tillatelse til å bruke kameraet",
       "UNKNOWN": "Vi fikk ikke til å legge til bildet. Det kan være noe galt med bildefila eller en annen feil. Prøv gjerne et annet bilde for å sjekke"
     },
     "INCIDENT": {

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -369,7 +369,8 @@
     "IMAGE_DESCRIPTION": "Skildring av bilete",
     "IMAGE_DESCRIPTION_PLACEHOLDER": "Her kan du gi ei skildring av bilete",
     "IMAGE_ERROR": {
-      "ALBUM_READ_PERMISSION_MISSING": "Du må gi appen tillatelse til å lese media for å kunne legge til bilder fra biblioteket",
+      "ALBUM_READ_PERMISSION_MISSING": "Du må gi appen tillatelse til å lese fra fotoalbumet",
+      "CAMERA_PERMISSION_MISSING": "Du må gi appen tillatelse til å bruke kameraet",
       "UNKNOWN": "Vi fikk ikke til å legge til bildet. Det kan være noe galt med bildefila eller en annen feil. Prøv gjerne et annet bilde for å sjekke"
     },
     "INCIDENT": {

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -371,7 +371,7 @@
     "IMAGE_ERROR": {
       "ALBUM_READ_PERMISSION_MISSING": "Du må gi appen tillatelse til å lese fra fotoalbumet",
       "CAMERA_PERMISSION_MISSING": "Du må gi appen tillatelse til å bruke kameraet",
-      "UNKNOWN": "Vi fikk ikke til å legge til bildet. Det kan være noe galt med bildefila eller en annen feil. Prøv gjerne et annet bilde for å sjekke"
+      "UNKNOWN": "Vi fekk ikkje til å legge til bildet/bildane. Det kan være noko gale med ein bildefil eller ein annan feil. Prøv gjerne eit anna bilde for å sjekke"
     },
     "INCIDENT": {
       "ACTIVITY": "Aktivitet",
@@ -381,7 +381,7 @@
       "IMAGE_PLACEHOLDER": "+ Legg til ein beskrivelse av bilete",
       "TITLE": "Ulykke/hending"
     },
-    "INVALID_IMAGE": "Ugyldig biletformat",
+    "INVALID_IMAGE": "Ugyldig biletformat. Bare JPEG er støttet",
     "IN_CM": "I centimeter",
     "IN_FULL_CM": "I heile centimeter",
     "NONE": "Ingen valt",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -368,6 +368,10 @@
     "IMAGES": "Bilete",
     "IMAGE_DESCRIPTION": "Skildring av bilete",
     "IMAGE_DESCRIPTION_PLACEHOLDER": "Her kan du gi ei skildring av bilete",
+    "IMAGE_ERROR": {
+      "ALBUM_READ_PERMISSION_MISSING": "Du må gi appen tillatelse til å lese media for å kunne legge til bilder fra biblioteket",
+      "UNKNOWN": "Vi fikk ikke til å legge til bildet. Det kan være noe galt med bildefila eller en annen feil. Prøv gjerne et annet bilde for å sjekke"
+    },
     "INCIDENT": {
       "ACTIVITY": "Aktivitet",
       "COMMENT": "Skildring",


### PR DESCRIPTION
Jeg har byttet ut cordova-plugin-camera med capacitor/camera. Da fikk jeg ikke lengre problemer med å importere skjermdumper fra albunet på Samsung-tlf.
Har også ordnet bedre feilmeldinger, så da løser vi også https://nveprojects.atlassian.net/browse/RO-1809
Dette står igjen:

- [x] Teste på iOS, denne er kun testet på Android foreløpig
- [ ] "Native" feilmelding når telefonen spør om tilgang til album/kamera er kun på engelsk. Må oversettes! Jeg har registrert en egen feil på dette: https://nveprojects.atlassian.net/browse/RO-2001
- [x] Appen bryr seg ikke om bruker kun har gitt tilgang til en begrenset del av albumet

Tips til testing:

- ta bilde og legge til
- velg bilde fra album (kanskje kan du velge flere?)
- sjekk at bilder du tar blir lagt til albumet
- prøv å avbryte (gå tilbake fra) foto-appen etter du har valgt å ta bilde. Det skal funke uten feilmelding
- prøv å avbryte (gå tilbake fra) album-appen etter du har valgt album. Det skal funke uten feilmelding
- fjern rettigheter til media og sjekk at vi gir riktig feilmelding
- på iOS: Prøv å gi appen tilgang til kun en begrenset del av bildene


