### PR TITLE
Endret navn på appen til Varsom

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Vi har et 책pent beta-test-program hvor eksterne testere kan melde seg inn ved �
 ### Starte beta-testing p책 Apple App Store
 
 - For 책 rulle videre fra intern testing til beta, logg p책 https://appstoreconnect.apple.com/
-- Velg Varsom Regobs under My Apps
+- Velg Varsom under My Apps
 - Velg TestFlight
 - Under "Test information", legg inn release notes p책 begge spr책k
 - Velg External Groups / Beta Testers

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Varsom Regobs</string>
-    <string name="title_activity_main">Varsom Regobs</string>
+    <string name="app_name">Varsom</string>
+    <string name="title_activity_main">Varsom</string>
     <string name="package_name">no.nve.regobs4</string>
     <string name="custom_url_scheme">no.nve.regobs4</string>
 </resources>

--- a/appstore/description.en.txt
+++ b/appstore/description.en.txt
@@ -1,4 +1,4 @@
-About Varsom Regobs
+About Varsom
 
 Make better plans when in the backcountry or on lakes. Prevent damages from floods through better knowledge. Tell us about avalanches. Together we may save lives and minimize losses due to avalanches, floods, landslides and dangerous ice conditions.
 

--- a/appstore/description.no.txt
+++ b/appstore/description.no.txt
@@ -1,4 +1,4 @@
-Om Varsom Regobs
+Om Varsom
 
 Planlegg turen i fjellet bedre. Forebygg skader av skred og flommer med kunnskap. Fortell oss hvor skredene går. Sammen kan vi spare liv og verdier knyttet til snøskred, flom, jordskred og isforhold.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-# Regobs app build script
