### PR TITLE
RO-2113: Fiks av kræsj når vi setter retningspil på "GPS-markør"

### DIFF
--- a/src/app/core/helpers/leaflet/user-marker/user-marker.ts
+++ b/src/app/core/helpers/leaflet/user-marker/user-marker.ts
@@ -57,10 +57,12 @@ export class UserMarker {
   }
 
   setHeading(degrees: number) {
-    const element: HTMLElement = this.userMarker.getElement().childNodes[0] as HTMLElement;
-    const rotateZ = degrees - 90;
-    element.style['-webkit-transform'] = 'rotate(' + rotateZ + 'deg) translateX(15px)';
-    element.style.display = 'block';
+    const element: HTMLElement = this.userMarker?.getElement()?.childNodes[0] as HTMLElement;
+    if (element) {
+      const rotateZ = degrees - 90;
+      element.style['-webkit-transform'] = 'rotate(' + rotateZ + 'deg) translateX(15px)';
+      element.style.display = 'block';
+    }
   }
 
   private setAccuracy(position: Position) {


### PR DESCRIPTION
Av en eller annen grunn mister vi html-elementet til userMarker etter vi har sendt inn observasjon, og da røyk vi på en nullpointer-exception når vi setter retningspila på GPS-markøren.
Har ikke undersøkt hvorfor vi mister html-elementet. Det kan jo ha noe med at vi viser observassjonskort etter vi sender inn, og at user-marker brukes der. Men dette var en enkel fiks for å unngå kræsj i hvert fall.
Har bare sett feilen på Android, men tipper den skjer på iPhone også. På web har vi ikke kompassretning.