### PR TITLE
added right class name in media queries

### DIFF
--- a/src/app/components/coach-marks/coach-marks-simple-obs/coach-marks-simple-obs.component.scss
+++ b/src/app/components/coach-marks/coach-marks-simple-obs/coach-marks-simple-obs.component.scss
@@ -63,8 +63,7 @@
 
     @media only screen and (max-width:450px) {
         .toggle-coachmark-text,
-        .toggle-coachmark-extra-text-1,
-        .toggle-coachmark-extra-text-2 {
+        .toggle-coachmark-extra-text {
             right: -120px;
         }
 


### PR DESCRIPTION
Jeg endret klasse navn fra .toggle-coachmark-extra-text-1 og .toggle-coachmark-extra-text-2 til kun .toggle-coachmark-extra-text i css filen, men jeg glemte å korrigere det i media queries blokken. derfor teskten var kuttet i onboardingen og ble ikke posisjonert på en riktig måte siden den targetet feil klasser 