+# Varsom app build script
 # https://aka.ms/yaml
 
 trigger:

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,7 @@ import { KeyboardResize, KeyboardStyle } from '@capacitor/keyboard';
 
 const config: CapacitorConfig = {
   appId: 'no.nve.regobs4',
-  appName: 'Varsom Regobs',
+  appName: 'Varsom',
   webDir: 'www',
   bundledWebRuntime: false,
   server: {

--- a/config.xml
+++ b/config.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <widget android-versionCode="210902366" id="no.nve.regobs4" ios-CFBundleVersion="210902366" osx-CFBundleVersion="210902366" version="4.6.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-    <name>Varsom Regobs</name>
+    <name>Varsom</name>
     <description>Report incidents in nature</description>
     <author email="regobs@nve.no" href="http://nve.no/">NVE</author>
     <content src="index.html" />

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleDisplayName</key>
-    <string>Varsom Regobs</string>
+    <string>Varsom</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIdentifier</key>

--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -1,6 +1,6 @@
 {
 	"appId": "no.nve.regobs4",
-	"appName": "Varsom Regobs",
+  "appName": "Varsom",
 	"webDir": "www",
 	"bundledWebRuntime": false,
 	"server": {

--- a/src/app/modules/shared/services/logging/file-logging.service.ts
+++ b/src/app/modules/shared/services/logging/file-logging.service.ts
@@ -487,7 +487,7 @@ export class FileLoggingService {
       }
     }
 
-    async sendLogsByEmail(topic = 'Regobs-app-logger', body = ''): Promise<void> {
+    async sendLogsByEmail(topic = 'Varsom-app-logger', body = ''): Promise<void> {
       const canSend = await this.emailComposerService.canSendEmail();
       if (canSend) {
         const fileEntries = await this.getLogFiles();

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -1,4 +1,4 @@
-<app-header title="Varsom Regobs" [fullscreenSupport]="true"></app-header>
+<app-header title="{{ appname }}" [fullscreenSupport]="true"></app-header>
 <ion-content>
   
   <app-map 

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -80,7 +80,7 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked {
     if (Capacitor.isNativePlatform()) {
       return 'Varsom';
     }
-    return 'Varsom-observasjoner';
+    return 'Varsom Regobs';
   }
 
   ngAfterViewChecked(): void {

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -25,6 +25,7 @@ import { RouterPage } from '../../core/helpers/routed-page';
 import { enterZone } from '../../core/helpers/observable-helper';
 import { MapCenterInfoComponent } from 'src/app/modules/map/components/map-center-info/map-center-info.component';
 import { DOCUMENT } from '@angular/common';
+import { Capacitor } from '@capacitor/core';
 
 const DEBUG_TAG = 'HomePage';
 
@@ -73,6 +74,13 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked {
     ).subscribe((newInfoBoxHeight) => {
       this.document.documentElement.style.setProperty('--map-center-info-height', `${newInfoBoxHeight}px`);
     });
+  }
+
+  get appname(): string {
+    if (Capacitor.isNativePlatform()) {
+      return 'Varsom';
+    }
+    return 'Varsom-observasjoner';
   }
 
   ngAfterViewChecked(): void {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -101,14 +101,13 @@
     "TITLE": "Help"
   },
   "LEGAL_TERMS": {
-    "HEADER": "About Varsom Regobs data",
+    "HEADER": "About Varsom data",
     "LINE_1": "Use the warnings, data and maps at your own risk. Errors and omissions may be present.",
     "LINE_2": "A warning is a planning tool and may differ from the actual situation. Always make your own evaluation. Conditions may be complex and differ from the warning.",
-    "LINE_3": "Data on Regobs is produced by the users and is available «as is». It may contain errors and omissions. NVE makes no warranties for errors, omissions and assessments produced by the users.",
-    "LINE_4": "When publishing images with observations in Regobs, you also accept reuse of these images (licensed under <a href='https://data.norge.no/nlod/en/'>NLOD</a>).",
+    "LINE_3": "Data in Varsom is produced by the users and is available «as is». It may contain errors and omissions. NVE makes no warranties for errors, omissions and assessments produced by the users.",
+    "LINE_4": "When publishing images with observations in Varsom, you also accept reuse of these images (licensed under <a href='https://data.norge.no/nlod/en/'>NLOD</a>).",
     "LINE_5": "Read more in our <a href=\"{{legalUrl}}\" target=\"_blank\">Terms of Service</a>.",
-    "OK": "Ok, I accept",
-    "TERMS": "Data on Varsom Regobs is produced by the users of Regobs and is available as it is. The information may contain errors and omissions. NVE makes no guarantee for the quality or accuracy of the information which is found on Regobs and does not take responsibility for data which is incorrect or misleading. The number of stars besides a username (1-5) indicates the level of competence of the person providing observations. Without stars, competence is unknown or low."
+    "OK": "Ok, I accept"
   },
   "LOGIN": {
     "CHANGE_PASSWORD": "Change password",
@@ -145,7 +144,7 @@
     "SEARCH_TEXT": "Search for location"
   },
   "MENU": {
-    "ABOUT_REGOBS": "About data in Regobs",
+    "ABOUT_REGOBS": "About data in Varsom",
     "AND": "and",
     "CONTACT_REGOBS": "Contact us",
     "CONTACT_REGOBS_ERROR": "Report error",
@@ -196,7 +195,7 @@
     "MAX_COUNT_REACHED_TEXT": "We show max {{ maxCount }} observations here. You may see more at <a target=\"_blank\" href=\"{{ myObservationsUrl }}/\">your page on web</a>",
     "MY_SENT_OBSERVATIONS": "My sent observations",
     "NO_OBSERVATIONS": "Share your observations!",
-    "NO_OBSERVATIONS_TEXT": "Your observartions will appear here. Share your observations, pictures and assessements with others on Varsom Regobs.",
+    "NO_OBSERVATIONS_TEXT": "Your observartions will appear here. Share your observations, pictures and assessements with others on Varsom.",
     "SENT_SUBTITLE": "The following observations have been submitted and are now stored in Regobs.",
     "TITLE": "My observations"
   },
@@ -613,7 +612,6 @@
           "WATER_EQUIVALENT": "Water Equivalent",
           "WEIGHT": "Weight (g)"
         },
-        "SNOW_PROFILE_HELP_TEXT": "Unfortunately, we do not have a form for snow profiles in the current version of the Varsom Regobs app. But, you can upload a picture of a hand drawn profile or an export from a third party app like Ullr Labs Avalanche. On regobs.no you may update the profile information with the forms and plots provided there.",
         "SNOW_TEMP": {
           "ADD_LAYER_BOTTOM": "Add new point",
           "DEPTH": "Depth (cm)",
@@ -736,11 +734,11 @@
   },
   "SETTINGS": {
     "ALLOW_ANALYTICS": "Allow sending app usage data",
-    "ALLOW_ANALYTICS_DESCRIPTION": "Help us improve Varsom Regobs by letting us know how you use the application.",
+    "ALLOW_ANALYTICS_DESCRIPTION": "Help us improve Varsom by letting us know how you use the application.",
     "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "This data is anonymous and cannot be linked to you personally.",
     "ALLOW_ANALYTICS_HEADER": "Share usage statistics",
     "APPMODE": "App mode",
-    "APP_VERSION": "App version",
+    "APP_VERSION": "Version",
     "CONFIRM_RESET": "Are you sure you want to reset app?",
     "COUNTRY": "Country",
     "DROPDOWNS_FAILED": "Could not update dropdowns. Please check network settings and try again later.",
@@ -764,7 +762,7 @@
   },
   "SET_NICK_ALERT": {
     "ERROR": "Couldn't save nickname. Please try later.",
-    "HELP_TEXT": "You need a nickname to use Varsom Regobs. The nickname is shown on your observations.",
+    "HELP_TEXT": "You need a nickname to use Varsom. The nickname is shown on your observations.",
     "INPUT_TEXT": "Please type nickname",
     "NICK": "Nick"
   },
@@ -785,7 +783,7 @@
       "NORWEGIAN_SECONDARY_LANGUAGE": "Norsk"
     },
     "COMPETENCE_PAGE": {
-      "HEADER": "Use Regobs wisely!",
+      "HEADER": "Use Varsom wisely!",
       "LINE_1": "Use the information in the app, but also make your own judgments. View the observations in context of the observer's competence that appears as stars by the name."
     },
     "I_UNDERSTAND": "Ok, I understand",
@@ -804,7 +802,7 @@
     },
     "PAGE_4": {
       "HEADER": "What and how?",
-      "LINE_1": "Choose what to see and share on Regobs. You can read about sharing observations at varsom.no/snøskredskolen and varsom.no/isskolen"
+      "LINE_1": "Choose what to see and share on Varsom. You can read about sharing observations at varsom.no/snøskredskolen and varsom.no/isskolen"
     },
     "SKIP_START": "Skip"
   },
@@ -848,7 +846,7 @@
     "ICE_LEGEND_TEXT_6": "Pipeline",
     "ICE_LEGEND_TEXT_7": "Power plant tunnel",
     "ICE_MAP_DESCRIPTION": "The support map shows parts of watercourses that behave unpredictably throughout the winter due to regulations for power generation",
-    "INFO_PAGE": "<h1>About maps with slope angle and runout zones</h1>\nThe maps are automatically produced and may contain errors. There may be steep terrain, which is not represented in the elevation model and thus not displayed in the maps.\nSome avalanches may have longer runouts than what is displayed as runout zones in the maps.\n\n<h2>What consideration to take?</h2>\nAdjust your risk by choosing where, when and how you travel. Varsom Regobs is a planning tool and its data may differ from the actual situation. Always make your own evaluation.\n \n<h2>When is it safe?</h2>\nAll travel in snow covered avalanche terrain has an element of risk.\n\n<h2>Want to learn more?</h2>\nYou may learn more by taking an avalanche safety course and on Snøskredskolen on Varsom.no.",
+    "INFO_PAGE": "<h1>About maps with slope angle and runout zones</h1>\nThe maps are automatically produced and may contain errors. There may be steep terrain, which is not represented in the elevation model and thus not displayed in the maps.\nSome avalanches may have longer runouts than what is displayed as runout zones in the maps.\n\n<h2>What consideration to take?</h2>\nAdjust your risk by choosing where, when and how you travel. Varsom app is a planning tool and its data may differ from the actual situation. Always make your own evaluation.\n \n<h2>When is it safe?</h2>\nAll travel in snow covered avalanche terrain has an element of risk.\n\n<h2>Want to learn more?</h2>\nYou may learn more by taking an avalanche safety course and on Snøskredskolen on Varsom.no.",
     "LOW": "Low",
     "MARITINE_BORDER": "Sea border",
     "MIDDLE": "Intermediate",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -784,7 +784,7 @@
     },
     "COMPETENCE_PAGE": {
       "HEADER": "Use Varsom wisely!",
-      "LINE_1": "Use the information in the app, but also make your own judgments. View the observations in context of the observer's competence that appears as stars by the name."
+      "LINE_1": "Use the information in Varsom, but also make your own judgments. View the observations in context of the observer's competence that appears as stars by the name."
     },
     "I_UNDERSTAND": "Ok, I understand",
     "PAGE_1": {
@@ -846,7 +846,7 @@
     "ICE_LEGEND_TEXT_6": "Pipeline",
     "ICE_LEGEND_TEXT_7": "Power plant tunnel",
     "ICE_MAP_DESCRIPTION": "The support map shows parts of watercourses that behave unpredictably throughout the winter due to regulations for power generation",
-    "INFO_PAGE": "<h1>About maps with slope angle and runout zones</h1>\nThe maps are automatically produced and may contain errors. There may be steep terrain, which is not represented in the elevation model and thus not displayed in the maps.\nSome avalanches may have longer runouts than what is displayed as runout zones in the maps.\n\n<h2>What consideration to take?</h2>\nAdjust your risk by choosing where, when and how you travel. Varsom app is a planning tool and its data may differ from the actual situation. Always make your own evaluation.\n \n<h2>When is it safe?</h2>\nAll travel in snow covered avalanche terrain has an element of risk.\n\n<h2>Want to learn more?</h2>\nYou may learn more by taking an avalanche safety course and on Snøskredskolen on Varsom.no.",
+    "INFO_PAGE": "<h1>About maps with slope angle and runout zones</h1>\nThe maps are automatically produced and may contain errors. There may be steep terrain, which is not represented in the elevation model and thus not displayed in the maps.\nSome avalanches may have longer runouts than what is displayed as runout zones in the maps.\n\n<h2>What consideration to take?</h2>\nAdjust your risk by choosing where, when and how you travel. Varsom is a planning tool and its data may differ from the actual situation. Always make your own evaluation.\n \n<h2>When is it safe?</h2>\nAll travel in snow covered avalanche terrain has an element of risk.\n\n<h2>Want to learn more?</h2>\nYou may learn more by taking an avalanche safety course and on Snøskredskolen on Varsom.no.",
     "LOW": "Low",
     "MARITINE_BORDER": "Sea border",
     "MIDDLE": "Intermediate",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -101,14 +101,13 @@
     "TITLE": "Hjelp"
   },
   "LEGAL_TERMS": {
-    "HEADER": "Om data i Varsom Regobs",
+    "HEADER": "Om data i Varsom-appen",
     "LINE_1": "Bruk varslene, observasjonene og kartene på eget ansvar. Det kan forekomme feil og mangler.",
     "LINE_2": "Husk at varselet er et hjelpemiddel, ikke en fasit. Gjør alltid egne vurderinger. Lokale forhold der du er, kan være mer komplekse og avvike fra det som er varslet.",
-    "LINE_3": "Data i Varsom Regobs produseres av brukerne av Regobs og foreligger «som de er». Data kan inneholde feil og mangler. NVE har ikke ansvar for feil, mangler og vurderinger som produseres av brukerne.",
-    "LINE_4": "Når du publiserer bilder på observasjoner i Regobs aksepterer du at bildene kan gjenbrukes (lisensiert under <a href='https://data.norge.no/nlod/no/'> Norsk lisens for offentlige data</a>).",
+    "LINE_3": "Data i Varsom-appen produseres av brukerne og foreligger «som de er». Data kan inneholde feil og mangler. NVE har ikke ansvar for feil, mangler og vurderinger som produseres av brukerne.",
+    "LINE_4": "Når du publiserer bilder på observasjoner aksepterer du at bildene kan gjenbrukes (lisensiert under <a href='https://data.norge.no/nlod/no/'> Norsk lisens for offentlige data</a>).",
     "LINE_5": "Les mer i våre <a href=\"{{legalUrl}}\" target=\"_blank\">brukervilkår</a>.",
-    "OK": "Ok, jeg aksepterer",
-    "TERMS": "Data i Varsom Regobs produseres av brukerne av Regobs og foreligger \"som de er\". Data kan inneholde feil og mangler. NVE gir ingen garantier for informasjonens aktualitet og tar ikke ansvar for at data kan gi feil eller villedende informasjon. Antall stjerner (1-5) beskriver kompetansenivået til den som leverer observasjoner. Uten stjerner er kompetansen ukjent eller lav."
+    "OK": "Ok, jeg aksepterer"
   },
   "LOGIN": {
     "CHANGE_PASSWORD": "Endre passord",
@@ -145,7 +144,7 @@
     "SEARCH_TEXT": "Søk etter sted"
   },
   "MENU": {
-    "ABOUT_REGOBS": "Om data i Regobs",
+    "ABOUT_REGOBS": "Om data i Varsom-appen",
     "AND": "og",
     "CONTACT_REGOBS": "Kontakt oss",
     "CONTACT_REGOBS_ERROR": "Rapporter feil",
@@ -196,7 +195,7 @@
     "MAX_COUNT_REACHED_TEXT": "Vi viser maks {{ maxCount }} observasjoner her. Du kan se flere på <a target=\"_blank\" href=\"{{ myObservationsUrl }}/\">din side på web</a>",
     "MY_SENT_OBSERVATIONS": "Mine innsendte observasjoner",
     "NO_OBSERVATIONS": "Del dine observasjoner!",
-    "NO_OBSERVATIONS_TEXT": "Her vil observasjoner du selv har gjort ligge. Med Varsom Regobs er det lett å dele observasjoner, bilder og vurderinger med andre.",
+    "NO_OBSERVATIONS_TEXT": "Her vil observasjoner du selv har gjort ligge. Med Varsom-appen er det lett å dele observasjoner, bilder og vurderinger med andre.",
     "SENT_SUBTITLE": "Disse observasjonene er sendt inn og lagret i Regobs.",
     "TITLE": "Mine observasjoner"
   },
@@ -213,7 +212,7 @@
     "NICKNAME_TEXT": "Kallenavn er et navn som er synlig for alle og vises sammen med observasjoner du gjør",
     "NO_GROUPS": "Du er ikke medlem av noen grupper",
     "PHOTOGRAPHER": "Fotograf",
-    "PUBLISH_PHOTOS": "Når du publiserer bilder i Regobs aksepterer du at de er lisensiert under NLOD og kan gjenbrukes. <a href=\"https://data.norge.no/nlod/no/\">Les mer om data</a>",
+    "PUBLISH_PHOTOS": "Når du publiserer bilder i Varsom-appen aksepterer du at de er lisensiert under NLOD og kan gjenbrukes. <a href=\"https://data.norge.no/nlod/no/\">Les mer om data</a>",
     "SAVE": "Lagre",
     "TITLE": "Min side",
     "USER": "Bruker"
@@ -267,7 +266,7 @@
   "POPUP_DISCLAMER": {
     "ABOUT_OBSERVATIONS": {
       "HEADER": "Om observasjoner",
-      "MESSAGE": "Bruk observasjonene på eget ansvar, de produseres av brukerne av Regobs og foreligger «som den er». NVE har ikke ansvar for feil, mangler og vurderinger som produseres av brukerne.\nSe observasjonene i lys av observatørens kompetanse som vises som stjerner ved navnet."
+      "MESSAGE": "Bruk observasjonene på eget ansvar, de produseres av brukerne og foreligger «som de er». NVE har ikke ansvar for feil, mangler og vurderinger som produseres av brukerne.\nSe observasjonene i lys av observatørens kompetanse som vises som stjerner ved navnet."
     },
     "ABOUT_OFFLINE_SUPPORT_MAPS": {
       "HEADER": "Offline-kart",
@@ -613,7 +612,6 @@
           "WATER_EQUIVALENT": "Vannekvivalent",
           "WEIGHT": "Vekt (g)"
         },
-        "SNOW_PROFILE_HELP_TEXT": "Vi har dessverre ikke støtte for å registrere et snøprofil i Varsom Regobs appen. Men, du kan ta et bilde av et håndtegnet profil eller eksportere et profil fra en tredjeparts app som Ullr Labs Avalanche. På regobs.no kan du senere oppdatere observasjonen med å bruke egne skjema og plot for snøprofiler.",
         "SNOW_TEMP": {
           "ADD_LAYER_BOTTOM": "Legg til nytt punkt",
           "DEPTH": "Dybde (cm)",
@@ -736,11 +734,11 @@
   },
   "SETTINGS": {
     "ALLOW_ANALYTICS": "Tillat sending av bruksdata",
-    "ALLOW_ANALYTICS_DESCRIPTION": "Hjelp oss å forbedre Varsom Regobs ved å la oss se hvordan du bruker applikasjonen.",
+    "ALLOW_ANALYTICS_DESCRIPTION": "Hjelp oss å forbedre Varsom-appen ved å la oss se hvordan du bruker applikasjonen.",
     "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Denne dataen er anonym og kan ikke knyttes til deg personlig.",
     "ALLOW_ANALYTICS_HEADER": "Del bruksstatistikk",
     "APPMODE": "Appmodus",
-    "APP_VERSION": "App versjon",
+    "APP_VERSION": "Versjon",
     "CONFIRM_RESET": "Er du sikker på du vil tilbakestille app?",
     "COUNTRY": "Land",
     "DROPDOWNS_FAILED": "Klarte ikke oppdatere nedtrekksmenyer. Vennligst sjekk om du har nettverk og prøv igjen litt senere.",
@@ -764,7 +762,7 @@
   },
   "SET_NICK_ALERT": {
     "ERROR": "Fikk ikke til å lagre kallenavn. Vennligst prøv igjen senere.",
-    "HELP_TEXT": "Du må legge til et kallenavn for å bruke Varsom Regobs. Kallenavnet blir vist i dine observasjoner.",
+    "HELP_TEXT": "Du må legge til et kallenavn for å bruke Varsom-appen. Kallenavnet blir vist i dine observasjoner.",
     "INPUT_TEXT": "Skriv inn kallenavn",
     "NICK": "Kallenavn"
   },
@@ -785,7 +783,7 @@
       "NORWEGIAN_SECONDARY_LANGUAGE": "Norwegian"
     },
     "COMPETENCE_PAGE": {
-      "HEADER": "Bruk Regobs fornuftig!",
+      "HEADER": "Bruk Varsom-appen fornuftig!",
       "LINE_1": "Bruk informasjonen i appen, men gjør også dine egne vurderinger. Se observasjonene i lys av observatørens kompetanse som vises som stjerner ved navnet."
     },
     "I_UNDERSTAND": "Ok, jeg forstår",
@@ -804,7 +802,7 @@
     },
     "PAGE_4": {
       "HEADER": "Hva og hvordan?",
-      "LINE_1": "Du velger selv hva du vil se og dele på Varsom Regobs. Du kan lese om hvordan du deler observasjoner med andre på varsom.no/snøskredskolen og varsom.no/isskolen"
+      "LINE_1": "Du velger selv hva du vil se og dele på Varsom-appen. Du kan lese om hvordan du deler observasjoner med andre på varsom.no/snøskredskolen og varsom.no/isskolen"
     },
     "SKIP_START": "Hopp over"
   },
