### PR TITLE
RO-2061: Url skal vise kun dato når vi velger antall dager tilbake

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -1,6 +1,5 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import moment from 'moment';
-import 'moment-timezone';
 import { firstValueFrom, Observable, of } from 'rxjs';
 import { GeoHazard, LangKey } from 'src/app/modules/common-core/models';
 import { IMapView } from 'src/app/modules/map/services/map/map-view.interface';
@@ -73,15 +72,16 @@ describe('SearchCriteriaService', () => {
   }));
 
   it('default days-back filter should work', fakeAsync(async () => {
-    //    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
-    jasmine.clock().mockDate(new Date('2000-12-24T08:00:00+01:00'));
-    // const offset = new Date().getTimezoneOffset();
-    // const expectedFromTime2 = moment(new Date('2000-12-24 00:00:00.000')).add(offset, 'm');
-    // const expectedFromTime = moment(new Date('2000-12-24 00:00:00.000')).toISOString();
+    jasmine.clock().mockDate(new Date('2000-12-24T08:00:00+01:00')); //norwegian time
+    const offset = new Date().getTimezoneOffset();
+    console.log('=======> offset = ' + offset);
+    const expectedFromTime = moment(new Date('2000-12-21 00:00:00.000')).toISOString();
+    console.log('=======> expectedFromTime = ' + expectedFromTime);
+    console.log('=====> moment = ' + moment().toISOString());
 
     //check that criteria contains from time. Should be 3 days earlier minus 1 hour because UTC is one hour after us
     const criteria = await firstValueFrom(service.searchCriteria$);
-    expect(criteria.FromDtObsTime).toEqual('2000-12-20T23:00:00.000Z');
+    expect(criteria.FromDtObsTime).toEqual(expectedFromTime);
 
     //check fromDate parameter in url. Should be 3 days earlier based on local time
     const url = new URL(document.location.href);

--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -1,4 +1,6 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import moment from 'moment';
+import 'moment-timezone';
 import { firstValueFrom, Observable, of } from 'rxjs';
 import { GeoHazard, LangKey } from 'src/app/modules/common-core/models';
 import { IMapView } from 'src/app/modules/map/services/map/map-view.interface';
@@ -71,7 +73,11 @@ describe('SearchCriteriaService', () => {
   }));
 
   it('default days-back filter should work', fakeAsync(async () => {
-    jasmine.clock().mockDate(new Date('2000-12-24'));
+    //    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
+    jasmine.clock().mockDate(new Date('2000-12-24T08:00:00+01:00'));
+    // const offset = new Date().getTimezoneOffset();
+    // const expectedFromTime2 = moment(new Date('2000-12-24 00:00:00.000')).add(offset, 'm');
+    // const expectedFromTime = moment(new Date('2000-12-24 00:00:00.000')).toISOString();
 
     //check that criteria contains from time. Should be 3 days earlier minus 1 hour because UTC is one hour after us
     const criteria = await firstValueFrom(service.searchCriteria$);

--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -73,13 +73,10 @@ describe('SearchCriteriaService', () => {
 
   it('default days-back filter should work', fakeAsync(async () => {
     jasmine.clock().mockDate(new Date('2000-12-24T08:00:00+01:00')); //norwegian time
-    const offset = new Date().getTimezoneOffset();
-    console.log('=======> offset = ' + offset);
     const expectedFromTime = moment(new Date('2000-12-21 00:00:00.000')).toISOString();
-    console.log('=======> expectedFromTime = ' + expectedFromTime);
-    console.log('=====> moment = ' + moment().toISOString());
 
-    //check that criteria contains from time. Should be 3 days earlier minus 1 hour because UTC is one hour after us
+    //check that criteria contains correct from time. Should be 3 days earlier at midnight
+    //we must also adjust for time zone because search criteria is in UTC and 1 or 2 hour(s) earlier than norwegian time
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.FromDtObsTime).toEqual(expectedFromTime);
 

--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -36,6 +36,11 @@ describe('SearchCriteriaService', () => {
       currentGeoHazard: [GeoHazard.Soil, GeoHazard.Water]
     });
 
+    jasmine.clock().install();
+  });
+
+  afterEach(function() {
+    jasmine.clock().uninstall();
   });
 
   it('should be created', () => {
@@ -65,6 +70,18 @@ describe('SearchCriteriaService', () => {
     expect(url2.searchParams.get('hazard')).toEqual('70');
   }));
 
+  it('default days-back filter should work', fakeAsync(async () => {
+    jasmine.clock().mockDate(new Date('2000-12-24'));
+
+    //check that criteria contains from time. Should be 3 days earlier minus 1 hour because UTC is one hour after us
+    const criteria = await firstValueFrom(service.searchCriteria$);
+    expect(criteria.FromDtObsTime).toEqual('2000-12-20T23:00:00.000Z');
+
+    //check fromDate parameter in url. Should be 3 days earlier based on local time
+    const url = new URL(document.location.href);
+    expect(url.searchParams.get('fromDate')).toEqual('2000-12-21');
+  }));
+
   it('nick name filter should work', fakeAsync(async () => {
     service.setObserverNickName('Nick');
     tick(1);
@@ -76,14 +93,6 @@ describe('SearchCriteriaService', () => {
     //check that url contains nickname filter
     const url = new URL(document.location.href);
     expect(url.searchParams.get('nick')).toEqual('Nick');
-
-    //TODO: Sjekk at den kan lese kallenavn fra url og sette filter
-    // history.pushState(null, '', `${window.location.pathname}?nick=Nicky`);
-    // service.readUrlParams();
-    // tick(1);
-    // //check that current criteria contains expected nick name
-    // const criteria2 = await firstValueFrom(service.searchCriteria$);
-    // expect(criteria2.ObserverNickName).toEqual('Nicky');
   }));
 
 });

--- a/src/app/core/services/search-criteria/url-params.ts
+++ b/src/app/core/services/search-criteria/url-params.ts
@@ -6,13 +6,17 @@ export class UrlParams {
 
   private params = new URLSearchParams(document.location.search);
 
+  /**
+   * Add a query parameter and a value
+   * @param key parameter name
+   * @param value if value is null, the parameter will be deleted from the url
+   */
   set(key: string, value: unknown): UrlParams {
     if (value) {
       if (Array.isArray(value)) {
         this.params.delete(key);
         value.forEach(v =>  this.params.append(key, '' + v));
       } else {
-        //TODO: Handle datetime. Maybe only show yy-MM-dd if time is 00:00 to make url simpler?
         this.params.set(key, '' + value);
       }
     } else {


### PR DESCRIPTION
...i stedet for full ISO-dato/tid.

Eksempel på fra-tid-parameter før:
`fromTime=2022-11-15T23%3A00%3A00.000Z`

Nå ser den sånn ut:
`fromDate=2022-11-16`

Regobs-API'et krever fortsatt full ISO-dato-tid, så vi må konvertere mellom URL og SearchCriteria.