### PR TITLE
Forsøk på menneskevennlige flervalg-url-parametre

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -1,6 +1,5 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { ActivatedRoute, Router } from '@angular/router';
-import { firstValueFrom, Observable } from 'rxjs';
+import { firstValueFrom, Observable, of } from 'rxjs';
 import { GeoHazard, LangKey } from 'src/app/modules/common-core/models';
 import { IMapView } from 'src/app/modules/map/services/map/map-view.interface';
 import { MapService } from 'src/app/modules/map/services/map/map.service';
@@ -10,24 +9,23 @@ import { UserSettingService } from '../user-setting/user-setting.service';
 import { SearchCriteriaService } from './search-criteria.service';
 
 class TestMapService {
-  mapView: Observable<IMapView>;
+  mapView$: Observable<IMapView>;
 }
 
 describe('SearchCriteriaService', () => {
   let service: SearchCriteriaService;
   let userSettingService: UserSettingService;
   let mapService: TestMapService;
-  let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
     TestBed.configureTestingModule({});
 
     mapService = new TestMapService();
+    mapService.mapView$ = of({ bounds: undefined, center: undefined, zoom: undefined });
+
     userSettingService = new UserSettingService(null, null);
-    router = jasmine.createSpyObj('Router', ['navigate']);
 
     service = new SearchCriteriaService(
-      router,
       userSettingService,
       mapService as unknown as MapService,
       new TestLoggingService());
@@ -44,46 +42,48 @@ describe('SearchCriteriaService', () => {
     expect(service).toBeTruthy();
   });
 
-  //TODO: Få denne til å virke!
-  // it('filter should contain current language and geo hazard automatically', fakeAsync(async () => {
-  //   tick(1);
-  //   //check default criteria
-  //   const criteria = await firstValueFrom(service.searchCriteria$);
-  //   expect(criteria.LangKey).toEqual(LangKey.nn);
-  //   expect(criteria.SelectedGeoHazards).toEqual([GeoHazard.Soil, GeoHazard.Water]);
-  //   //TODO: Check URL for filter parameter
-
-  //   //verify that criteria changes when we change language and geo hazard
-  //   userSettingService.saveUserSettings({
-  //     ...await firstValueFrom(userSettingService.userSetting$),
-  //     language: LangKey.en,
-  //     currentGeoHazard: [GeoHazard.Ice]
-  //   });
-  //   tick(1);
-  //   const criteria2 = await firstValueFrom(service.searchCriteria$);
-  //   expect(criteria2.LangKey).toEqual(LangKey.en);
-  //   expect(criteria2.SelectedGeoHazards).toEqual([GeoHazard.Ice]);
-  // }));
-
-  it('obsTime filter should work', fakeAsync(async () => {
-    service.setObsTime('fromTime', 'toTime');
+  it('filter should contain current language and geo hazard automatically', fakeAsync(async () => {
     tick(1);
-
-    //check that current criteria contains expected obstime
+    //check default criteria
     const criteria = await firstValueFrom(service.searchCriteria$);
-    expect(criteria.FromDtObsTime).toEqual('fromTime');
-    expect(criteria.ToDtObsTime).toEqual('toTime');
-    //TODO: Check URL for filter parameter
+    expect(criteria.LangKey).toEqual(LangKey.nn);
+    expect(criteria.SelectedGeoHazards).toEqual([GeoHazard.Soil, GeoHazard.Water]);
+    const url = new URL(document.location.href);
+    expect(url.searchParams.get('hazard')).toEqual('20~60');
+
+    //verify that criteria changes when we change language and geo hazard
+    userSettingService.saveUserSettings({
+      ...await firstValueFrom(userSettingService.userSetting$),
+      language: LangKey.en,
+      currentGeoHazard: [GeoHazard.Ice]
+    });
+    tick(1);
+    const criteria2 = await firstValueFrom(service.searchCriteria$);
+    expect(criteria2.LangKey).toEqual(LangKey.en);
+    expect(criteria2.SelectedGeoHazards).toEqual([GeoHazard.Ice]);
+    const url2 = new URL(document.location.href);
+    expect(url2.searchParams.get('hazard')).toEqual('70');
   }));
 
   it('nick name filter should work', fakeAsync(async () => {
-    service.setObserverNickName('nick');
+    service.setObserverNickName('Nick');
     tick(1);
 
     //check that current criteria contains expected nick name
     const criteria = await firstValueFrom(service.searchCriteria$);
-    expect(criteria.ObserverNickName).toEqual('nick');
-    //TODO: Check URL for filter parameter
+    expect(criteria.ObserverNickName).toEqual('Nick');
+
+    //check that url contains nickname filter
+    const url = new URL(document.location.href);
+    expect(url.searchParams.get('nick')).toEqual('Nick');
+
+    //TODO: Sjekk at den kan lese kallenavn fra url og sette filter
+    // history.pushState(null, '', `${window.location.pathname}?nick=Nicky`);
+    // service.readUrlParams();
+    // tick(1);
+    // //check that current criteria contains expected nick name
+    // const criteria2 = await firstValueFrom(service.searchCriteria$);
+    // expect(criteria2.ObserverNickName).toEqual('Nicky');
   }));
 
 });

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -182,10 +182,6 @@ export class SearchCriteriaService {
     return null;
   }
 
-  setObsTime(fromTime: string, toTime: string) {
-    //TODO
-  }
-
   setObserverNickName(nickName: string) {
     this.searchCriteriaChanges.next({ ObserverNickName: nickName });
   }


### PR DESCRIPTION
Jeg fant hvilke skilletegn som ikke må url-enkodes og valgte "~" for å putte tabell-parametre i url.
Vi har valget mellom bindestrek, punktum, understrek og tilde, se https://www.rfc-editor.org/rfc/rfc3986#section-2.3

Har ingen sterke meninger om hvilket skilletegn vi velger. Bindestrek er jo enklere å skrive, men kan kanskje misforstås som "fra-til". Samme med punktum, som gjerne har spesiell betydning. Har også tenkt at punktum på sikt kanskje kan brukes for hierearkiske parametre, hvis vi f.eks. skal begynne å filtrere på enkeltfelter på skjema for å skille mellom skjematype og felt. Understrek  må gjerne brukes, men kan være litt vanskelig å se noen ganger.

Jeg har implementert dette for naturfare-filteret.
Da blir det altså hazard=20~60 i stedet for hazard=20&hazard=60.

Tenkte vi kunne bruke samme opplegg for observasjons/skjematype, men har ikke implementert noen funksjoner for dette search-criteria.service siden det kan gjøres av den som lager dette filteret.