### PR TITLE
Show url query params on map, observation list and warning list only

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -59,6 +59,7 @@ describe('SearchCriteriaService', () => {
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.LangKey).toEqual(LangKey.nb);
     expect(criteria.SelectedGeoHazards).toEqual([GeoHazard.Snow]);
+    await service.applyQueryParams();
     const url = new URL(document.location.href);
     expect(url.searchParams.get('hazard')).toEqual('10');
 
@@ -72,6 +73,7 @@ describe('SearchCriteriaService', () => {
     const criteria2 = await firstValueFrom(service.searchCriteria$);
     expect(criteria2.LangKey).toEqual(LangKey.en);
     expect(criteria2.SelectedGeoHazards).toEqual([GeoHazard.Soil, GeoHazard.Water]);
+    await service.applyQueryParams();
     const url2 = new URL(document.location.href);
     expect(url2.searchParams.get('hazard')).toEqual('20~60');
   }));
@@ -84,7 +86,7 @@ describe('SearchCriteriaService', () => {
     //we must also adjust for time zone because search criteria is in UTC and 1 or 2 hour(s) earlier than norwegian time
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.FromDtObsTime).toEqual(expectedFromTime);
-
+    await service.applyQueryParams();
     //check fromDate parameter in url. Should be 2 days earlier based on local time
     const url = new URL(document.location.href);
     expect(url.searchParams.get('fromDate')).toEqual('2000-12-22');
@@ -97,7 +99,7 @@ describe('SearchCriteriaService', () => {
     //check that current criteria contains expected nick name
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.ObserverNickName).toEqual('Nick');
-
+    await service.applyQueryParams();
     //check that url contains nickname filter
     const url = new URL(document.location.href);
     expect(url.searchParams.get('nick')).toEqual('Nick');
@@ -109,6 +111,7 @@ describe('SearchCriteriaService', () => {
 
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.ObserverCompetence).toEqual([150, 105]);
+    await service.applyQueryParams();
     const url = new URL(document.location.href);
     expect(url.searchParams.get('competence')).toEqual('150~105');
   }));
@@ -120,7 +123,7 @@ describe('SearchCriteriaService', () => {
     //check that current criteria contains expected type
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.SelectedRegistrationTypes).toEqual([obsType]);
-
+    await service.applyQueryParams();
     const url = new URL(document.location.href);
     expect(url.searchParams.get('type')).toEqual('81.13');
   }));
@@ -133,7 +136,7 @@ describe('SearchCriteriaService', () => {
     //check that criteria contains only obsType2
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.SelectedRegistrationTypes).toEqual([{ Id: 81, SubTypes: [13] }]);
-
+    await service.applyQueryParams();
     const url = new URL(document.location.href);
     expect(url.searchParams.get('type')).toEqual('81.13');
   }));
@@ -145,7 +148,7 @@ describe('SearchCriteriaService', () => {
     await service.removeObservationType(obsType2);
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.SelectedRegistrationTypes).toEqual([{ Id: 81, SubTypes: [13, 26] }]);
-
+    await service.applyQueryParams();
     const url = new URL(document.location.href);
     expect(url.searchParams.get('type')).toEqual('81.13~81.26');
   }));
@@ -155,7 +158,7 @@ describe('SearchCriteriaService', () => {
     await service.removeObservationType(obsType2);
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.SelectedRegistrationTypes).toEqual(null);
-
+    await service.applyQueryParams();
     const url = new URL(document.location.href);
     expect(url.searchParams.get('type')).toEqual(null);
   }));
@@ -167,6 +170,7 @@ describe('SearchCriteriaService', () => {
       //check that current criteria contains expected orderBy
       const criteria = await firstValueFrom(service.searchCriteria$);
       expect(criteria.OrderBy).toEqual(test.apiValue);
+      await service.applyQueryParams();
       const url = new URL(document.location.href);
       expect(url.searchParams.get('orderBy')).toEqual(test.urlValue);
     }));