@@ -848,7 +846,7 @@
     "ICE_LEGEND_TEXT_6": "Rørgate",
     "ICE_LEGEND_TEXT_7": "Kraftverkstunnel",
     "ICE_MAP_DESCRIPTION": "Støttekartet viser deler av vassdrag som oppfører seg uforutsigbart gjennom vinteren grunnet reguleringer for kraftproduksjon",
-    "INFO_PAGE": "<h1>Om kart med bratthet og utløp</h1>\nKartene er automatisk generert og kan inneholde feil. Det kan eksistere bratte heng som høydemodellen ikke plukker opp og derfor ikke vises på kartet.\nNoen skred kan gå lenger enn det som er markert som utløpsområde i kartet.\n\n<h2>Hvilke hensyn må tas?</h2>\nTilpass egen risiko ved å velge hvor, når og hvordan du ferdes. Varsom Regobs er et hjelpemiddel, ikke en fasit. Gjør alltid egne vurderinger.\n\n<h2>Når er det trygt?</h2>\nAll ferdsel i snødekt skredterreng er forbundet med risiko. \n\n<h2>Lære mer?</h2>\nDu kan lære mer på skredkurs og Snøskredskolen på Varsom.no.",
+    "INFO_PAGE": "<h1>Om kart med bratthet og utløp</h1>\nKartene er automatisk generert og kan inneholde feil. Det kan eksistere bratte heng som høydemodellen ikke plukker opp og derfor ikke vises på kartet.\nNoen skred kan gå lenger enn det som er markert som utløpsområde i kartet.\n\n<h2>Hvilke hensyn må tas?</h2>\nTilpass egen risiko ved å velge hvor, når og hvordan du ferdes. Varsom er et hjelpemiddel, ikke en fasit. Gjør alltid egne vurderinger.\n\n<h2>Når er det trygt?</h2>\nAll ferdsel i snødekt skredterreng er forbundet med risiko. \n\n<h2>Lære mer?</h2>\nDu kan lære mer på skredkurs og Snøskredskolen på Varsom.no.",
     "LOW": "Lav",
     "MARITINE_BORDER": "Marin grense flate",
     "MIDDLE": "Middels",
