### PR TITLE
Bugfix/competence filter automatic stations

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -230,6 +230,8 @@ export class SearchCriteriaService {
     const type = url.searchParams.get(URL_PARAM_TYPE);
     const convertTypeFromUrlToCriteria = type != null ? this.convertRegTypeFromUrlToDto(type) : null;
 
+    //I recommend to add spread operator on optional properties so that we dont send 'null' values to API.
+    //example: ...(nickName && {ObserverCompetence: nickname})
     const criteria = {
       SelectedGeoHazards: geoHazards,
       FromDtObsTime: fromObsTime,
@@ -321,21 +323,6 @@ export class SearchCriteriaService {
       return compArr;
     }, [] as number[]);
     this.searchCriteriaChanges.next({ ObserverCompetence: removedDuplicates });
-  }
-
-  async addAutomaticStationFilter(automaticStationToAdd: number[]) {
-    const { ObserverCompetence: existingCompetence } = await firstValueFrom(this.searchCriteria$);
-    if (existingCompetence) {
-      this.setCompetence([...existingCompetence, ...automaticStationToAdd]);
-    }
-  }
-
-  async removeAutomaticStationFilter(automaticStationToRemove: number[]) {
-    const { ObserverCompetence: existingCompetence } = await firstValueFrom(this.searchCriteria$);
-    if (existingCompetence) {
-      const newCompetence = existingCompetence.filter((c) => automaticStationToRemove.indexOf(c) === -1);
-      this.searchCriteriaChanges.next({ ObserverCompetence: newCompetence });
-    }
   }
 
   async setObservationType(newType: RegistrationTypeCriteriaDto) {

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -507,7 +507,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private updateMapView() {
-    if (this.map && this.isActive.value) {
+    if (this.map) {
       this.mapService.updateMapView({
         bounds: this.map.getBounds(),
         center: this.map.getCenter(),

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -507,7 +507,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private updateMapView() {
-    if (this.map) {
+    if (this.map && this.isActive.value) {
       this.mapService.updateMapView({
         bounds: this.map.getBounds(),
         center: this.map.getCenter(),

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -4,83 +4,77 @@
   </ion-list-header>
   <app-observations-days-back></app-observations-days-back>
   <app-update-observations></app-update-observations>
-  <div *ngIf="true">
-    <!-- Dette er på prototypestadiet, så vi skjuler dette foreløpig -->
-    <!-- TODO: Oversettelser på all tekst -->
-    <ion-list-header color="varsom-blue" class="ion-no-margin">
-      <ion-label> Observasjonstype </ion-label>
-    </ion-list-header>
+  <ion-list-header color="varsom-blue" class="ion-no-margin">
+    <ion-label> Observasjonstype </ion-label>
+  </ion-list-header>
 
-    <ion-item *ngIf="observationTypesOptions">
-      <ion-list lines="none">
-        <ng-container *ngFor="let type of observationTypesOptions">
-          <ion-item class="item-height">
-            <ion-checkbox
-              [(ngModel)]="type.isChecked"
-              (ionChange)="setNewType($event, type.parentId, type.id)"
-              color="varsom-dark-blue"
-            >
-            </ion-checkbox>
-            <ion-label class="ion-padding-start">{{ type.name }}</ion-label>
-          </ion-item>
-        </ng-container>
-      </ion-list>
-    </ion-item>
+  <ion-item *ngIf="observationTypesOptions">
+    <ion-list lines="none">
+      <ng-container *ngFor="let type of observationTypesOptions">
+        <ion-item class="item-height">
+          <ion-checkbox
+            [(ngModel)]="type.isChecked"
+            (ionChange)="setNewType($event, type.parentId, type.id)"
+            color="varsom-dark-blue"
+          >
+          </ion-checkbox>
+          <ion-label class="ion-padding-start">{{ type.name }}</ion-label>
+        </ion-item>
+      </ng-container>
+    </ion-list>
+  </ion-item>
 
-    <ion-list-header color="varsom-blue" class="ion-no-margin">
-      <ion-label>
-        {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.TITLE" | translate }}
-      </ion-label>
-    </ion-list-header>
-    <!-- TODO: Legg til eller hente kompetanser i menyen. Husk at på snø er det en spesiell kompetanse A -->
-    <ion-item *ngIf="competenceOptions">
-      <ion-label class="no-margin-bottom" color="dark" position="stacked">{{
-        "OBSERVATION_FILTER.COMPETANCE_FILTER.LABEL" | translate
-      }}</ion-label>
-      <ion-select [interface]="popupType" [value]="chosenValue" (ionChange)="onSelectCompetenceChange($event)">
-        <ion-select-option value="all">{{ "OBSERVATION_FILTER.COMPETANCE_FILTER.ALL" | translate }}</ion-select-option>
-        <ion-select-option *ngFor="let co of competenceOptions" [value]="co">
-          {{ co.name }}
-        </ion-select-option>
-      </ion-select>
-    </ion-item>
-    <ion-item *ngIf="isShowAutomaticStation">
-      <ion-checkbox
-        [checked]="isAutomaticStationChecked"
-        color="varsom-dark-blue"
-        mode="md"
-        [value]="automaticStation"
-        (ionChange)="onCheckAutomaticStations($event)"
-      >
-      </ion-checkbox>
-      <ion-label class="ion-padding-start"
-        >{{ "OBSERVATION_FILTER.COMPETANCE_FILTER.AUTOMATIC_STATIONS" | translate }}
-      </ion-label>
-    </ion-item>
+  <ion-list-header color="varsom-blue" class="ion-no-margin">
+    <ion-label>
+      {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.TITLE" | translate }}
+    </ion-label>
+  </ion-list-header>
+  <!-- TODO: Legg til eller hente kompetanser i menyen. Husk at på snø er det en spesiell kompetanse A -->
+  <ion-item *ngIf="competenceOptions">
+    <ion-label class="no-margin-bottom" color="dark" position="stacked">{{
+      "OBSERVATION_FILTER.COMPETANCE_FILTER.LABEL" | translate
+    }}</ion-label>
+    <ion-select [interface]="popupType" [value]="chosenCompetenceValue" (ionChange)="onSelectCompetenceChange($event)">
+      <ion-select-option *ngFor="let co of competenceOptions" [value]="co">
+        {{ co.name }}
+      </ion-select-option>
+    </ion-select>
+  </ion-item>
+  <ion-item *ngIf="isShowAutomaticStation">
+    <ion-checkbox
+      [checked]="isAutomaticStationChecked"
+      color="varsom-dark-blue"
+      mode="md"
+      [value]="automaticStation"
+      (ionChange)="onCheckAutomaticStations($event)"
+    >
+    </ion-checkbox>
+    <ion-label class="ion-padding-start"
+      >{{ "OBSERVATION_FILTER.COMPETANCE_FILTER.AUTOMATIC_STATIONS" | translate }}
+    </ion-label>
+  </ion-item>
 
-    <!-- TODO: Finne ut hvordan vi implementerer navnesøk - aynskront eller med søkeknapp? -->
-    <!--
-    <ion-item>
-      <ion-label class="no-margin-bottom" color="dark" position="stacked">Søk</ion-label>
-      <ion-searchbar
-        [value]="nickName"
-        [debounce]="1000"
-        mode="ios"
-        class="ion-no-padding"
-        placeholder="Søk på observatørnavn"
-        (ionChange)="setNickName($event.target.value)"
-        (ionClear)="setNickName(null)"
-      >
-      </ion-searchbar>
-    </ion-item>
-    -->
-    <!-- TODO: Implementere reset filter funksjonalitet -->
-    <!--
-    <ion-item>
-      <ion-button class="resetFiltersButton" type="button" fill="clear">
-        <ion-icon src="./assets/icon/reset-button.svg"> </ion-icon>Tilbakestill filtere
-      </ion-button>
-    </ion-item>
-    -->
-  </div>
+  <!-- TODO: Finne ut hvordan vi implementerer navnesøk - aynskront eller med søkeknapp? -->
+  <!--
+  <ion-item>
+    <ion-label class="no-margin-bottom" color="dark" position="stacked">Søk</ion-label>
+    <ion-searchbar
+      [value]="nickName"
+      [debounce]="1000"
+      mode="ios"
+      class="ion-no-padding"
+      placeholder="Søk på observatørnavn"
+      (ionChange)="setNickName($event.value.target)"
+    >
+    </ion-searchbar>
+  </ion-item>
+-->
+  <!-- TODO: Implementere reset filter funksjonalitet -->
+  <!--
+  <ion-item>
+    <ion-button class="resetFiltersButton" type="button" fill="clear">
+      <ion-icon src="./assets/icon/reset-button.svg"> </ion-icon>Tilbakestill filtere
+    </ion-button>
+  </ion-item>
+  -->
 </ion-list>

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -29,7 +29,6 @@
       {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.TITLE" | translate }}
     </ion-label>
   </ion-list-header>
-  <!-- TODO: Legg til eller hente kompetanser i menyen. Husk at på snø er det en spesiell kompetanse A -->
   <ion-item *ngIf="competenceOptions">
     <ion-label class="no-margin-bottom" color="dark" position="stacked">{{
       "OBSERVATION_FILTER.COMPETANCE_FILTER.LABEL" | translate

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -5,7 +5,7 @@
   <app-observations-days-back></app-observations-days-back>
   <app-update-observations></app-update-observations>
   <ion-list-header color="varsom-blue" class="ion-no-margin">
-    <ion-label> Observasjonstype </ion-label>
+    <ion-label> {{ "OBSERVATION_FILTER.OBSERVATION_TYPE_FILTER.TITLE" | translate }} </ion-label>
   </ion-list-header>
 
   <ion-item *ngIf="observationTypesOptions">

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -68,7 +68,8 @@
         mode="ios"
         class="ion-no-padding"
         placeholder="Søk på observatørnavn"
-        (ionChange)="setNickName($event)"
+        (ionChange)="setNickName($event.target.value)"
+        (ionClear)="setNickName(null)"
       >
       </ion-searchbar>
     </ion-item>

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -295,10 +295,9 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     else this.searchCriteriaService.removeObservationType(obsType);
   }
 
-  setNickName(event) {
-    const nickName = event.target.value?.toLowerCase();
-    if (nickName) {
-      this.searchCriteriaService.setObserverNickName(nickName);
-    }
+  setNickName(value) {
+    let nickName;
+    value != null ? (nickName = value.toLowerCase()) : null;
+    this.searchCriteriaService.setObserverNickName(nickName);
   }
 }

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -223,6 +223,9 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     const ids = event.detail.value.ids;
     if (this.isAutomaticStationChecked && event.detail.value.name === 'All') {
       this.searchCriteriaService.setCompetence(null);
+    } else if (this.isAutomaticStationChecked) {
+      ids.push(105);
+      this.searchCriteriaService.setCompetence(ids);
     } else {
       this.searchCriteriaService.setCompetence(ids);
     }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -219,8 +219,11 @@
   },
   "OBSERVATION_FILTER": {
     "TITLE": "Observation filter",
+    "OBSERVATION_TYPE_FILTER": {
+      "TITLE": "Observation type"
+    },
     "COMPETANCE_FILTER": {
-      "TITLE": "Observator",
+      "TITLE": "Observer",
       "LABEL": "Competence",
       "ALL": "All",
       "AUTOMATIC_STATIONS": "Automatic stations"

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -219,6 +219,9 @@
   },
   "OBSERVATION_FILTER": {
     "TITLE": "Observasjonsfilter",
+    "OBSERVATION_TYPE_FILTER": {
+      "TITLE": "Observasjonstype"
+    },
     "COMPETANCE_FILTER": {
       "TITLE": "Observatør",
       "LABEL": "Kompetanse",


### PR DESCRIPTION
vi dropper ukjente kompetanser og bruker 'alle' istedenfor. nå funker checkbox på automatiske stasjoner som den burde, altså når alle kompetanser er valgt i dropdownen og automatiske stasjoner er avsjekket så filtrerer appen på alle kompetanser bortsett fra automatiske stasjoner (id: 105)