@@ -238,9 +242,7 @@ describe('SearchCriteriaService url parsing', () => {
     );
     tick();
     const criteria = await firstValueFrom(service.searchCriteria$);
-    const url = new URL(document.location.href).toString();
     expect(criteria.ObserverCompetence).toEqual(undefined);
-    expect(url.includes('competence')).toBeFalse();
   }));
 
   it('nick name url filter should work', fakeAsync(async () => {
@@ -274,7 +276,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   wrongObservationTypeUrl.forEach((test) => {
-    it('type url wrong format, remove type param from url', fakeAsync(async () => {
+    it('type url wrong format, set undefined in criteria', fakeAsync(async () => {
       new UrlParams().set('type', test).apply();
       service = new SearchCriteriaService(
         userSettingService,
@@ -284,9 +286,7 @@ describe('SearchCriteriaService url parsing', () => {
 
       tick();
       const criteria = await firstValueFrom(service.searchCriteria$);
-      const url = new URL(document.location.href).toString();
       expect(criteria.SelectedRegistrationTypes).toEqual(undefined);
-      expect(url.includes('type')).toBeFalse();
     }));
   });
 

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -215,9 +215,7 @@ export class SearchCriteriaService {
 
       // Hver gang vi får nye søkekriterier, sett url-parametere. NB - fint å bruke shareReplay sammen med denne
       // siden dette er en bi-effekt det er unødvendig å kjøre flere ganger.
-      tap((newCriteria) => {
-        this.setUrlParams(newCriteria);
-      }),
+
       // Jeg tror vi trenger en shareReplay her for at de som subscriber sent
       // skal få alle søkekriteriene når vi bruker scan, men er ikke sikker.
       // Uansett kjekt med en shareReplay her, se kommentar over.
@@ -288,6 +286,8 @@ export class SearchCriteriaService {
     currentCriteria && this.setUrlParams(currentCriteria);
   }
 
+  //looks like those params are set regardless if the starting page needs to show them or not. We dont need
+  //params on settings or my-observations
   private setUrlParams(criteria: SearchCriteriaRequestDto) {
     const params = new UrlParams();
     params.set(URL_PARAM_GEOHAZARD, numberArrayToSeparatedString(criteria.SelectedGeoHazards));

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -286,8 +286,6 @@ export class SearchCriteriaService {
     currentCriteria && this.setUrlParams(currentCriteria);
   }
 
-  //looks like those params are set regardless if the starting page needs to show them or not. We dont need
-  //params on settings or my-observations
   private setUrlParams(criteria: SearchCriteriaRequestDto) {
     const params = new UrlParams();
     params.set(URL_PARAM_GEOHAZARD, numberArrayToSeparatedString(criteria.SelectedGeoHazards));

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -212,13 +212,6 @@ export class SearchCriteriaService {
         ToDtObsTime: null,
         Extent: extent,
       })),
-
-      // Hver gang vi får nye søkekriterier, sett url-parametere. NB - fint å bruke shareReplay sammen med denne
-      // siden dette er en bi-effekt det er unødvendig å kjøre flere ganger.
-
-      // Jeg tror vi trenger en shareReplay her for at de som subscriber sent
-      // skal få alle søkekriteriene når vi bruker scan, men er ikke sikker.
-      // Uansett kjekt med en shareReplay her, se kommentar over.
       tap((currentCriteria) => this.logger.debug('Current combined criteria', DEBUG_TAG, currentCriteria)),
       shareReplay(1)
     );

--- a/src/app/pages/tabs/tabs.page.ts
+++ b/src/app/pages/tabs/tabs.page.ts
@@ -1,6 +1,6 @@
 import { Component, NgZone, OnDestroy, OnInit } from '@angular/core';
 import { Platform } from '@ionic/angular';
-import { Observable, Subscription } from 'rxjs';
+import { combineLatest, Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { FullscreenService } from '../../core/services/fullscreen/fullscreen.service';
 import { UserSettingService } from '../../core/services/user-setting/user-setting.service';
@@ -55,11 +55,13 @@ export class TabsPage implements OnInit, OnDestroy {
     this.isAndroid = this.platform.is('android');
     this.fullscreen$ = this.fullscreenService.isFullscreen$;
     this.selectedTab$ = this.tabsService.selectedTab$;
-    this.tabsService.selectedTab$.subscribe((tab) => this.applyCurrentQueryParams(tab));
+    combineLatest([this.searchCriteriaService.searchCriteria$, this.tabsService.selectedTab$]).subscribe(([_, tab]) =>
+      this.applyCurrentQueryParams(tab)
+    );
   }
 
   private applyCurrentQueryParams(path: string) {
-    if (path == TABS.HOME || path == TABS.OBSERVATION_LIST || path == TABS.WARNING_LIST) {
+    if (path === TABS.HOME || path == TABS.OBSERVATION_LIST || path == TABS.WARNING_LIST) {
       this.searchCriteriaService.applyQueryParams();
     }
   }

--- a/src/app/pages/tabs/tabs.page.ts
+++ b/src/app/pages/tabs/tabs.page.ts
@@ -61,7 +61,7 @@ export class TabsPage implements OnInit, OnDestroy {
   }
 
   private applyCurrentQueryParams(path: string) {
-    if (path === TABS.HOME || path == TABS.OBSERVATION_LIST || path == TABS.WARNING_LIST) {
+    if (path == TABS.HOME || path == TABS.OBSERVATION_LIST || path == TABS.WARNING_LIST) {
       this.searchCriteriaService.applyQueryParams();
     }
   }

--- a/src/app/pages/tabs/tabs.service.ts
+++ b/src/app/pages/tabs/tabs.service.ts
@@ -29,12 +29,13 @@ export class TabsService {
   }
 
   private parseTabFromPath(path: string) {
-    if (path.indexOf(TABS.OBSERVATION_LIST) > -1) {
+    const cleanPath = path.includes('?') ? path.slice(0, path.indexOf('?')) : path;
+    if (cleanPath.indexOf(TABS.OBSERVATION_LIST) > -1) {
       return TABS.OBSERVATION_LIST;
-    }
-    if (path.indexOf(TABS.WARNING_LIST) > -1) {
+    } else if (cleanPath.indexOf(TABS.WARNING_LIST) > -1) {
       return TABS.WARNING_LIST;
+    } else if (cleanPath === '') {
+      return TABS.HOME;
     }
-    return TABS.HOME;
   }
 }


### PR DESCRIPTION
Ser ut params ble satt i urlen uansett om man trenger det eller ikke. Start appen med myobservastions eller ny registrering side. der trenger vi ikke params. siden params skal vises bare mellom tabber sletta jeg setParams i searchCriteria$ siden den kjørte alltid når appen startet (derfor viste params seg på myobservations side for eksempel), og abonnerer på searchCriteria i tab.page istedenfor. der sjekker vi om en tab vi trenger params til å vise er på, og kjører setParams derfra med applyCurrentQueryParams.

måtte også rydde pathen fordi hvis man startet siden med urlen som /my-observations returnerte parseTabFromPath 'home' og derfor ble også params satt hvis man åpnet 'my observations' fra meny fanen.