@@ -876,7 +874,7 @@
     "END_ERROR": "Klarte ikke stoppe tur. Vennligst prøv igjen senere. Turen vil automatisk ble stoppet ved midnatt.",
     "ERROR": "Klarte ikke starte tur. Vennligs prøv igjen.",
     "ERROR_POSITION": "Kan ikke starte tur uten GPS posisjon.",
-    "LEGACY_HELP_TEXT": "Her melder du fra om at du planlegger tur i dag.\n\nDet er nyttig for skredvarslingen å vite om det kan ventes observasjoner i dag. Det er også nyttig å vite hva slags observasjoner som kan ventes (hva ser du etter, hvor skal du på tur) og når regner du med at disse sendes inn på Regobs.\n\nAlle betalte observatører skal registrere hva slags obstur som planlegges: er det en ordinær betalt observasjonstur, eller er det en tilleggsregistrering? Tilleggsregistrering er innsending av observasjoner du har gjort i annet arbeid eller på fritiden din.",
+    "LEGACY_HELP_TEXT": "Her melder du fra om at du planlegger tur i dag.\n\nDet er nyttig for skredvarslingen å vite om det kan ventes observasjoner i dag. Det er også nyttig å vite hva slags observasjoner som kan ventes (hva ser du etter, hvor skal du på tur) og når regner du med at disse sendes inn.\n\nAlle betalte observatører skal registrere hva slags obstur som planlegges: er det en ordinær betalt observasjonstur, eller er det en tilleggsregistrering? Tilleggsregistrering er innsending av observasjoner du har gjort i annet arbeid eller på fritiden din.",
     "ONGOING_TRIP": "Tur pågår",
     "STARTED": "Tur startet",
     "START_TRIP": "Start tur",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -101,10 +101,10 @@
     "TITLE": "Hjelp"
   },
   "LEGAL_TERMS": {
-    "HEADER": "Om data i Varsom-appen",
+    "HEADER": "Om data i Varsom",
     "LINE_1": "Bruk varslene, observasjonene og kartene på eget ansvar. Det kan forekomme feil og mangler.",
     "LINE_2": "Husk at varselet er et hjelpemiddel, ikke en fasit. Gjør alltid egne vurderinger. Lokale forhold der du er, kan være mer komplekse og avvike fra det som er varslet.",
-    "LINE_3": "Data i Varsom-appen produseres av brukerne og foreligger «som de er». Data kan inneholde feil og mangler. NVE har ikke ansvar for feil, mangler og vurderinger som produseres av brukerne.",
+    "LINE_3": "Observasjoner produseres av brukerne og foreligger «som de er». Data kan inneholde feil og mangler. NVE har ikke ansvar for feil, mangler og vurderinger som produseres av brukerne.",
     "LINE_4": "Når du publiserer bilder på observasjoner aksepterer du at bildene kan gjenbrukes (lisensiert under <a href='https://data.norge.no/nlod/no/'> Norsk lisens for offentlige data</a>).",
     "LINE_5": "Les mer i våre <a href=\"{{legalUrl}}\" target=\"_blank\">brukervilkår</a>.",
     "OK": "Ok, jeg aksepterer"
@@ -144,7 +144,7 @@
     "SEARCH_TEXT": "Søk etter sted"
   },
   "MENU": {
-    "ABOUT_REGOBS": "Om data i Varsom-appen",
+    "ABOUT_REGOBS": "Om data i Varsom",
     "AND": "og",
     "CONTACT_REGOBS": "Kontakt oss",
     "CONTACT_REGOBS_ERROR": "Rapporter feil",
@@ -195,7 +195,7 @@
     "MAX_COUNT_REACHED_TEXT": "Vi viser maks {{ maxCount }} observasjoner her. Du kan se flere på <a target=\"_blank\" href=\"{{ myObservationsUrl }}/\">din side på web</a>",
     "MY_SENT_OBSERVATIONS": "Mine innsendte observasjoner",
     "NO_OBSERVATIONS": "Del dine observasjoner!",
-    "NO_OBSERVATIONS_TEXT": "Her vil observasjoner du selv har gjort ligge. Med Varsom-appen er det lett å dele observasjoner, bilder og vurderinger med andre.",
+    "NO_OBSERVATIONS_TEXT": "Her vil observasjoner du selv har gjort ligge. Det er lett å dele observasjoner, bilder og vurderinger med andre.",
     "SENT_SUBTITLE": "Disse observasjonene er sendt inn og lagret i Regobs.",
     "TITLE": "Mine observasjoner"
   },
@@ -212,7 +212,7 @@
     "NICKNAME_TEXT": "Kallenavn er et navn som er synlig for alle og vises sammen med observasjoner du gjør",
     "NO_GROUPS": "Du er ikke medlem av noen grupper",
     "PHOTOGRAPHER": "Fotograf",
-    "PUBLISH_PHOTOS": "Når du publiserer bilder i Varsom-appen aksepterer du at de er lisensiert under NLOD og kan gjenbrukes. <a href=\"https://data.norge.no/nlod/no/\">Les mer om data</a>",
+    "PUBLISH_PHOTOS": "Når du publiserer bilder på observasjoner aksepterer du at de er lisensiert under NLOD og kan gjenbrukes. <a href=\"https://data.norge.no/nlod/no/\">Les mer om data</a>",
     "SAVE": "Lagre",
     "TITLE": "Min side",
     "USER": "Bruker"
@@ -734,7 +734,7 @@
   },
   "SETTINGS": {
     "ALLOW_ANALYTICS": "Tillat sending av bruksdata",
-    "ALLOW_ANALYTICS_DESCRIPTION": "Hjelp oss å forbedre Varsom-appen ved å la oss se hvordan du bruker applikasjonen.",
+    "ALLOW_ANALYTICS_DESCRIPTION": "Hjelp oss å forbedre Varsom ved å la oss se hvordan du bruker applikasjonen.",
     "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Disse dataene er anonymisert og kan ikke knyttes til deg personlig.",
     "ALLOW_ANALYTICS_HEADER": "Del bruksstatistikk",
     "APPMODE": "Appmodus",
@@ -762,7 +762,7 @@
   },
   "SET_NICK_ALERT": {
     "ERROR": "Fikk ikke til å lagre kallenavn. Vennligst prøv igjen senere.",
-    "HELP_TEXT": "Du må legge til et kallenavn for å bruke Varsom-appen. Kallenavnet blir vist i dine observasjoner.",
+    "HELP_TEXT": "Du må legge til et kallenavn. Kallenavnet blir vist i dine observasjoner.",
     "INPUT_TEXT": "Skriv inn kallenavn",
     "NICK": "Kallenavn"
   },
