### PR TITLE
render toast with error message on failed permissions

### DIFF
--- a/src/app/core/services/geo-position/geo-position.service.ts
+++ b/src/app/core/services/geo-position/geo-position.service.ts
@@ -314,6 +314,7 @@ export class GeoPositionService implements OnDestroy {
 
 
   private async startWatchingPosition(): Promise<void> {
+    await this.checkPermissions();
     const watchPositionCallback: WatchPositionCallback = (position: Position, err: any) => {
       if (err) {
         this.loggingService.log(
@@ -384,7 +385,7 @@ export class GeoPositionService implements OnDestroy {
   private async checkPermissions() : Promise<boolean> {
     try {
       if (isAndroidOrIos(this.platform)) {
-        this.checkPermissionsApp();
+        await this.checkPermissionsApp();
       }
     } catch (err) {
       this.loggingService.error(
@@ -392,6 +393,8 @@ export class GeoPositionService implements OnDestroy {
         DEBUG_TAG,
         'Error asking for location permissions'
       );
+      const errorMessage = this.translateService.instant('GEOLOCATION.POSITION_ERROR.PermissionDenied');
+      this.createToast(errorMessage);
       return true; // continue anyway on error
     }
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -81,7 +81,7 @@
   "DRAFT": "Draft",
   "GEOLOCATION": {
     "POSITION_ERROR": {
-      "PermissionDenied": "To fetch your position you need to alter your browser settings",
+      "PermissionDenied": "To fetch your position you need to alter your location settings",
       "PositionUnavailable": "Not able fetch your position",
       "Timeout": "It took to long time to fetch your position",
       "INVALID": "Invalid position data",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -81,7 +81,7 @@
   "DRAFT": "Kladd",
   "GEOLOCATION": {
     "POSITION_ERROR": {
-      "PermissionDenied": "For å hente posisjonen din må du endre innstillinger i nettleseren",
+      "PermissionDenied": "For å hente posisjonen din må du endre lokasjonsinnstillinger",
       "PositionUnavailable": "Får ikke tak i posisjonen din",
       "Timeout": "Det tok for lang tid å få tak i posisjonen din",
       "INVALID": "Kan ikke vise posisjonen din pga. ufullstendige posisjonsdata",


### PR DESCRIPTION
Testet både på Android og Iphone. På Android dukker opp bare toaster med en feilmelding hvis posisjonsenhet er av.
På Iphone vises default dialog vindu når man åpner appen, men hvis man fortsetter å bruke appen uten å skru på lokasjonen så får man toaster med felimelding når man tryker på gps knapp