### PR TITLE
Flytte felter fra skredhendelse til ulykke/skade, samt validere

### DIFF
--- a/src/app/core/helpers/incident-validation.ts
+++ b/src/app/core/helpers/incident-validation.ts
@@ -1,0 +1,24 @@
+import { IncidentEditModel } from 'src/app/modules/common-regobs-api';
+
+
+export class IncidentValidation {
+  static onCasualtiesNumChange(incident: IncidentEditModel){
+    if (
+      (incident.InvolvedNum == undefined && incident.CasualtiesNum > 0)
+       || (incident.CasualtiesNum > incident.InvolvedNum)){
+      return false;
+    } else {
+      return true;
+    }
+  }
+  static onDeadNumChange(incident: IncidentEditModel){
+    if(
+      (incident.InvolvedNum == undefined && incident.CasualtiesNum == undefined && incident.DeadNum > 0)
+      || (incident.DeadNum > incident.CasualtiesNum)
+      || (incident.DeadNum > incident.InvolvedNum)){
+      return false;
+    } else {
+      return true;
+    }
+  }
+}

--- a/src/app/core/helpers/incident-validation.ts
+++ b/src/app/core/helpers/incident-validation.ts
@@ -3,9 +3,7 @@ import { IncidentEditModel } from 'src/app/modules/common-regobs-api';
 
 export class IncidentValidation {
   static onCasualtiesNumChange(incident: IncidentEditModel){
-    if (
-      (incident.InvolvedNum == undefined && incident.CasualtiesNum > 0)
-       || (incident.CasualtiesNum > incident.InvolvedNum)){
+    if ((incident.CasualtiesNum > incident.InvolvedNum)){
       return false;
     } else {
       return true;
@@ -13,8 +11,7 @@ export class IncidentValidation {
   }
   static onDeadNumChange(incident: IncidentEditModel){
     if(
-      (incident.InvolvedNum == undefined && incident.CasualtiesNum == undefined && incident.DeadNum > 0)
-      || (incident.DeadNum > incident.CasualtiesNum)
+      (incident.DeadNum > incident.CasualtiesNum)
       || (incident.DeadNum > incident.InvolvedNum)){
       return false;
     } else {

--- a/src/app/modules/map/helpers/leaflet-cluser.helper.ts
+++ b/src/app/modules/map/helpers/leaflet-cluser.helper.ts
@@ -1,5 +1,6 @@
 import * as L from 'leaflet';
 import { settings } from '../../../../settings';
+import 'leaflet.markercluster';
 
 export class LeafletClusterHelper {
   static createMarkerClusterGroup(options?: L.MarkerClusterGroupOptions) {

--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.html
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.html
@@ -5,7 +5,7 @@
     [color]="color"
     position="stacked"
     [ngClass]="{'ion-text-uppercase': !simpleObsMode, 'simple-mode-title': simpleObsMode}">
-    {{ title | translate}}
+    {{ title | translate}} {{isValid == false ? '('+(errorMessage | translate)+')' : null}}
   </ion-label>
   <ion-text
     [ngClass]="{'ion-align-self-start': true, 'simple-mode-sub': simpleObsMode}"

--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.html
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.html
@@ -4,6 +4,7 @@
     *ngIf="title"
     [color]="color"
     position="stacked"
+    class="no-white-space-wrap"
     [ngClass]="{'ion-text-uppercase': !simpleObsMode, 'simple-mode-title': simpleObsMode}">
     {{ title | translate}} {{isValid == false ? '('+(errorMessage | translate)+')' : null}}
   </ion-label>

--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.scss
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.scss
@@ -11,3 +11,6 @@
     font-size: 18px;
     color: #333;
 }
+.no-white-space-wrap {
+    white-space: normal;
+}

--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.ts
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.ts
@@ -19,6 +19,8 @@ export class NumericInputComponent {
   @Input() suffix: string;
   @Input() decimalSeparator;
   @Input() value: number;
+  @Input() isValid = true;
+  @Input() errorMessage?: string;
   @Output() valueChange = new EventEmitter();
   @Input() title: string;
   @Input() placeholder: string;

--- a/src/app/modules/registration/pages/incident/incident.module.ts
+++ b/src/app/modules/registration/pages/incident/incident.module.ts
@@ -4,11 +4,13 @@ import { IncidentPage } from './incident.page';
 import { SharedComponentsModule } from '../../shared-components.module';
 import { AddWebUrlModalPageModule } from '../add-web-url-modal/add-web-url-modal.module';
 import { RegistrationModule } from '../../registration.module';
+import { CanDeactivateRouteGuard } from '../can-deactivate-route.guard';
 
 const routes: Routes = [
   {
     path: '',
-    component: IncidentPage
+    component: IncidentPage,
+    canDeactivate: [CanDeactivateRouteGuard]
   }
 ];
 

--- a/src/app/modules/registration/pages/incident/incident.page.html
+++ b/src/app/modules/registration/pages/incident/incident.page.html
@@ -14,22 +14,23 @@
     <ion-list>
       <app-kdv-select title="REGISTRATION.INCIDENT.ACTIVITY" kdvKey="Ice_ActivityInfluencedKDV"
                       [(value)]="incident.ActivityInfluencedTID"></app-kdv-select>
-      <app-numeric-input title="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM"
-                         [color]="!isInvolvedValid ? 'danger' : 'medium'"
-                         [min]="0"
-                         [(value)]="incident.InvolvedNum"></app-numeric-input>
+      <app-numeric-input title="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM" [min]="0" [(value)]="incident.InvolvedNum"
+        (valueChange)="groupValidate()">
+      </app-numeric-input>
       <app-numeric-input title="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM"
                          [color]="!isCasualtiesValid ? 'danger' : 'medium'"
                          [min]="0"
                          [isValid]="isCasualtiesValid"
                          errorMessage="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM_ERROR_MESSAGE"
-                         [(value)]="incident.CasualtiesNum"></app-numeric-input>
+                         [(value)]="incident.CasualtiesNum"
+                         (valueChange)="groupValidate()"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM"
                          [color]="!isDeadValid ? 'danger' : 'medium'"
                          [min]="0"
                          [isValid]="isDeadValid"
                          errorMessage="REGISTRATION.ICE.INCIDENT.DEAD_NUM_ERROR_MESSAGE"
-                         [(value)]="incident.DeadNum"></app-numeric-input>
+                         [(value)]="incident.DeadNum"
+                         (valueChange)="groupValidate()"></app-numeric-input>
       <app-kdv-select title="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV"
                       [(value)]="incident.RescueTID"></app-kdv-select>
       <app-kdv-select title="REGISTRATION.ICE.INCIDENT.SAFETY_GEAR_TID" kdvKey="Ice_SafetyGearKDV"

--- a/src/app/modules/registration/pages/incident/incident.page.html
+++ b/src/app/modules/registration/pages/incident/incident.page.html
@@ -15,10 +15,11 @@
       <app-kdv-select title="REGISTRATION.INCIDENT.ACTIVITY" kdvKey="Ice_ActivityInfluencedKDV"
                       [(value)]="incident.ActivityInfluencedTID"></app-kdv-select>
       <app-numeric-input title="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM"
-                         [(value)]="incident.InvolvedNum"></app-numeric-input>
+                         [(value)]="incident.InvolvedNum" min="0"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM"
-                         [(value)]="incident.CasualtiesNum"></app-numeric-input>
-      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM" [(value)]="incident.DeadNum"></app-numeric-input>
+                         [(value)]="incident.CasualtiesNum" min="0"></app-numeric-input>
+      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM" [(value)]="incident.DeadNum"
+                         min="0"></app-numeric-input>
       <app-kdv-select title="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV"
                       [(value)]="incident.RescueTID"></app-kdv-select>
       <app-kdv-select title="REGISTRATION.ICE.INCIDENT.SAFETY_GEAR_TID" kdvKey="Ice_SafetyGearKDV"

--- a/src/app/modules/registration/pages/incident/incident.page.html
+++ b/src/app/modules/registration/pages/incident/incident.page.html
@@ -16,17 +16,20 @@
                       [(value)]="incident.ActivityInfluencedTID"></app-kdv-select>
       <app-numeric-input title="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM"
                          [color]="!isInvolvedValid ? 'danger' : 'medium'"
-                         [(value)]="incident.InvolvedNum" min="0"></app-numeric-input>
+                         [min]="0"
+                         [(value)]="incident.InvolvedNum"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM"
-                         [readonly]="!incident.InvolvedNum"
                          [color]="!isCasualtiesValid ? 'danger' : 'medium'"
-                         [(value)]="incident.CasualtiesNum" min="0"
-                         [max]="incident.InvolvedNum"></app-numeric-input>
+                         [min]="0"
+                         [isValid]="isCasualtiesValid"
+                         errorMessage="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM_ERROR_MESSAGE"
+                         [(value)]="incident.CasualtiesNum"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM"
-                         [readonly]="!incident.CasualtiesNum || !incident.InvolvedNum"
                          [color]="!isDeadValid ? 'danger' : 'medium'"
-                         [(value)]="incident.DeadNum" min="0"
-                         [max]="incident.CasualtiesNum"></app-numeric-input>
+                         [min]="0"
+                         [isValid]="isDeadValid"
+                         errorMessage="REGISTRATION.ICE.INCIDENT.DEAD_NUM_ERROR_MESSAGE"
+                         [(value)]="incident.DeadNum"></app-numeric-input>
       <app-kdv-select title="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV"
                       [(value)]="incident.RescueTID"></app-kdv-select>
       <app-kdv-select title="REGISTRATION.ICE.INCIDENT.SAFETY_GEAR_TID" kdvKey="Ice_SafetyGearKDV"

--- a/src/app/modules/registration/pages/incident/incident.page.html
+++ b/src/app/modules/registration/pages/incident/incident.page.html
@@ -15,11 +15,18 @@
       <app-kdv-select title="REGISTRATION.INCIDENT.ACTIVITY" kdvKey="Ice_ActivityInfluencedKDV"
                       [(value)]="incident.ActivityInfluencedTID"></app-kdv-select>
       <app-numeric-input title="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM"
+                         [color]="!isInvolvedValid ? 'danger' : 'medium'"
                          [(value)]="incident.InvolvedNum" min="0"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM"
-                         [(value)]="incident.CasualtiesNum" min="0"></app-numeric-input>
-      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM" [(value)]="incident.DeadNum"
-                         min="0"></app-numeric-input>
+                         [readonly]="!incident.InvolvedNum"
+                         [color]="!isCasualtiesValid ? 'danger' : 'medium'"
+                         [(value)]="incident.CasualtiesNum" min="0"
+                         [max]="incident.InvolvedNum"></app-numeric-input>
+      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM"
+                         [readonly]="!incident.CasualtiesNum || !incident.InvolvedNum"
+                         [color]="!isDeadValid ? 'danger' : 'medium'"
+                         [(value)]="incident.DeadNum" min="0"
+                         [max]="incident.CasualtiesNum"></app-numeric-input>
       <app-kdv-select title="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV"
                       [(value)]="incident.RescueTID"></app-kdv-select>
       <app-kdv-select title="REGISTRATION.ICE.INCIDENT.SAFETY_GEAR_TID" kdvKey="Ice_SafetyGearKDV"

--- a/src/app/modules/registration/pages/incident/incident.page.ts
+++ b/src/app/modules/registration/pages/incident/incident.page.ts
@@ -13,6 +13,10 @@ import { IncidentEditModel } from 'src/app/modules/common-regobs-api';
 })
 export class IncidentPage extends BasePage {
 
+  isInvolvedValid = true;
+  isCasualtiesValid = true;
+  isDeadValid = true;
+
   get geoHazardName(): string {
     return GeoHazard[this.draft.registration.GeoHazardTID];
   }
@@ -23,5 +27,28 @@ export class IncidentPage extends BasePage {
 
   constructor(basePageService: BasePageService, activatedRoute: ActivatedRoute) {
     super(RegistrationTid.Incident, basePageService, activatedRoute);
+  }
+
+  /**
+   * If InvolvedNum is set then:
+   * CasualtiesNum must be equal to or less than InvolvedNum.
+   * DeadNum must be equal to or less than CasualtiesNum.
+   * All numbers must be >= 0.
+   * CasualtiesNum and DeadNum can be empty.
+   */
+  isValid() {
+    const {
+      InvolvedNum,
+      CasualtiesNum,
+      DeadNum
+    } = this.incident;
+
+    if (InvolvedNum) {
+      this.isInvolvedValid = InvolvedNum >= 0;
+      this.isCasualtiesValid = CasualtiesNum === undefined || CasualtiesNum <= InvolvedNum;
+      this.isDeadValid = DeadNum === undefined || DeadNum <= CasualtiesNum;
+    }
+
+    return this.isInvolvedValid && this.isCasualtiesValid && this.isDeadValid;
   }
 }

--- a/src/app/modules/registration/pages/incident/incident.page.ts
+++ b/src/app/modules/registration/pages/incident/incident.page.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { RegistrationTid } from 'src/app/modules/common-registration/registration.models';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 import { IncidentEditModel } from 'src/app/modules/common-regobs-api';
+import { IncidentValidation } from 'src/app/core/helpers/incident-validation';
 
 @Component({
   selector: 'app-incident',
@@ -13,8 +14,7 @@ import { IncidentEditModel } from 'src/app/modules/common-regobs-api';
 })
 export class IncidentPage extends BasePage {
 
-  isInvolvedValid = true;
-  isCasualtiesValid = true;
+  isCasualtiesValid= true;
   isDeadValid = true;
 
   get geoHazardName(): string {
@@ -31,6 +31,11 @@ export class IncidentPage extends BasePage {
     super(RegistrationTid.Incident, basePageService, activatedRoute);
   }
 
+  groupValidate(){
+    this.isCasualtiesValid = IncidentValidation.onCasualtiesNumChange(this.incident);
+    this.isDeadValid =  IncidentValidation.onDeadNumChange(this.incident);
+  }
+
   /**
    * If InvolvedNum is set then:
    * CasualtiesNum must be equal to or less than InvolvedNum.
@@ -39,15 +44,7 @@ export class IncidentPage extends BasePage {
    * CasualtiesNum and DeadNum can be empty.
    */
   isValid() {
-    const {
-      InvolvedNum,
-      CasualtiesNum,
-      DeadNum
-    } = this.incident;
-
-    this.isCasualtiesValid = CasualtiesNum === undefined || CasualtiesNum <= InvolvedNum;
-    this.isDeadValid = DeadNum === undefined || DeadNum <= CasualtiesNum;
-
-    return this.isInvolvedValid && this.isCasualtiesValid && this.isDeadValid;
+    this.groupValidate();
+    return this.isCasualtiesValid && this.isDeadValid;
   }
 }

--- a/src/app/modules/registration/pages/incident/incident.page.ts
+++ b/src/app/modules/registration/pages/incident/incident.page.ts
@@ -36,13 +36,6 @@ export class IncidentPage extends BasePage {
     this.isDeadValid =  IncidentValidation.onDeadNumChange(this.incident);
   }
 
-  /**
-   * If InvolvedNum is set then:
-   * CasualtiesNum must be equal to or less than InvolvedNum.
-   * DeadNum must be equal to or less than CasualtiesNum.
-   * All numbers must be >= 0.
-   * CasualtiesNum and DeadNum can be empty.
-   */
   isValid() {
     this.groupValidate();
     return this.isCasualtiesValid && this.isDeadValid;

--- a/src/app/modules/registration/pages/incident/incident.page.ts
+++ b/src/app/modules/registration/pages/incident/incident.page.ts
@@ -25,7 +25,9 @@ export class IncidentPage extends BasePage {
     return this.draft.registration.Incident;
   }
 
-  constructor(basePageService: BasePageService, activatedRoute: ActivatedRoute) {
+  constructor(
+    basePageService: BasePageService,
+    activatedRoute: ActivatedRoute) {
     super(RegistrationTid.Incident, basePageService, activatedRoute);
   }
 
@@ -43,11 +45,8 @@ export class IncidentPage extends BasePage {
       DeadNum
     } = this.incident;
 
-    if (InvolvedNum) {
-      this.isInvolvedValid = InvolvedNum >= 0;
-      this.isCasualtiesValid = CasualtiesNum === undefined || CasualtiesNum <= InvolvedNum;
-      this.isDeadValid = DeadNum === undefined || DeadNum <= CasualtiesNum;
-    }
+    this.isCasualtiesValid = CasualtiesNum === undefined || CasualtiesNum <= InvolvedNum;
+    this.isDeadValid = DeadNum === undefined || DeadNum <= CasualtiesNum;
 
     return this.isInvolvedValid && this.isCasualtiesValid && this.isDeadValid;
   }

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -113,19 +113,27 @@
                       [(value)]="incident.ActivityInfluencedTID"></app-kdv-select>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
                          [color]="!isInvolvedValid ? 'danger' : 'medium'"
-                         [(value)]="incident.InvolvedNum" min="0"></app-numeric-input>
+                         [min]="0"
+                         [(value)]="incident.InvolvedNum"
+                         (valueChange)="groupValidate()"
+                         ></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
-                         [readonly]="!incident.InvolvedNum"
                          [color]="!isCasualtiesValid ? 'danger' : 'medium'"
-                         [(value)]="incident.CasualtiesNum" min="0"
-                         [max]="incident.InvolvedNum"></app-numeric-input>
+                         [isValid]="isCasualtiesValid"
+                         errorMessage="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM_ERROR_MESSAGE"
+                         [min]="0"
+                         [(value)]="incident.CasualtiesNum" (valueChange)="groupValidate()"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM"
-                         [readonly]="!incident.CasualtiesNum || !incident.InvolvedNum"
                          [color]="!isDeadValid ? 'danger' : 'medium'"
-                         [(value)]="incident.DeadNum" min="0"
-                         [max]="incident.CasualtiesNum"></app-numeric-input>
+                         [isValid]="isDeadValid"
+                         errorMessage="REGISTRATION.SNOW.AVALANCHE_OBS.DEAD_NUM_ERROR_MESSAGE"
+                         [min]="0"
+                         [(value)]="incident.DeadNum" (valueChange)="groupValidate()"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
-                         [(value)]="incident.HarmedNum" min="0"></app-numeric-input>
+                         [color]="!isHarmedValid ? 'danger' : 'medium'" 
+                         [(value)]="incident.HarmedNum"
+                         (valueChange)="groupValidate()"
+                         [min]="0"></app-numeric-input>
       <ion-item>
         <ion-label
           position="stacked"
@@ -136,7 +144,8 @@
         <ion-toggle [(ngModel)]="incident.TrafficObstructed"></ion-toggle>
       </ion-item>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.EVACUATED_NUM"
-                         [(value)]="incident.EvacuatedNum" min="0"></app-numeric-input>
+                         [(value)]="incident.EvacuatedNum"
+                         [min]="0"></app-numeric-input>
       <ion-item>
         <ion-label
           position="stacked"

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -114,9 +114,13 @@
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
                          [(value)]="incident.InvolvedNum" min="0"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
-                         [(value)]="incident.CasualtiesNum" min="0"></app-numeric-input>
-      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM" [(value)]="incident.DeadNum"
-                         min="0"></app-numeric-input>
+                         *ngIf="incident.InvolvedNum"
+                         [(value)]="incident.CasualtiesNum" min="0"
+                         [max]="incident.InvolvedNum"></app-numeric-input>
+      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM"
+                         *ngIf="incident.CasualtiesNum && incident.InvolvedNum"
+                         [(value)]="incident.DeadNum" min="0"
+                         [max]="incident.CasualtiesNum"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
                          [(value)]="incident.HarmedNum" min="0"></app-numeric-input>
       <ion-item>

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -112,13 +112,16 @@
       <app-kdv-select title="REGISTRATION.INCIDENT.ACTIVITY" kdvKey="Snow_ActivityInfluencedKDV"
                       [(value)]="incident.ActivityInfluencedTID"></app-kdv-select>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
+                         [color]="!isInvolvedValid ? 'danger' : 'medium'"
                          [(value)]="incident.InvolvedNum" min="0"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
-                         *ngIf="incident.InvolvedNum"
+                         [readonly]="!incident.InvolvedNum"
+                         [color]="!isCasualtiesValid ? 'danger' : 'medium'"
                          [(value)]="incident.CasualtiesNum" min="0"
                          [max]="incident.InvolvedNum"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM"
-                         *ngIf="incident.CasualtiesNum && incident.InvolvedNum"
+                         [readonly]="!incident.CasualtiesNum || !incident.InvolvedNum"
+                         [color]="!isDeadValid ? 'danger' : 'medium'"
                          [(value)]="incident.DeadNum" min="0"
                          [max]="incident.CasualtiesNum"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -90,26 +90,6 @@
       </app-numeric-input>
       <app-text-comment title="REGISTRATION.SNOW.AVALANCHE_OBS.TRAJECTORY_NAME" [max]="100" [rows]="2"
                         [(value)]="avalancheObs.Trajectory"></app-text-comment>
-      <ion-item>
-        <ion-label
-          position="stacked"
-          color="medium"
-          class="ion-text-uppercase">
-          {{'REGISTRATION.SNOW.AVALANCHE_OBS.TRAFFIC_OBSTRUCTED' | translate}}
-        </ion-label>
-        <ion-toggle [(ngModel)]="incident.TrafficObstructed"></ion-toggle>
-      </ion-item>
-      <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.EVACUATED_NUM"
-                         [(value)]="incident.EvacuatedNum"></app-numeric-input>
-      <ion-item>
-        <ion-label
-          position="stacked"
-          color="medium"
-          class="ion-text-uppercase">
-          {{'REGISTRATION.SNOW.AVALANCHE_OBS.MATERIAL_DAMAGES' | translate}}
-        </ion-label>
-        <ion-toggle [(ngModel)]="incident.MaterialDamages"></ion-toggle>
-      </ion-item>
       <app-text-comment title="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheObs.Comment">
       </app-text-comment>
       <ion-list-header class="ion-text-uppercase">
@@ -138,6 +118,26 @@
       <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM" [(value)]="incident.DeadNum"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
                          [(value)]="incident.HarmedNum"></app-numeric-input>
+      <ion-item>
+        <ion-label
+          position="stacked"
+          color="medium"
+          class="ion-text-uppercase">
+          {{'REGISTRATION.SNOW.AVALANCHE_OBS.TRAFFIC_OBSTRUCTED' | translate}}
+        </ion-label>
+        <ion-toggle [(ngModel)]="incident.TrafficObstructed"></ion-toggle>
+      </ion-item>
+      <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.EVACUATED_NUM"
+                         [(value)]="incident.EvacuatedNum"></app-numeric-input>
+      <ion-item>
+        <ion-label
+          position="stacked"
+          color="medium"
+          class="ion-text-uppercase">
+          {{'REGISTRATION.SNOW.AVALANCHE_OBS.MATERIAL_DAMAGES' | translate}}
+        </ion-label>
+        <ion-toggle [(ngModel)]="incident.MaterialDamages"></ion-toggle>
+      </ion-item>
       <app-kdv-select title="REGISTRATION.SNOW.AVALANCHE_OBS.SLOPE_ACTIVITY_TID" kdvKey="Snow_SlopeActivityKDV"
                       [(value)]="incident.SlopeActivityTID"></app-kdv-select>
       <app-kdv-select title="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV"

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -112,12 +112,13 @@
       <app-kdv-select title="REGISTRATION.INCIDENT.ACTIVITY" kdvKey="Snow_ActivityInfluencedKDV"
                       [(value)]="incident.ActivityInfluencedTID"></app-kdv-select>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
-                         [(value)]="incident.InvolvedNum"></app-numeric-input>
+                         [(value)]="incident.InvolvedNum" min="0"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
-                         [(value)]="incident.CasualtiesNum"></app-numeric-input>
-      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM" [(value)]="incident.DeadNum"></app-numeric-input>
+                         [(value)]="incident.CasualtiesNum" min="0"></app-numeric-input>
+      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM" [(value)]="incident.DeadNum"
+                         min="0"></app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
-                         [(value)]="incident.HarmedNum"></app-numeric-input>
+                         [(value)]="incident.HarmedNum" min="0"></app-numeric-input>
       <ion-item>
         <ion-label
           position="stacked"
@@ -128,7 +129,7 @@
         <ion-toggle [(ngModel)]="incident.TrafficObstructed"></ion-toggle>
       </ion-item>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.EVACUATED_NUM"
-                         [(value)]="incident.EvacuatedNum"></app-numeric-input>
+                         [(value)]="incident.EvacuatedNum" min="0"></app-numeric-input>
       <ion-item>
         <ion-label
           position="stacked"

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -99,19 +99,33 @@
       </ion-list-header>
       <app-kdv-select title="REGISTRATION.INCIDENT.ACTIVITY" kdvKey="Snow_ActivityInfluencedKDV"
         [(value)]="incident.ActivityInfluencedTID"></app-kdv-select>
-      <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
-        [color]="!isInvolvedValid ? 'danger' : 'medium'" [min]="0" [(value)]="incident.InvolvedNum"
-        (valueChange)="groupValidate()"></app-numeric-input>
+      <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM" [color]="!isInvolvedValid ? 'danger' : 'medium'"
+        [min]="0" [(value)]="incident.InvolvedNum" (valueChange)="groupValidate()">
+      </app-numeric-input>
       <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
-        [color]="!isCasualtiesValid ? 'danger' : 'medium'" [isValid]="isCasualtiesValid"
-        errorMessage="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM_ERROR_MESSAGE" [min]="0"
-        [(value)]="incident.CasualtiesNum" (valueChange)="groupValidate()"></app-numeric-input>
-      <app-numeric-input title="REGISTRATION.INCIDENT.DEAD_NUM" [color]="!isDeadValid ? 'danger' : 'medium'"
-        [isValid]="isDeadValid" errorMessage="REGISTRATION.SNOW.AVALANCHE_OBS.DEAD_NUM_ERROR_MESSAGE" [min]="0"
-        [(value)]="incident.DeadNum" (valueChange)="groupValidate()"></app-numeric-input>
-      <app-numeric-input title="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
-        [color]="!isHarmedValid ? 'danger' : 'medium'" [(value)]="incident.HarmedNum" (valueChange)="groupValidate()"
-        [min]="0"></app-numeric-input>
+        [color]="!isCasualtiesValid ? 'danger' : 'medium'" 
+        [isValid]="isCasualtiesValid"
+        errorMessage="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM_ERROR_MESSAGE" 
+        [min]="0"
+        [(value)]="incident.CasualtiesNum" 
+        (valueChange)="groupValidate()">
+      </app-numeric-input>
+      <app-numeric-input
+        title="REGISTRATION.INCIDENT.DEAD_NUM" 
+        [color]="!isDeadValid ? 'danger' : 'medium'"
+        [isValid]="isDeadValid" [errorMessage]="!isErrorMessageHarmAndDead ? 'REGISTRATION.SNOW.AVALANCHE_OBS.DEAD_NUM_ERROR_MESSAGE' : 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE'" [min]="0"
+        [(value)]="incident.DeadNum" 
+        (valueChange)="groupValidate()">
+      </app-numeric-input>
+      <app-numeric-input 
+        title="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
+        [errorMessage]="!isErrorMessageHarmAndDead ? 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM_ERROR_MESSAGE' : 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE'"
+        [isValid]="isHarmedValid"
+        [color]="!isHarmedValid ? 'danger' : 'medium'" 
+        [(value)]="incident.HarmedNum" 
+        (valueChange)="groupValidate()"
+        [min]="0">
+      </app-numeric-input>
       <ion-item>
         <ion-label position="stacked" color="medium" class="ion-text-uppercase">
           {{'REGISTRATION.SNOW.AVALANCHE_OBS.TRAFFIC_OBSTRUCTED' | translate}}

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.spec.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.spec.ts
@@ -1,27 +1,64 @@
-// import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { GeoHazard } from 'src/app/modules/common-core/models';
+import { BasePageService } from '../../base-page-service';
+import { AvalancheObsPage } from './avalanche-obs.page';
+import 'leaflet.markercluster';
 
-// import { AvalancheObsPage } from './avalanche-obs.page';
 
-// describe('AvalancheObsPage', () => {
-//   let component: AvalancheObsPage;
-//   let fixture: ComponentFixture<AvalancheObsPage>;
+describe('AvalancheObsPage', () => {
+  let component: AvalancheObsPage;
+  beforeEach(() => {
+    const basePageService = new BasePageService(null, null, null, null, null);
+    component = new AvalancheObsPage(basePageService, null, null);
+    component.draft = {
+      registration: {
+        DtObsTime: new Date(2020, 0, 1).toISOString(),
+        GeoHazardTID: GeoHazard.Snow,
+        Incident: {},
+        AvalancheObs: {
+          DtAvalancheTime: new Date(2020, 0, 1).toISOString()
+        }
+      },
+      uuid: null,
+      syncStatus: null,
+      simpleMode: false,
+    };
+  });
+  it('empty incident is valid', () => {
+    expect(component.isValid()).toBeTrue();
+  });
 
-//   beforeEach(async(() => {
-//     TestBed.configureTestingModule({
-//       declarations: [ AvalancheObsPage ],
-//       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-//     })
-//     .compileComponents();
-//   }));
+  it('Number of casualties higher than number involved, is not valid', () => {
+    component.draft.registration.Incident.InvolvedNum = 5;
+    component.draft.registration.Incident.CasualtiesNum = 7;
+    expect(component.isValid()).toBeFalse();
+  });
 
-//   beforeEach(() => {
-//     fixture = TestBed.createComponent(AvalancheObsPage);
-//     component = fixture.componentInstance;
-//     fixture.detectChanges();
-//   });
+  it('Number of dead higher than number of casualties, is not valid', () => {
+    component.draft.registration.Incident.InvolvedNum = 6;
+    component.draft.registration.Incident.CasualtiesNum = 4;
+    component.draft.registration.Incident.DeadNum = 5;
+    expect(component.isValid()).toBeFalse();
+  });
 
-//   it('should create', () => {
-//     expect(component).toBeTruthy();
-//   });
-// });
+  it('Number of harmed is higher than number of involved, is not valid', () => {
+    component.draft.registration.Incident.InvolvedNum = 6;
+    component.draft.registration.Incident.HarmedNum = 7;
+    expect(component.isValid()).toBeFalse();
+  });
+
+  it('Number of harmed and dead is higher than number of casualties, is not valid', () => {
+    component.draft.registration.Incident.InvolvedNum = 6;
+    component.draft.registration.Incident.CasualtiesNum = 4;
+    component.draft.registration.Incident.DeadNum = 3;
+    component.draft.registration.Incident.HarmedNum = 3;
+    expect(component.isValid()).toBeFalse();
+  });
+
+  it('Form is valid', () => {
+    component.draft.registration.Incident.InvolvedNum = 6;
+    component.draft.registration.Incident.CasualtiesNum = 5;
+    component.draft.registration.Incident.DeadNum = 3;
+    component.draft.registration.Incident.HarmedNum = 2;
+    expect(component.isValid()).toBeTrue();
+  });
+});

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.spec.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.spec.ts
@@ -27,6 +27,16 @@ describe('AvalancheObsPage', () => {
     expect(component.isValid()).toBeTrue();
   });
 
+  it('Number of casualties is given without number involved, is valid', () => {
+    component.draft.registration.Incident.CasualtiesNum = 7;
+    expect(component.isValid()).toBeTrue();
+  });
+
+  it('Number of dead is given without number casualties or involved, is valid', () => {
+    component.draft.registration.Incident.DeadNum = 7;
+    expect(component.isValid()).toBeTrue();
+  });
+
   it('Number of casualties higher than number involved, is not valid', () => {
     component.draft.registration.Incident.InvolvedNum = 5;
     component.draft.registration.Incident.CasualtiesNum = 7;
@@ -40,8 +50,15 @@ describe('AvalancheObsPage', () => {
     expect(component.isValid()).toBeFalse();
   });
 
+  it('Number of dead higher than number of involved without casualties, is not valid', () => {
+    component.draft.registration.Incident.InvolvedNum = 6;
+    component.draft.registration.Incident.DeadNum = 7;
+    expect(component.isValid()).toBeFalse();
+  });
+
   it('Number of harmed is higher than number of involved, is not valid', () => {
     component.draft.registration.Incident.InvolvedNum = 6;
+    component.draft.registration.Incident.CasualtiesNum = 3;
     component.draft.registration.Incident.HarmedNum = 7;
     expect(component.isValid()).toBeFalse();
   });
@@ -52,6 +69,26 @@ describe('AvalancheObsPage', () => {
     component.draft.registration.Incident.DeadNum = 3;
     component.draft.registration.Incident.HarmedNum = 3;
     expect(component.isValid()).toBeFalse();
+  });
+
+  it('Number of harmed and dead is higher than number of involved without casualties specified, is not valid', () => {
+    component.draft.registration.Incident.InvolvedNum = 6;
+    component.draft.registration.Incident.DeadNum = 4;
+    component.draft.registration.Incident.HarmedNum = 3;
+    expect(component.isValid()).toBeFalse();
+  });
+
+  it('Number of harmed and dead is higher than number of casualties without involved specified, is not valid', () => {
+    component.draft.registration.Incident.CasualtiesNum = 4;
+    component.draft.registration.Incident.DeadNum = 3;
+    component.draft.registration.Incident.HarmedNum = 3;
+    expect(component.isValid()).toBeFalse();
+  });
+
+  it('Number of harmed and dead without casualties and involved, is valid', () => {
+    component.draft.registration.Incident.DeadNum = 3;
+    component.draft.registration.Incident.HarmedNum = 3;
+    expect(component.isValid()).toBeTrue();
   });
 
   it('Form is valid', () => {

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -63,6 +63,7 @@ export class AvalancheObsPage extends BasePage {
   isInvolvedValid = true;
   isCasualtiesValid = true;
   isDeadValid = true;
+  isHarmedValid = true;
 
   get avalancheObs(): AvalancheObsEditModel {
     return this.draft.registration.AvalancheObs;
@@ -116,6 +117,69 @@ export class AvalancheObsPage extends BasePage {
     this.draft = await this.basePageService.delete(this.draft, [this.registrationTid, RegistrationTid.Incident]);
   }
 
+
+  groupValidate(){
+    console.log('called');
+    this.onCasualtiesNumChange();
+    this.onDeadNumChange();
+    this.onHarmedChange();
+  }
+
+  onCasualtiesNumChange(){
+
+
+    if (
+      (this.incident.InvolvedNum == undefined && this.incident.CasualtiesNum > 0)
+       || (this.incident.CasualtiesNum > this.incident.InvolvedNum)){
+      this.isCasualtiesValid = false;
+    } else {
+      this.isCasualtiesValid = true;
+    }
+  }
+
+  onDeadNumChange(){
+
+    if(
+      (this.incident.InvolvedNum == undefined && this.incident.CasualtiesNum == undefined && this.incident.DeadNum > 0)
+      || (this.incident.DeadNum > this.incident.CasualtiesNum)){
+      this.isDeadValid = false;
+    } else {
+      this.isDeadValid = true;
+    }
+  }
+
+  //Så den beste sjekken er at summen av døde og skadete ikke må overstige antall involverte eller antall skredtatte.
+  onHarmedChange(){
+
+    //if only involved exist make sure harmedNum is not higher than involved
+    if (
+      (this.incident.InvolvedNum == undefined && this.incident.HarmedNum > 0)
+      || (this.incident.HarmedNum > this.incident.InvolvedNum))
+    {
+      this.isHarmedValid = false;
+    }
+    else if((this.incident.DeadNum > 0 && (this.incident.DeadNum + this.incident.HarmedNum) > this.incident.CasualtiesNum)){
+      this.isHarmedValid = false;
+      this.isDeadValid = false;
+    }
+    else {
+      this.isHarmedValid = true;
+    }
+
+    //if both involved and casualties exist make sure its not higher than casualties and involved ones
+
+
+    //if dead ones exist make sure that sum of hurt and dead is not higher than casualties
+    /*if(
+      //check if involved or casualties exist
+      (this.incident.InvolvedNum == undefined && this.incident.CasualtiesNum == undefined && harmedNum > 0)
+      || (harmedNum > )
+    ) {
+      this.isHarmedValid = false;
+    }*/
+
+  }
+
   /**
    * If InvolvedNum is set then:
    * CasualtiesNum must be equal to or less than InvolvedNum.
@@ -133,11 +197,8 @@ export class AvalancheObsPage extends BasePage {
       DeadNum
     } = this.incident;
 
-    if (InvolvedNum) {
-      this.isInvolvedValid = InvolvedNum >= 0;
-      this.isCasualtiesValid = CasualtiesNum === undefined || CasualtiesNum <= InvolvedNum;
-      this.isDeadValid = DeadNum === undefined || DeadNum <= CasualtiesNum;
-    }
+    this.isCasualtiesValid = CasualtiesNum === undefined || CasualtiesNum <= InvolvedNum;
+    this.isDeadValid = DeadNum === undefined || DeadNum <= CasualtiesNum;
 
     return !!this.avalancheObs.DtAvalancheTime && this.isInvolvedValid && this.isCasualtiesValid && this.isDeadValid;
   }

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -128,19 +128,18 @@ export class AvalancheObsPage extends BasePage {
     this.showWarning = true;
 
     const {
-      InvolvedNum: antallInvolvert,
-      CasualtiesNum: antallSkadet,
-      DeadNum: antallDode
+      InvolvedNum,
+      CasualtiesNum,
+      DeadNum
     } = this.incident;
 
-    if (antallInvolvert) {
-      this.isInvolvedValid = antallInvolvert >= 0;
-      this.isCasualtiesValid = antallSkadet === undefined || antallSkadet <= antallInvolvert;
-      this.isDeadValid = antallDode === undefined || antallDode <= antallSkadet;
+    if (InvolvedNum) {
+      this.isInvolvedValid = InvolvedNum >= 0;
+      this.isCasualtiesValid = CasualtiesNum === undefined || CasualtiesNum <= InvolvedNum;
+      this.isDeadValid = DeadNum === undefined || DeadNum <= CasualtiesNum;
     }
 
     return !!this.avalancheObs.DtAvalancheTime && this.isInvolvedValid && this.isCasualtiesValid && this.isDeadValid;
-
   }
 
   async isEmpty(): Promise<boolean> {

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -112,9 +112,33 @@ export class AvalancheObsPage extends BasePage {
     this.draft = await this.basePageService.delete(this.draft, [this.registrationTid, RegistrationTid.Incident]);
   }
 
+  /**
+   * If InvolvedNum is set then:
+   * CasualtiesNum must be equal to or less than InvolvedNum.
+   * DeadNum must be equal to or less than CasualtiesNum.
+   * All numbers must be >= 0.
+   * CasualtiesNum and DeadNum can be empty.
+   * DtAvalancheTime must be set.
+   */
   isValid() {
     this.showWarning = true;
-    return !!this.avalancheObs.DtAvalancheTime;
+
+    const {
+      InvolvedNum: antallInvolvert,
+      CasualtiesNum: antallSkadet,
+      DeadNum: antallDode
+    } = this.incident;
+
+    let isInvolvedValid = true, isCasualtiesValid = true, isDeadValid = true;
+
+    if (antallInvolvert) {
+      isInvolvedValid = antallInvolvert >= 0;
+      isCasualtiesValid = antallSkadet === undefined || antallSkadet <= antallInvolvert;
+      isDeadValid = antallDode === undefined || antallDode <= antallSkadet;
+    }
+
+    return !!this.avalancheObs.DtAvalancheTime && isInvolvedValid && isCasualtiesValid && isDeadValid;
+
   }
 
   async isEmpty(): Promise<boolean> {

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -60,6 +60,10 @@ export class AvalancheObsPage extends BasePage {
   showWarning = false;
   maxDate: string;
 
+  isInvolvedValid = true;
+  isCasualtiesValid = true;
+  isDeadValid = true;
+
   get avalancheObs(): AvalancheObsEditModel {
     return this.draft.registration.AvalancheObs;
   }
@@ -129,15 +133,13 @@ export class AvalancheObsPage extends BasePage {
       DeadNum: antallDode
     } = this.incident;
 
-    let isInvolvedValid = true, isCasualtiesValid = true, isDeadValid = true;
-
     if (antallInvolvert) {
-      isInvolvedValid = antallInvolvert >= 0;
-      isCasualtiesValid = antallSkadet === undefined || antallSkadet <= antallInvolvert;
-      isDeadValid = antallDode === undefined || antallDode <= antallSkadet;
+      this.isInvolvedValid = antallInvolvert >= 0;
+      this.isCasualtiesValid = antallSkadet === undefined || antallSkadet <= antallInvolvert;
+      this.isDeadValid = antallDode === undefined || antallDode <= antallSkadet;
     }
 
-    return !!this.avalancheObs.DtAvalancheTime && isInvolvedValid && isCasualtiesValid && isDeadValid;
+    return !!this.avalancheObs.DtAvalancheTime && this.isInvolvedValid && this.isCasualtiesValid && this.isDeadValid;
 
   }
 

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -125,16 +125,19 @@ export class AvalancheObsPage extends BasePage {
     this.onHarmedChange();
   }
 
-  //Så den beste sjekken er at summen av døde og skadete ikke må overstige antall involverte eller antall skredtatte.
   onHarmedChange(){
-    if (
-      (this.incident.InvolvedNum == undefined && this.incident.HarmedNum > 0)
-      || (this.incident.HarmedNum > this.incident.InvolvedNum))
+    if
+    ((isNaN(this.incident.CasualtiesNum)
+    && isNaN(this.incident.DeadNum)
+    && (this.incident.HarmedNum > this.incident.InvolvedNum))
+    || (isNaN(this.incident.DeadNum)
+    && (this.incident.HarmedNum > this.incident.InvolvedNum)))
     {
       this.isHarmedValid = false;
     }
-    else if((this.incident.DeadNum > 0
-      && (this.incident.DeadNum + this.incident.HarmedNum) > this.incident.CasualtiesNum)){
+    else if((!isNaN(this.incident.DeadNum)
+      && ((this.incident.DeadNum + this.incident.HarmedNum) > this.incident.CasualtiesNum
+        || (this.incident.DeadNum + this.incident.HarmedNum) > this.incident.InvolvedNum ))){
       this.isHarmedValid = false;
       this.isDeadValid = false;
       this.isErrorMessageHarmAndDead = true;
@@ -143,17 +146,8 @@ export class AvalancheObsPage extends BasePage {
       this.isHarmedValid = true;
       this.isErrorMessageHarmAndDead = false;
     }
-
   }
 
-  /**
-   * If InvolvedNum is set then:
-   * CasualtiesNum must be equal to or less than InvolvedNum.
-   * DeadNum must be equal to or less than CasualtiesNum.
-   * All numbers must be >= 0.
-   * CasualtiesNum and DeadNum can be empty.
-   * DtAvalancheTime must be set.
-   */
   isValid() {
     this.showWarning = true;
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -540,6 +540,8 @@
         "CASUALTIES_NUM_ERROR_MESSAGE": "Must be equal or smaller to the Number involved",
         "DEAD_NUM_ERROR_MESSAGE": "Must be equal or smaller than Number of casualties",
         "HARMED_NUM": "Number injured",
+        "HARMED_NUM_ERROR_MESSAGE": "Must be equal or smaller than number involved",
+        "HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE": "Sum of dead and injured must be equal or smaller than number casualties",
         "SAFETY_GEAR_TID": "Sender/receiver",
         "LOCAL_TOURIST_TID": "Local or visiting",
         "LOCAL_KNOWLEDGE_TID": "Knowledge of the area",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -414,8 +414,8 @@
       "INCIDENT": {
         "INVOLVED_NUM": "Number in the tour group",
         "CASUALTIES_NUM": "Number through the ice",
-        "CASUALTIES_NUM_ERROR_MESSAGE": "Must be equal or smaller than number in the tour group",
-        "DEAD_NUM_ERROR_MESSAGE": "Must be equal or smaller than number through the ice",
+        "CASUALTIES_NUM_ERROR_MESSAGE": "Cannot be greater than the number in the tour group",
+        "DEAD_NUM_ERROR_MESSAGE": "Cannot be greater than the number through the ice or the number in the tour group",
         "SAFETY_GEAR_TID": "Rescue equipment"
       }
     },
@@ -537,11 +537,11 @@
         "REMOTELY_TRIGGERED": "Remotely triggered",
         "INVOLVED_NUM": "Number involved",
         "CASUALTIES_NUM": "Number of casualties",
-        "CASUALTIES_NUM_ERROR_MESSAGE": "Must be equal or smaller to the Number involved",
-        "DEAD_NUM_ERROR_MESSAGE": "Must be equal or smaller than Number of casualties",
+        "CASUALTIES_NUM_ERROR_MESSAGE": "Cannot be greater than the number involved",
+        "DEAD_NUM_ERROR_MESSAGE": "Cannot be greater than the number of casualties or involved",
         "HARMED_NUM": "Number injured",
-        "HARMED_NUM_ERROR_MESSAGE": "Must be equal or smaller than number involved",
-        "HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE": "Sum of dead and injured must be equal or smaller than number casualties",
+        "HARMED_NUM_ERROR_MESSAGE": "Cannot be greater than the number involved",
+        "HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE": "Sum of dead and injured cannot be greater than the number casualties or involved",
         "SAFETY_GEAR_TID": "Sender/receiver",
         "LOCAL_TOURIST_TID": "Local or visiting",
         "LOCAL_KNOWLEDGE_TID": "Knowledge of the area",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -415,6 +415,8 @@
       "INCIDENT": {
         "INVOLVED_NUM": "Number in the tour group",
         "CASUALTIES_NUM": "Number through the ice",
+        "CASUALTIES_NUM_ERROR_MESSAGE": "Must be equal or smaller than number in the tour group",
+        "DEAD_NUM_ERROR_MESSAGE": "Must be equal or smaller than number through the ice",
         "SAFETY_GEAR_TID": "Rescue equipment"
       }
     },
@@ -536,6 +538,8 @@
         "REMOTELY_TRIGGERED": "Remotely triggered",
         "INVOLVED_NUM": "Number involved",
         "CASUALTIES_NUM": "Number of casualties",
+        "CASUALTIES_NUM_ERROR_MESSAGE": "Must be equal or smaller to the Number involved",
+        "DEAD_NUM_ERROR_MESSAGE": "Must be equal or smaller than Number of casualties",
         "HARMED_NUM": "Number injured",
         "SAFETY_GEAR_TID": "Sender/receiver",
         "LOCAL_TOURIST_TID": "Local or visiting",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -415,6 +415,8 @@
       "INCIDENT": {
         "INVOLVED_NUM": "Antall i turgruppa",
         "CASUALTIES_NUM": "Antall gjennom isen",
+        "CASUALTIES_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall i turgruppa",
+        "DEAD_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall gjennom isen",
         "SAFETY_GEAR_TID": "Redningsutstyr"
       }
     },
@@ -534,9 +536,12 @@
         "TRAJECTORY_NAME": "Skredbanenavn",
         "VALID_EXPOSITION": "Eksposisjon",
         "REMOTELY_TRIGGERED": "Fjernutløst",
-        "INVOLVED_NUM": "Antall involvert",
+        "INVOLVED_NUM": "Antall involverte",
         "CASUALTIES_NUM": "Antall skredtatte",
+        "CASUALTIES_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall involverte",
+        "DEAD_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall skredtatte",
         "HARMED_NUM": "Antall kun skadet",
+        "HARMED_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall involverte",
         "SAFETY_GEAR_TID": "Sender/mottaker",
         "LOCAL_TOURIST_TID": "Lokal eller tilreisende",
         "LOCAL_KNOWLEDGE_TID": "Kjennskap til området",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -414,8 +414,8 @@
       "INCIDENT": {
         "INVOLVED_NUM": "Antall i turgruppa",
         "CASUALTIES_NUM": "Antall gjennom isen",
-        "CASUALTIES_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall i turgruppa",
-        "DEAD_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall gjennom isen",
+        "CASUALTIES_NUM_ERROR_MESSAGE": "Kan ikke være flere enn antall i turgruppa",
+        "DEAD_NUM_ERROR_MESSAGE": "Kan ikke være flere enn antall gjennom isen eller antall i turgruppa",
         "SAFETY_GEAR_TID": "Redningsutstyr"
       }
     },
@@ -537,10 +537,11 @@
         "REMOTELY_TRIGGERED": "Fjernutløst",
         "INVOLVED_NUM": "Antall involverte",
         "CASUALTIES_NUM": "Antall skredtatte",
-        "CASUALTIES_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall involverte",
-        "DEAD_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall skredtatte",
+        "CASUALTIES_NUM_ERROR_MESSAGE": "Kan ikke være flere enn antall involverte",
+        "DEAD_NUM_ERROR_MESSAGE": "Kan ikke være flere enn antall skredtatte eller involverte",
         "HARMED_NUM": "Antall kun skadet",
-        "HARMED_NUM_ERROR_MESSAGE": "Må være lik eller mindre antall involverte",
+        "HARMED_NUM_ERROR_MESSAGE": "Kan ikke være flere enn antall involverte",
+        "HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE": "Sum antall døde og kun skadet kan ikke være flere enn antall skredtatte eller involverte",
         "SAFETY_GEAR_TID": "Sender/mottaker",
         "LOCAL_TOURIST_TID": "Lokal eller tilreisende",
         "LOCAL_KNOWLEDGE_TID": "Kjennskap til området",


### PR DESCRIPTION
Flyttet Trafikk hindret, antall evakuerte og materielle skader fra skredhendelse til ulykke/skade.

Implementerte følgende validering på disse feltene:
- [ ] Antall skredsatte må være mindre eller lik antall i gruppen
- [ ] Antall døde må være mindre eller lik antall skredsatte.
- [ ] Summen av døde og skadete ikke må overstige antall involverte eller antall skredtatte
- [ ] Tallene må være positive.

- [ ] Viser feilmelding (rød farge) på feltene når valideringen feiler.