@@ -783,8 +783,8 @@
       "NORWEGIAN_SECONDARY_LANGUAGE": "Norwegian"
     },
     "COMPETENCE_PAGE": {
-      "HEADER": "Bruk Varsom-appen fornuftig!",
-      "LINE_1": "Bruk informasjonen i appen, men gjør også dine egne vurderinger. Se observasjonene i lys av observatørens kompetanse som vises som stjerner ved navnet."
+      "HEADER": "Bruk Varsom fornuftig!",
+      "LINE_1": "Bruk informasjonen i Varsom, men gjør også dine egne vurderinger. Se observasjonene i lys av observatørens kompetanse som vises som stjerner ved navnet."
     },
     "I_UNDERSTAND": "Ok, jeg forstår",
     "PAGE_1": {
@@ -802,7 +802,7 @@
     },
     "PAGE_4": {
       "HEADER": "Hva og hvordan?",
-      "LINE_1": "Du velger selv hva du vil se og dele på Varsom-appen. Du kan lese om hvordan du deler observasjoner med andre på varsom.no/snøskredskolen og varsom.no/isskolen"
+      "LINE_1": "Du velger selv hva du vil se og dele på Varsom. Du kan lese om hvordan du deler observasjoner med andre på varsom.no/snøskredskolen og varsom.no/isskolen"
     },
     "SKIP_START": "Hopp over"
   },

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -735,7 +735,7 @@
   "SETTINGS": {
     "ALLOW_ANALYTICS": "Tillat sending av bruksdata",
     "ALLOW_ANALYTICS_DESCRIPTION": "Hjelp oss å forbedre Varsom-appen ved å la oss se hvordan du bruker applikasjonen.",
-    "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Denne dataen er anonym og kan ikke knyttes til deg personlig.",
+    "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Disse dataene er anonymisert og kan ikke knyttes til deg personlig.",
     "ALLOW_ANALYTICS_HEADER": "Del bruksstatistikk",
     "APPMODE": "Appmodus",
     "APP_VERSION": "Versjon",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -664,7 +664,7 @@
   "SETTINGS": {
     "ALLOW_ANALYTICS": "Tillat sending av bruksdata",
     "ALLOW_ANALYTICS_DESCRIPTION": "Hjelp oss å gjere Varsom RegObs betre med å la oss sjå korleis du bruker applikasjonen. ",
-    "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Denne dataen er anonym og kan ikkje knyttast til deg personleg.",
+    "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Disse dataene er anonymisert og kan ikkje knyttast til deg personleg.",
     "ALLOW_ANALYTICS_HEADER": "Del bruksstatistikk",
     "APPMODE": "App-modus",
     "APP_VERSION": "Versjon",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -89,12 +89,13 @@
     "TITLE": "Hjelp"
   },
   "LEGAL_TERMS": {
-    "HEADER": "Om data i Varsom Regobs",
+    "HEADER": "Om data i Varsom-appen",
     "LINE_1": "Bruk varsel, observajonar og kart på eige ansvar. Feil og manglar kan førekomme.  ",
     "LINE_2": "Hugs at varselet er eit hjelpemiddel, ikkje ein fasit. Gjer alltid eigne vurderingar. Dei lokale tilhøva der du er kan vere meir komplekse og avvike frå det som er varsla. ",
-    "LINE_3": "Data på Varsom Regobs produserast av brukerane. Den er ikkje kvalitetsikra og kan innehalde feil og manglar. NVE tek ikkje ansvar for kvaliteten og gyldigheita av observasjonar frå brukarane. ",
-    "OK": "Greit, eg aksepterar",
-    "TERMS": "Data på Varsom Regobs produserast av brukerane. Den er ikkje kvalitetsikra og kan innehalde feil og manglar. Tal på stjerner til den som har observert kan brukast som ein indikator på kompetansenivået. NVE tek ikkje ansvar for kvaliteten og gyldigheita til observasjonar. "
+    "LINE_3": "Data i Varsom-appen produserast av brukerane. Dei er ikkje kvalitetsikra og kan innehalde feil og manglar. NVE tek ikkje ansvar for kvaliteten og gyldigheita av observasjonar frå brukarane. ",
+    "LINE_4": "Når du publiserer bilder på observasjonar aksepterer du at bildene kan gjenbrukes (lisensiert under <a href='https://data.norge.no/nlod/no/'> Norsk lisens for offentlige data</a>).",
+    "LINE_5": "Les meir i våre <a href=\"{{legalUrl}}\" target=\"_blank\">brukarvilkår</a>.",
+    "OK": "Greit, eg aksepterar"
   },
   "LOGIN": {
     "CHANGE_PASSWORD": "Endre passord",
@@ -129,7 +130,7 @@
     "SEARCH_TEXT": "Søk etter stad"
   },
   "MENU": {
-    "ABOUT_REGOBS": "Om data i Regobs",
+    "ABOUT_REGOBS": "Om data i Varsom-appen",
     "AND": "og",
     "CONTACT_REGOBS": "Kontakt oss",
     "CONTACT_REGOBS_ERROR": "Rapporter feil",
@@ -177,7 +178,7 @@
     "MAX_COUNT_REACHED_TEXT": "Vi viser maks {{ maxCount }} observasjonar her. Du kan sjå fleire på <a target=\"_blank\" href=\"{{ myObservationsUrl }}/\">di side på web</a>",
     "MY_SENT_OBSERVATIONS": "Mine innsendte observasjonar",
     "NO_OBSERVATIONS": "Del dine observasjonar!",
-    "NO_OBSERVATIONS_TEXT": "Her ligg observasjonar du sjølv har gjort. Med Varsom Regobs er det lett å dele observasjonar, bilete og vurderingar med andre. ",
+    "NO_OBSERVATIONS_TEXT": "Her ligg observasjonar du sjølv har gjort. Med Varsom-appen er det lett å dele observasjonar, bilete og vurderingar med andre. ",
     "SENT_SUBTITLE": "Desse observasjonane er sendt inn og lagra i Regobs. ",
     "TITLE": "Mine observasjonar"
   },
@@ -194,7 +195,7 @@
     "NICKNAME_TEXT": "Kallenavn er eit navn som er synlig for alle og vises sammen med observasjonar du gjør",
     "NO_GROUPS": "Du er ikkje medlem av noen grupper",
     "PHOTOGRAPHER": "Fotograf",
-    "PUBLISH_PHOTOS": "Når du publiserer bilder i Regobs aksepterer du at de er lisensiert under NLOD og kan gjenbrukast. <a href=\"https://data.norge.no/nlod/no/\">Les meir om data</a>",
+    "PUBLISH_PHOTOS": "Når du publiserer bilder i Varsom-appen aksepterer du at de er lisensiert under NLOD og kan gjenbrukast. <a href=\"https://data.norge.no/nlod/no/\">Les meir om data</a>",
     "SAVE": "Lagre",
     "TITLE": "Min side",
     "USER": "Brukar"
@@ -245,7 +246,7 @@
   "POPUP_DISCLAMER": {
     "ABOUT_OBSERVATIONS": {
       "HEADER": "Om observasjonar",
-      "MESSAGE": "Observasjonar brukast på eige ansvar. Dei er registrerast av Regobs sine brukarar og er ikkje kvalitetsjekka. NVE tek ikkje ansvar for feil, manglar og vurderingar som registererast av brukarane. \nKompetansenivået, som visast som stjerner bak navnet, KAN vere ein indikator på truverdigheit. "
+      "MESSAGE": "Observasjonar brukast på eige ansvar. Dei er registrert av brukarane og er ikkje kvalitetsjekka. NVE tek ikkje ansvar for feil, manglar og vurderingar som registererast av brukarane. \nKompetansenivået, som visast som stjerner bak navnet, KAN vere ein indikator på truverdigheit. "
     },
     "ABOUT_OFFLINE_SUPPORT_MAPS": {
       "HEADER": "Offline-kart",
@@ -541,7 +542,6 @@
           "WATER_EQUIVALENT": "Vassekvivalent",
           "WEIGHT": "Vekt (g)"
         },
-        "SNOW_PROFILE_HELP_TEXT": "Det er dessverre ikkje mogleg å registrere snøprofil i Varsom Regobs appen. Du kan likevel ta og legge inn bilete av ein handteiknaprofil eller profil frå tredjeparts appar som t.d. Ullr Labs Avalanche. På webversjonen, regobs.no, kan du seinare lage digitale snøprofil og oppdatere observasjonen.",
         "SNOW_TEMP": {
           "ADD_LAYER_BOTTOM": "Legg til nytt punkt",
           "DEPTH": "Djupn (cm)",
@@ -667,7 +667,7 @@
     "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Denne dataen er anonym og kan ikkje knyttast til deg personleg.",
     "ALLOW_ANALYTICS_HEADER": "Del bruksstatistikk",
     "APPMODE": "App-modus",
-    "APP_VERSION": "App-versjon",
+    "APP_VERSION": "Versjon",
     "CONFIRM_RESET": "Er du sikker på at du vil resetje app?",
     "COUNTRY": "Land",
     "DROPDOWNS_FAILED": "Klarte ikkje å oppdatere nedtrekksmenyar. Vennlegast sjekk om du har nettverk og prøv igjen litt seinare.",
@@ -691,7 +691,7 @@
   },
   "SET_NICK_ALERT": {
     "ERROR": "Klarte ikkje lagre kallenavn. Ver venleg og prøv igjen seinare.",
-    "HELP_TEXT": "Du må legge til eit kallenamn for å bruke Varsom Regobs. Kallenamnet vert vist i dine observasjonar.",
+    "HELP_TEXT": "Du må legge til eit kallenamn for å bruke Varsom-appen. Kallenamnet vert vist i dine observasjonar.",
     "INPUT_TEXT": "Skriv inn kallenamn",
     "NICK": "Kallenamn"
   },
@@ -712,7 +712,7 @@
       "NORWEGIAN_SECONDARY_LANGUAGE": "Norsk"
     },
     "COMPETENCE_PAGE": {
-      "HEADER": "Bruk Regobs fornuftig!",
+      "HEADER": "Bruk Varsom-appen fornuftig!",
       "LINE_1": "Bruk informasjonen i appen, men gjer også dine eigne vurderingar. Sjå observasjonar i lys av observatøren sin kompetanse (visast som stjerner med namnet)."
     },
     "I_UNDERSTAND": "Ok, eg skjønnar",
@@ -731,7 +731,7 @@
     },
     "PAGE_4": {
       "HEADER": "Kva og korleis?",
-      "LINE_1": "Du vel sjølv kva du vil sjå å dele på Varsom Regobs. De kan lese om korleis du delar observasjonar med andre på varsom.no/skredskolen og varsom.no/isskolen."
+      "LINE_1": "Du vel sjølv kva du vil sjå å dele i Varsom-appen. De kan lese om korleis du delar observasjonar med andre på varsom.no/skredskolen og varsom.no/isskolen."
     },
     "SKIP_START": "Hopp over"
   },
