### PR TITLE
added fast obs start via iskart

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -65,6 +65,10 @@ const routes: Routes = [
       import('./modules/login/user-information.module').then((m) => m.UserInformationModule)
   },
   {
+    path: 'start-registration/:geoHazard',
+    redirectTo: 'registration/new/:geoHazard'
+  },
+  {
     path: 'registration',
     loadChildren: () =>
       import('./modules/registration/registration.module').then(

--- a/src/app/modules/common-regobs-api/services/location.service.ts
+++ b/src/app/modules/common-regobs-api/services/location.service.ts
@@ -107,7 +107,6 @@ class LocationService extends __BaseService {
     let __params = this.newParams();
     let __headers = new HttpHeaders();
     let __body: any = null;
-
     if (params.langKey != null) __params = __params.set('langKey', params.langKey.toString());
     let req = new HttpRequest<any>(
       'GET',


### PR DESCRIPTION
Nå kan man starte ny observasjon via enten start-registration eller registration/new. 
URLen støtter også enten :lat/:long eller :locationId
GeoHazard kan nå også skrives som string ('Snow', 'Soil', etc) og koden støtter handling av case sensitivity. 
Metoden LocationGet ble ikke i bruk av andre komponentene så jeg endret returnert type til ObsLocationViewModel siden den var enklere å handle i obs-location.page.ts

Jeg fjernet også delay på popupene så at de vises med en gang