@@ -773,7 +773,7 @@
     "ICE_LEGEND_TEXT_6": "Røyrgate",
     "ICE_LEGEND_TEXT_7": "Kraftverkstunnel",
     "ICE_MAP_DESCRIPTION": "Støttekartet viser delar av vassdrag som oppfører seg uforutsigbart gjennom vinteren grunna reguleringar for kraftproduksjon",
-    "INFO_PAGE": "<h1>Om kart med helling og utløp</h1>\nKarta er automatisk generert og kan innehalde feil. Det kan eksistere bratte heng som høgdemodellen ikkje får med seg og derfor ikke visast på kartet.\nNokre skred kan gå lenger enn det som er markert som utløpsområde i kartet.\n\n<h2>Kva omsyn må takast?</h2>\nTilpass eigen risiko med å velje, når og korleis du ferdast. Varsom Regobs er eit hjelpemiddel, ikkje ein fasit. Gjer alltid eigne vurderingar. \n\n<h2>Når er det trygt?</h2>\nDet er ein viss risiko med all ferdsel i snødekt skredterreng.\n\n<h2>Lære meir?</h2>\nDu kan lære meir på skredkurs og Snøskredskulen på Varsom.no.",
+    "INFO_PAGE": "<h1>Om kart med helling og utløp</h1>\nKarta er automatisk generert og kan innehalde feil. Det kan eksistere bratte heng som høgdemodellen ikkje får med seg og derfor ikke visast på kartet.\nNokre skred kan gå lenger enn det som er markert som utløpsområde i kartet.\n\n<h2>Kva omsyn må takast?</h2>\nTilpass eigen risiko med å velje, når og korleis du ferdast. Varsom er eit hjelpemiddel, ikkje ein fasit. Gjer alltid eigne vurderingar. \n\n<h2>Når er det trygt?</h2>\nDet er ein viss risiko med all ferdsel i snødekt skredterreng.\n\n<h2>Lære meir?</h2>\nDu kan lære meir på skredkurs og Snøskredskulen på Varsom.no.",
     "LOW": "Låg",
     "MARITINE_BORDER": "Marin grense flate",
     "MIDDLE": "Middels",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -89,10 +89,10 @@
     "TITLE": "Hjelp"
   },
   "LEGAL_TERMS": {
-    "HEADER": "Om data i Varsom-appen",
+    "HEADER": "Om data i Varsom",
     "LINE_1": "Bruk varsel, observajonar og kart på eige ansvar. Feil og manglar kan førekomme.  ",
     "LINE_2": "Hugs at varselet er eit hjelpemiddel, ikkje ein fasit. Gjer alltid eigne vurderingar. Dei lokale tilhøva der du er kan vere meir komplekse og avvike frå det som er varsla. ",
-    "LINE_3": "Data i Varsom-appen produserast av brukerane. Dei er ikkje kvalitetsikra og kan innehalde feil og manglar. NVE tek ikkje ansvar for kvaliteten og gyldigheita av observasjonar frå brukarane. ",
+    "LINE_3": "Observasjonar produserast av brukerane. Dei er ikkje kvalitetsikra og kan innehalde feil og manglar. NVE tek ikkje ansvar for kvaliteten og gyldigheita av observasjonar frå brukarane. ",
     "LINE_4": "Når du publiserer bilder på observasjonar aksepterer du at bildene kan gjenbrukes (lisensiert under <a href='https://data.norge.no/nlod/no/'> Norsk lisens for offentlige data</a>).",
     "LINE_5": "Les meir i våre <a href=\"{{legalUrl}}\" target=\"_blank\">brukarvilkår</a>.",
     "OK": "Greit, eg aksepterar"
@@ -130,7 +130,7 @@
     "SEARCH_TEXT": "Søk etter stad"
   },
   "MENU": {
-    "ABOUT_REGOBS": "Om data i Varsom-appen",
+    "ABOUT_REGOBS": "Om data i Varsom",
     "AND": "og",
     "CONTACT_REGOBS": "Kontakt oss",
     "CONTACT_REGOBS_ERROR": "Rapporter feil",
@@ -178,7 +178,7 @@
     "MAX_COUNT_REACHED_TEXT": "Vi viser maks {{ maxCount }} observasjonar her. Du kan sjå fleire på <a target=\"_blank\" href=\"{{ myObservationsUrl }}/\">di side på web</a>",
     "MY_SENT_OBSERVATIONS": "Mine innsendte observasjonar",
     "NO_OBSERVATIONS": "Del dine observasjonar!",
-    "NO_OBSERVATIONS_TEXT": "Her ligg observasjonar du sjølv har gjort. Med Varsom-appen er det lett å dele observasjonar, bilete og vurderingar med andre. ",
+    "NO_OBSERVATIONS_TEXT": "Her ligg observasjonar du sjølv har gjort. Det er lett å dele observasjonar, bilete og vurderingar med andre. ",
     "SENT_SUBTITLE": "Desse observasjonane er sendt inn og lagra i Regobs. ",
     "TITLE": "Mine observasjonar"
   },
@@ -195,7 +195,7 @@
     "NICKNAME_TEXT": "Kallenavn er eit navn som er synlig for alle og vises sammen med observasjonar du gjør",
     "NO_GROUPS": "Du er ikkje medlem av noen grupper",
     "PHOTOGRAPHER": "Fotograf",
-    "PUBLISH_PHOTOS": "Når du publiserer bilder i Varsom-appen aksepterer du at de er lisensiert under NLOD og kan gjenbrukast. <a href=\"https://data.norge.no/nlod/no/\">Les meir om data</a>",
+    "PUBLISH_PHOTOS": "Når du publiserer bilder på observasjonar aksepterer du at de er lisensiert under NLOD og kan gjenbrukast. <a href=\"https://data.norge.no/nlod/no/\">Les meir om data</a>",
     "SAVE": "Lagre",
     "TITLE": "Min side",
     "USER": "Brukar"
@@ -691,7 +691,7 @@
   },
   "SET_NICK_ALERT": {
     "ERROR": "Klarte ikkje lagre kallenavn. Ver venleg og prøv igjen seinare.",
-    "HELP_TEXT": "Du må legge til eit kallenamn for å bruke Varsom-appen. Kallenamnet vert vist i dine observasjonar.",
+    "HELP_TEXT": "Du må legge til eit kallenamn. Kallenamnet vert vist i dine observasjonar.",
     "INPUT_TEXT": "Skriv inn kallenamn",
     "NICK": "Kallenamn"
   },
@@ -712,8 +712,8 @@
       "NORWEGIAN_SECONDARY_LANGUAGE": "Norsk"
     },
     "COMPETENCE_PAGE": {
-      "HEADER": "Bruk Varsom-appen fornuftig!",
-      "LINE_1": "Bruk informasjonen i appen, men gjer også dine eigne vurderingar. Sjå observasjonar i lys av observatøren sin kompetanse (visast som stjerner med namnet)."
+      "HEADER": "Bruk Varsom fornuftig!",
+      "LINE_1": "Bruk informasjonen i Varsom, men gjer også dine eigne vurderingar. Sjå observasjonar i lys av observatøren sin kompetanse (visast som stjerner med namnet)."
     },
     "I_UNDERSTAND": "Ok, eg skjønnar",
     "PAGE_1": {
@@ -731,7 +731,7 @@
     },
     "PAGE_4": {
       "HEADER": "Kva og korleis?",
-      "LINE_1": "Du vel sjølv kva du vil sjå å dele i Varsom-appen. De kan lese om korleis du delar observasjonar med andre på varsom.no/skredskolen og varsom.no/isskolen."
+      "LINE_1": "Du vel sjølv kva du vil sjå å dele i Varsom. De kan lese om korleis du delar observasjonar med andre på varsom.no/skredskolen og varsom.no/isskolen."
     },
     "SKIP_START": "Hopp over"
   },

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -89,11 +89,11 @@
     "TITLE": "Hjälp"
   },
   "LEGAL_TERMS": {
-    "HEADER": "Om data i Varsom-appen",
+    "HEADER": "Om data i Varsom",
     "LINE_1": "Använd varningar, observationer och kartor på egen risk. Det kan finnas fel och information kan saknas.",
     "LINE_2": "En prognos är ett planeringsverktyg och kan skilja sig från den faktiska situationen. Gör alltid din egen utvärdering. Förhållandena kan vara komplexa och skiljer sig från prognosen.",
-    "LINE_3": "Data i Varsom-appen har producerats av användarna och är tillgängliga «som de är». Datan kan innehålla fel och utelämnanden. NVE lämnar inga garanterar för fel och utelämnanden i uppgifterna.",
-    "LINE_4": "När du publicerar bilder på observationer i Varsom-appen accepterar du att bilderna kan återanvändas (licensierat under <a href='https://data.norge.no/nlod/no/'>Norsk lisens for offentlige data</a>).",
+    "LINE_3": "Observationer har producerats av användarna och är tillgängliga «som de är». Datan kan innehålla fel och utelämnanden. NVE lämnar inga garanterar för fel och utelämnanden i uppgifterna.",
+    "LINE_4": "När du publicerar bilder på observationer accepterar du att bilderna kan återanvändas (licensierat under <a href='https://data.norge.no/nlod/no/'>Norsk lisens for offentlige data</a>).",
     "LINE_5": "Läs mer i våra <a href=\"{{legalUrl}}\" target=\"_blank\">användarvillkor</a>.",
     "OK": "Okej, jag accepterar"
   },
@@ -131,7 +131,7 @@
     "SEARCH_TEXT": "Sök efter plats"
   },
   "MENU": {
-    "ABOUT_REGOBS": "Om data i Varsom-appen",
+    "ABOUT_REGOBS": "Om data i Varsom",
     "AND": "och",
     "CONTACT_REGOBS": "Kontakta oss",
     "CONTACT_REGOBS_ERROR": "Rapportera fel",
@@ -621,7 +621,7 @@
   },
   "SETTINGS": {
     "ALLOW_ANALYTICS": "Tillåt att skicka användningsdata",
-    "ALLOW_ANALYTICS_DESCRIPTION": "Hjälp oss att förbättra Varsom-appen genom att låta oss veta hur du använder applikationen.",
+    "ALLOW_ANALYTICS_DESCRIPTION": "Hjälp oss att förbättra Varsom genom att låta oss veta hur du använder applikationen.",
     "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Denna information är anonym och kan inte kopplas till dig personligen.",
     "ALLOW_ANALYTICS_HEADER": "Dela användningsstatistik",
     "APPMODE": "Appläge",
@@ -663,8 +663,8 @@
       "NORWEGIAN_SECONDARY_LANGUAGE": "Norwegian"
     },
     "COMPETENCE_PAGE": {
-      "HEADER": "Använd Varsom-appen klokt!",
-      "LINE_1": "Använd informationen i appen, men gör också egna bedömningar. Använd observationerna utifrån observatörens kompetens, som visas som stjärnor med namnet."
+      "HEADER": "Använd Varsom klokt!",
+      "LINE_1": "Använd informationen i Varsom, men gör också egna bedömningar. Använd observationerna utifrån observatörens kompetens, som visas som stjärnor med namnet."
     },
     "I_UNDERSTAND": "Okej, jag förstår",
     "PAGE_1": {
@@ -726,7 +726,7 @@
     "ICE_LEGEND_TEXT_6": "Rörledning",
     "ICE_LEGEND_TEXT_7": "Kraftverkstunnel",
     "ICE_MAP_DESCRIPTION": "Stödkarta visar delar av vattendrag som uppför sig oförutsägbart under vintern på grund av reglering vid vattenkraftsproduktion",
-    "INFO_PAGE": "<h1>Om kartor med lutningsgrad och utloppszoner</h1>\nKartorna produceras automatiskt och kan innehålla fel. Det kan finnas brant terräng, som inte representeras i höjdmodellen och därmed inte visas på kartorna.\nVissa laviner kan ha längre utloppzoner än vad som visas som visas på kartorna.\n\n<h2> Vad ska man beakta?</h2>\nVälj vilken risk du vill utsätta dig för genom att välja var, när och hur du åker. Varsom-appen är ett planeringsverktyg och dess data kan skilja sig från den faktiska situationen. Gör alltid din egen utvärdering.\n\n<h2> När är det säkert?</h2>\nAlla vistelse i snötäckt lavinterräng har ett inslag av risk.\n\n<h2> Vill du lära dig mer?</h2>\nDu kan lära dig mer genom att gå en Lavinkurs eller läsa mer på Snøskredskolen på Varsom.no.",
+    "INFO_PAGE": "<h1>Om kartor med lutningsgrad och utloppszoner</h1>\nKartorna produceras automatiskt och kan innehålla fel. Det kan finnas brant terräng, som inte representeras i höjdmodellen och därmed inte visas på kartorna.\nVissa laviner kan ha längre utloppzoner än vad som visas som visas på kartorna.\n\n<h2> Vad ska man beakta?</h2>\nVälj vilken risk du vill utsätta dig för genom att välja var, när och hur du åker. Varsom är ett planeringsverktyg och dess data kan skilja sig från den faktiska situationen. Gör alltid din egen utvärdering.\n\n<h2> När är det säkert?</h2>\nAlla vistelse i snötäckt lavinterräng har ett inslag av risk.\n\n<h2> Vill du lära dig mer?</h2>\nDu kan lära dig mer genom att gå en Lavinkurs eller läsa mer på Snøskredskolen på Varsom.no.",
     "LOW": "Låg",
     "MARITINE_BORDER": "Havsgräns",
     "MIDDLE": "Medel",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -89,14 +89,13 @@
     "TITLE": "Hjälp"
   },
   "LEGAL_TERMS": {
-    "HEADER": "Om data i Varsom Regobs",
+    "HEADER": "Om data i Varsom-appen",
     "LINE_1": "Använd varningar, observationer och kartor på egen risk. Det kan finnas fel och information kan saknas.",
     "LINE_2": "En prognos är ett planeringsverktyg och kan skilja sig från den faktiska situationen. Gör alltid din egen utvärdering. Förhållandena kan vara komplexa och skiljer sig från prognosen.",
-    "LINE_3": "Data på Regobs har producerats av användarna och är tillgängliga «som de är». Datan kan innehålla fel och utelämnanden. NVE lämnar inga garanterar för fel och utelämnanden i uppgifterna.",
-    "LINE_4": "När du publicerar bilder på observationer i Regobs accepterar du att bilderna kan återanvändas (licensierat under <a href='https://data.norge.no/nlod/no/'>Norsk lisens for offentlige data</a>).",
+    "LINE_3": "Data i Varsom-appen har producerats av användarna och är tillgängliga «som de är». Datan kan innehålla fel och utelämnanden. NVE lämnar inga garanterar för fel och utelämnanden i uppgifterna.",
+    "LINE_4": "När du publicerar bilder på observationer i Varsom-appen accepterar du att bilderna kan återanvändas (licensierat under <a href='https://data.norge.no/nlod/no/'>Norsk lisens for offentlige data</a>).",
     "LINE_5": "Läs mer i våra <a href=\"{{legalUrl}}\" target=\"_blank\">användarvillkor</a>.",
-    "OK": "Okej, jag accepterar",
-    "TERMS": "Data på Regobs har producerats av användarna och är tillgängliga \"som de är\". Datan kan innehålla fel och utelämnanden. NVE garanterar inte informationens aktualitet och tar inget ansvar för att data kan ge felaktig eller vilseledande information. Antalet stjärnor (1-5) beskriver kompetensnivån för leverantören av observationer. Utan stjärnor är kompetensen okänd eller låg."
+    "OK": "Okej, jag accepterar"
   },
   "LOGIN": {
     "CHANGE_PASSWORD": "Ändra lösenord",
@@ -132,7 +131,7 @@
     "SEARCH_TEXT": "Sök efter plats"
   },
   "MENU": {
-    "ABOUT_REGOBS": "Om data i Regobs",
+    "ABOUT_REGOBS": "Om data i Varsom-appen",
     "AND": "och",
     "CONTACT_REGOBS": "Kontakta oss",
     "CONTACT_REGOBS_ERROR": "Rapportera fel",
@@ -177,7 +176,7 @@
     "LOADING_MORE": "Laddar fler observationer ...",
     "MY_SENT_OBSERVATIONS": "Mina inskickade observationer",
     "NO_OBSERVATIONS": "Dela dina observationer!",
-    "NO_OBSERVATIONS_TEXT": "Här hittar du observationer du själv har gjort. Dela dina observationer, bilder och bedömningar med andra på Varsom Regobs.",
+    "NO_OBSERVATIONS_TEXT": "Här hittar du observationer du själv har gjort. Dela dina observationer, bilder och bedömningar med andra.",
     "SENT_SUBTITLE": "Dessa observationer lämnas in och lagras i Regobs.",
     "TITLE": "Mina observationer"
   },
@@ -501,7 +500,6 @@
           "WATER_EQUIVALENT": "Vattenekvivalent ",
           "WEIGHT": "Vikt (g)"
         },
-        "SNOW_PROFILE_HELP_TEXT": "Tyvärr stödjer inte den aktuella versionen av Varsom Regobs-appen formulär för snöprofiler. Men du kan ladda upp en bild av en handritad profil eller en export från en tredjepartsapp som Ullr Labs Avalanche. På regobs.no kan du senare uppdatera observationen med de formulär som finns där.",
         "SNOW_TEMP": {
           "ADD_LAYER_BOTTOM": "Lägg till en ny punkt",
           "DEPTH": "Djup (cm)",
@@ -623,11 +621,11 @@
   },
   "SETTINGS": {
     "ALLOW_ANALYTICS": "Tillåt att skicka användningsdata",
-    "ALLOW_ANALYTICS_DESCRIPTION": "Hjälp oss att förbättra Varsom Regobs genom att låta oss veta hur du använder applikationen.",
+    "ALLOW_ANALYTICS_DESCRIPTION": "Hjälp oss att förbättra Varsom-appen genom att låta oss veta hur du använder applikationen.",
     "ALLOW_ANALYTICS_DESCRIPTION_LINE2": "Denna information är anonym och kan inte kopplas till dig personligen.",
     "ALLOW_ANALYTICS_HEADER": "Dela användningsstatistik",
     "APPMODE": "Appläge",
-    "APP_VERSION": "App version",
+    "APP_VERSION": "Version",
     "CONFIRM_RESET": "Är du säker på att du vill återställa appen?",
     "COUNTRY": "Land",
     "DROPDOWNS_FAILED": "Det gick inte att uppdatera rullgardinsmenyerna. Kontrollera om du har ett nätverk och försök igen senare.",
@@ -665,7 +663,7 @@
       "NORWEGIAN_SECONDARY_LANGUAGE": "Norwegian"
     },
     "COMPETENCE_PAGE": {
-      "HEADER": "Använd Regobs klokt!",
+      "HEADER": "Använd Varsom-appen klokt!",
       "LINE_1": "Använd informationen i appen, men gör också egna bedömningar. Använd observationerna utifrån observatörens kompetens, som visas som stjärnor med namnet."
     },
     "I_UNDERSTAND": "Okej, jag förstår",
@@ -728,7 +726,7 @@
     "ICE_LEGEND_TEXT_6": "Rörledning",
     "ICE_LEGEND_TEXT_7": "Kraftverkstunnel",
     "ICE_MAP_DESCRIPTION": "Stödkarta visar delar av vattendrag som uppför sig oförutsägbart under vintern på grund av reglering vid vattenkraftsproduktion",
-    "INFO_PAGE": "<h1>Om kartor med lutningsgrad och utloppszoner</h1>\nKartorna produceras automatiskt och kan innehålla fel. Det kan finnas brant terräng, som inte representeras i höjdmodellen och därmed inte visas på kartorna.\nVissa laviner kan ha längre utloppzoner än vad som visas som visas på kartorna.\n\n<h2> Vad ska man beakta?</h2>\nVälj vilken risk du vill utsätta dig för genom att välja var, när och hur du åker. Varsom Regobs är ett planeringsverktyg och dess data kan skilja sig från den faktiska situationen. Gör alltid din egen utvärdering.\n\n<h2> När är det säkert?</h2>\nAlla vistelse i snötäckt lavinterräng har ett inslag av risk.\n\n<h2> Vill du lära dig mer?</h2>\nDu kan lära dig mer genom att gå en Lavinkurs eller läsa mer på Snøskredskolen på Varsom.no.",
+    "INFO_PAGE": "<h1>Om kartor med lutningsgrad och utloppszoner</h1>\nKartorna produceras automatiskt och kan innehålla fel. Det kan finnas brant terräng, som inte representeras i höjdmodellen och därmed inte visas på kartorna.\nVissa laviner kan ha längre utloppzoner än vad som visas som visas på kartorna.\n\n<h2> Vad ska man beakta?</h2>\nVälj vilken risk du vill utsätta dig för genom att välja var, när och hur du åker. Varsom-appen är ett planeringsverktyg och dess data kan skilja sig från den faktiska situationen. Gör alltid din egen utvärdering.\n\n<h2> När är det säkert?</h2>\nAlla vistelse i snötäckt lavinterräng har ett inslag av risk.\n\n<h2> Vill du lära dig mer?</h2>\nDu kan lära dig mer genom att gå en Lavinkurs eller läsa mer på Snøskredskolen på Varsom.no.",
     "LOW": "Låg",
     "MARITINE_BORDER": "Havsgräns",
     "MIDDLE": "Medel",

--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,6 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Varsom Regobs</title>
-
   <base href="/" />
 
   <meta name="viewport"

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <title>Varsom Regobs</title>
   <base href="/" />
 
   <meta name="viewport"


### PR DESCRIPTION
Denne løser disse sakene:
- https://nveprojects.atlassian.net/browse/RO-1907
- https://nveprojects.atlassian.net/browse/RO-1940

Har endret all tekst som refererer til "Varsom Regobs" til "Varsom-app". Dette brukes stort sett i onboarding.
Unntaket er navnet på appen som nå er "Varsom" i app-modus og "Varsom Regobs" (inntil videre) i web-modus.
Noen steder har jeg beholdt "Regobs" der dette er brukt for å beskrive datasystemet vi sender data til eller henter data fra.

Jeg har endret tekster på bokmål, nynorsk, svensk og engelsk. Turte ikke prøve meg på de andre språkene:)

Dette står igjen å avgjøre:
- [ ] Skal vi bytte hva appmodusene heter? For meg kunne de gjerne hete "produksjon", "demo" og "test".

