### PR TITLE
RO-2056/At-a-glance - hente observasjon m/bilder på web

### DIFF
--- a/src/app/components/map-item-bar/map-item-bar.component.html
+++ b/src/app/components/map-item-bar/map-item-bar.component.html
@@ -1,13 +1,15 @@
 <div class="map-item-bar" (click)="navigateToItem()" *ngIf="visible">
   <ion-grid class="ion-text-wrap">
     <ion-row class="ion-justify-content-center ion-nowrap">
-      <ion-col *ngIf="showImage" size="auto">
+      <ion-col *ngIf="firstAttachmentUrl" size="auto">
         <div class="image">
-          <img [src]="firstAttachment" (error)="handleMissingImage()" />
-          <span *ngIf="attachmentsCount" class="image-count">+{{ attachmentsCount }}</span>
+          <img [src]="firstAttachmentUrl" (error)="handleMissingImage()" />
+          <span *ngIf="additionaAttachmentCount && showAdditionalAttachmentCount" class="image-count"
+            >+{{ additionaAttachmentCount }}</span
+          >
         </div>
       </ion-col>
-      <ion-col size="auto" [ngClass]="showImage ? 'image-show' : 'image-show-not'">
+      <ion-col size="auto" [ngClass]="firstAttachmentUrl ? 'image-show' : 'image-show-not'">
         <ion-row>
           <ion-col>
             <div class="card-icon-item">

--- a/src/app/components/map-item-bar/map-item-bar.component.html
+++ b/src/app/components/map-item-bar/map-item-bar.component.html
@@ -1,52 +1,63 @@
 <div class="map-item-bar" (click)="navigateToItem()" *ngIf="visible">
   <ion-grid class="ion-text-wrap">
-    <ion-row>
-      <ion-col>
-        <div class="card-icon-item">
-          <svg-icon
-            class="card-icon-item-icon"
-            src="/assets/icon/time.svg"
-            [svgStyle]="{ 'width.px': 16, 'height.px': 16 }"
-          ></svg-icon>
-          <ion-label>{{ topHeader | formatDate | async }}</ion-label>
-        </div>
-        <div class="card-icon-item" *ngIf="masl">
-          <svg-icon
-            class="card-icon-item-icon"
-            src="/assets/icon/moh.svg"
-            [svgStyle]="{ 'width.px': 16, 'height.px': 16 }"
-          ></svg-icon>
-          <ion-label>{{ masl }} {{ "MAP_CENTER_INFO.ABOVE_SEA_LEVEL" | translate }}</ion-label>
+    <ion-row class="ion-justify-content-center ion-nowrap">
+      <ion-col *ngIf="showImage" size="auto">
+        <div class="image">
+          <img [src]="firstAttachment" (error)="handleMissingImage()" />
+          <span *ngIf="attachmentsCount" class="image-count">+{{ attachmentsCount }}</span>
         </div>
       </ion-col>
-    </ion-row>
-    <ion-row>
-      <ion-col>
-        <h5 class="ion-no-margin ion-text-nowrap">{{ title }}</h5>
-      </ion-col>
-    </ion-row>
-    <ion-row>
-      <ion-col>
-        <div class="card-icon-item">
-          <svg-icon
-            class="card-icon-item-icon"
-            src="/assets/icon/user.svg"
-            [svgStyle]="{ 'width.px': 16, 'height.px': 16 }"
-          ></svg-icon>
-          <ion-label>{{ name }}</ion-label>
-        </div>
-        <div class="card-icon-item">
-          <app-competence [competenceLevel]="competenceLevel"></app-competence>
-        </div>
+      <ion-col size="auto" [ngStyle]="{ 'max-width': showImage ? '200px' : '400px' }">
+        <ion-row>
+          <ion-col>
+            <div class="card-icon-item">
+              <svg-icon
+                class="card-icon-item-icon"
+                src="/assets/icon/time.svg"
+                [svgStyle]="{ 'width.px': 16, 'height.px': 16 }"
+              ></svg-icon>
+              <ion-label>{{ topHeader | formatDate | async }}</ion-label>
+            </div>
+            <div class="card-icon-item" *ngIf="masl">
+              <svg-icon
+                class="card-icon-item-icon"
+                src="/assets/icon/moh.svg"
+                [svgStyle]="{ 'width.px': 16, 'height.px': 16 }"
+              ></svg-icon>
+              <ion-label>{{ masl }} {{ "MAP_CENTER_INFO.ABOVE_SEA_LEVEL" | translate }}</ion-label>
+            </div>
+          </ion-col>
+        </ion-row>
+        <ion-row>
+          <ion-col>
+            <h5 class="ion-no-margin ion-text-nowrap">{{ title }}</h5>
+          </ion-col>
+        </ion-row>
+        <ion-row class="ion-align-items-center">
+          <ion-col>
+            <div class="card-icon-item">
+              <svg-icon
+                class="card-icon-item-icon"
+                src="/assets/icon/user.svg"
+                [svgStyle]="{ 'width.px': 16, 'height.px': 16 }"
+              ></svg-icon>
+              <ion-label>{{ name }}</ion-label>
+            </div>
+            <div class="card-icon-item">
+              <app-competence [competenceLevel]="competenceLevel"></app-competence>
+            </div>
+          </ion-col>
+        </ion-row>
       </ion-col>
     </ion-row>
   </ion-grid>
-  <div class="img-wrapper" *ngIf="attachments.length > 0" [ngClass]="{ full: attachments.length > 1 }">
+</div>
+
+<!--<div class="img-wrapper" *ngIf="attachments.length > 0" [ngClass]="{ full: attachments.length > 1 }">
     <app-img-swiper
       [showLabels]="false"
       [attachments]="attachments"
       [withFallbackText]="false"
       [small]="true"
     ></app-img-swiper>
-  </div>
-</div>
+  </div> -->

--- a/src/app/components/map-item-bar/map-item-bar.component.html
+++ b/src/app/components/map-item-bar/map-item-bar.component.html
@@ -7,7 +7,7 @@
           <span *ngIf="attachmentsCount" class="image-count">+{{ attachmentsCount }}</span>
         </div>
       </ion-col>
-      <ion-col size="auto" [ngStyle]="{ 'max-width': showImage ? '200px' : '400px' }">
+      <ion-col size="auto" [ngClass]="showImage ? 'image-show' : 'image-show-not'">
         <ion-row>
           <ion-col>
             <div class="card-icon-item">
@@ -52,12 +52,3 @@
     </ion-row>
   </ion-grid>
 </div>
-
-<!--<div class="img-wrapper" *ngIf="attachments.length > 0" [ngClass]="{ full: attachments.length > 1 }">
-    <app-img-swiper
-      [showLabels]="false"
-      [attachments]="attachments"
-      [withFallbackText]="false"
-      [small]="true"
-    ></app-img-swiper>
-  </div> -->

--- a/src/app/components/map-item-bar/map-item-bar.component.scss
+++ b/src/app/components/map-item-bar/map-item-bar.component.scss
@@ -2,8 +2,11 @@
   --img-wrapper-height: 22vh;
   --img-wrapper-width: 30vh;
   --img-wrapper-height-desktop: 18vh;
+  --img-size: 100px;
 
   position: absolute;
+  display: flex;
+  justify-content: center;
   left: 0;
   right: 0;
   bottom: 0;
@@ -13,6 +16,40 @@
   h5 {
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .image {
+    position: relative;
+    height: var(--img-size);
+
+    img {
+      width: var(--img-size);
+      height: var(--img-size);
+      object-fit: cover;
+    }
+
+    &-count {
+      position: absolute;
+      display: flex;
+      width: 32px;
+      height: 32px;
+      top: 8px;
+      right: 9px;
+      background: var(--images-overflow-background);
+      color: var(--ion-text-color);
+      border-radius: 50%;
+      justify-content: center;
+      align-items: center;
+    }
+
+    &-error-wrapper {
+      width: var(--img-size);
+      height: var(--img-size);
+      background-color: #f7f7f7;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
 
   .card-icon-item {
@@ -52,6 +89,12 @@
       justify-content: left;
       width: 100%;
       height: 100%;
+    }
+  }
+
+  @media only screen and (max-width: 350px) {
+    ion-col {
+      padding: 3px;
     }
   }
 }

--- a/src/app/components/map-item-bar/map-item-bar.component.scss
+++ b/src/app/components/map-item-bar/map-item-bar.component.scss
@@ -71,9 +71,6 @@
     .image-show {
       max-width: 200px;
     }
-  }
-
-  @media only screen and (max-width: 350px) {
     ion-col {
       padding: 3px;
     }

--- a/src/app/components/map-item-bar/map-item-bar.component.scss
+++ b/src/app/components/map-item-bar/map-item-bar.component.scss
@@ -42,13 +42,12 @@
       align-items: center;
     }
 
-    &-error-wrapper {
-      width: var(--img-size);
-      height: var(--img-size);
-      background-color: #f7f7f7;
-      display: flex;
-      align-items: center;
-      justify-content: center;
+    &-show {
+      max-width: 400px;
+    }
+
+    &-show-not {
+      max-width: 400px;
     }
   }
 
@@ -68,27 +67,9 @@
     }
   }
 
-  .img-wrapper {
-    position: absolute;
-    left: 0px;
-    width: var(--img-wrapper-width);
-    height: var(--img-wrapper-height);
-    top: calc(var(--img-wrapper-height) * -1);
-    display: flex;
-    justify-content: center;
-
-    &.full {
-      width: 100%;
-      max-width: none;
-    }
-
-    app-img-swiper {
-      display: flex;
-      flex: 1;
-      flex-direction: row;
-      justify-content: left;
-      width: 100%;
-      height: 100%;
+  @media only screen and (max-width: 500px) {
+    .image-show {
+      max-width: 200px;
     }
   }
 

--- a/src/app/components/map-item-bar/map-item-bar.component.ts
+++ b/src/app/components/map-item-bar/map-item-bar.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, NgZone, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { SafeUrl } from '@angular/platform-browser';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { MapItem } from '../../core/models/map-item.model';
 import { Router } from '@angular/router';
 import { AppMode, GeoHazard } from 'src/app/modules/common-core/models';
@@ -38,7 +38,12 @@ export class MapItemBarComponent implements OnInit, OnDestroy {
 
   // TODO: Rewrite this component to use observable. Maybe put visibleMapItem observable in map service?
 
-  constructor(private router: Router, private zone: NgZone, private userSettingService: UserSettingService) {
+  constructor(
+    private router: Router,
+    private zone: NgZone,
+    private userSettingService: UserSettingService,
+    private sanitizer: DomSanitizer
+  ) {
     this.visible = false;
   }
 
@@ -68,6 +73,14 @@ export class MapItemBarComponent implements OnInit, OnDestroy {
     this.showAdditionalAttachmentCount = false;
   }
 
+  private sanitize(url: string): SafeUrl {
+    if (url) {
+      return this.sanitizer.bypassSecurityTrustUrl(url);
+    } else {
+      return null;
+    }
+  }
+
   show(item: MapItem) {
     this.showAdditionalAttachmentCount = true;
     this.zone.run(async () => {
@@ -80,7 +93,7 @@ export class MapItemBarComponent implements OnInit, OnDestroy {
       // this.masl = item.ObsLocation ? item.ObsLocation.Height : undefined;
       // this.setDistanceAndType(item);
       this.attachments = [];
-      this.firstAttachmentUrl = item.FirstAttachmentUrl;
+      this.firstAttachmentUrl = this.sanitize(item.FirstAttachmentUrl);
       this.additionaAttachmentCount = this.getAdditionalAttachmentsCount(item.AttachmentsCount);
       this.visible = true;
     });

--- a/src/app/components/map-item-bar/map-item-bar.component.ts
+++ b/src/app/components/map-item-bar/map-item-bar.component.ts
@@ -1,21 +1,16 @@
 import { Component, OnInit, NgZone, OnDestroy } from '@angular/core';
 import { Observable, Subject, Subscription } from 'rxjs';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { MapItem } from '../../core/models/map-item.model';
-import * as L from 'leaflet';
 import { HelperService } from '../../core/services/helpers/helper.service';
 import { TranslateService } from '@ngx-translate/core';
 import { Router } from '@angular/router';
-import { GeoHazard, AppMode } from 'src/app/modules/common-core/models';
-import {
-  AtAGlanceViewModel,
-  AttachmentViewModel,
-  RegistrationViewModel,
-} from 'src/app/modules/common-regobs-api/models';
+import { AppMode, GeoHazard } from 'src/app/modules/common-core/models';
+import { AtAGlanceViewModel, AttachmentViewModel } from 'src/app/modules/common-regobs-api/models';
 import { UserSettingService } from '../../core/services/user-setting/user-setting.service';
 import { GeoPositionService } from '../../core/services/geo-position/geo-position.service';
-import { take } from 'rxjs/operators';
-import { getStarCount } from '../../core/helpers/competence-helper';
-import { getAllAttachmentsFromViewModel } from 'src/app/modules/common-registration/registration.helpers';
+import { getStarCountFromNumber } from '../../core/helpers/competence-helper';
+import { AttachmentService } from 'src/app/modules/common-regobs-api';
 
 @Component({
   selector: 'app-map-item-bar',
@@ -32,12 +27,16 @@ export class MapItemBarComponent implements OnInit, OnDestroy {
   topHeader: string;
   title: string;
   distanceAndType: string;
+  firstAttachment: SafeUrl;
+  attachmentsCount: number;
   name: string;
   id: number;
   geoHazard: GeoHazard;
   attachments: AttachmentViewModel[] = [];
   masl: number;
   competenceLevel: number;
+  showImage: boolean;
+  imgSrc: string;
 
   private subscription: Subscription;
   private _isVisible: Subject<boolean>;
@@ -53,9 +52,11 @@ export class MapItemBarComponent implements OnInit, OnDestroy {
     private geoPositionService: GeoPositionService,
     private helper: HelperService,
     private translateService: TranslateService,
+    private attachmentService: AttachmentService,
     private router: Router,
     private zone: NgZone,
-    private userSettingService: UserSettingService
+    private userSettingService: UserSettingService,
+    private sanitizer: DomSanitizer
   ) {
     this.visible = false;
     this._isVisible = new Subject();
@@ -78,24 +79,40 @@ export class MapItemBarComponent implements OnInit, OnDestroy {
     return item.FormNames.join(', ');
   }
 
+  getAttachmentsCount(count: number): number {
+    return count > 1 ? count - 1 : null;
+  }
+
+  public handleMissingImage() {
+    this.firstAttachment = './assets/images/broken-image-w-bg.svg';
+  }
+
+  private isAttachments(url: string) {
+    if (url) {
+      return this.sanitizer.bypassSecurityTrustUrl(url);
+    } else {
+      this.showImage = false;
+    }
+  }
+
   show(item: MapItem) {
-    this.zone.run(() => {
+    this.showImage = true;
+    this.zone.run(async () => {
       this.id = item.RegId;
       this.topHeader = item.DtObsTime;
       this.title = this.getTitle(item);
       this.name = item.NickName;
-      // this.competenceLevel = getStarCount(item.CompetenceLevelTID);
+      this.competenceLevel = getStarCountFromNumber(item.CompetenceLevelTID);
       this.geoHazard = item.GeoHazardTID;
       // this.masl = item.ObsLocation ? item.ObsLocation.Height : undefined;
       // this.setDistanceAndType(item);
       this.attachments = [];
-      // Why do we check for AppMode?
-      // if (this.appMode) {
-      //   this.attachments = getAllAttachmentsFromViewModel(item);
-      // }
+      this.firstAttachment = this.isAttachments(item.FirstAttachmentUrl);
+      this.attachmentsCount = this.getAttachmentsCount(item.AttachmentsCount);
       this.visible = true;
       this.publishChange();
     });
+    console.log(this.firstAttachment);
   }
 
   hide() {

--- a/src/app/components/map-item-bar/map-item-bar.component.ts
+++ b/src/app/components/map-item-bar/map-item-bar.component.ts
@@ -83,7 +83,7 @@ export class MapItemBarComponent implements OnInit, OnDestroy {
     return count > 1 ? count - 1 : null;
   }
 
-  public handleMissingImage() {
+  handleMissingImage() {
     this.firstAttachment = './assets/images/broken-image-w-bg.svg';
   }
 
@@ -112,7 +112,6 @@ export class MapItemBarComponent implements OnInit, OnDestroy {
       this.visible = true;
       this.publishChange();
     });
-    console.log(this.firstAttachment);
   }
 
   hide() {

--- a/src/app/core/helpers/competence-helper.ts
+++ b/src/app/core/helpers/competence-helper.ts
@@ -4,29 +4,3 @@ export function getStarCount(competenceLevel: string): number {
   }
   return competenceLevel.split('').filter((s) => s === '*').length;
 }
-
-export function getStarCountFromNumber(competenceLevel: number): number {
-  if (!competenceLevel) {
-    return 0;
-  } else if (competenceLevel < 200) {
-    switch (competenceLevel) {
-      default:
-      case 0:
-      case 100:
-        return 0;
-      case 110:
-        return 1;
-      case 115:
-        return 2;
-      case 120:
-        return 3;
-      case 130:
-        return 4;
-      case 150:
-        return 5;
-    }
-  } else {
-    const starsNum = competenceLevel.toString()[1];
-    return +starsNum;
-  }
-}

--- a/src/app/core/helpers/competence-helper.ts
+++ b/src/app/core/helpers/competence-helper.ts
@@ -4,3 +4,29 @@ export function getStarCount(competenceLevel: string): number {
   }
   return competenceLevel.split('').filter((s) => s === '*').length;
 }
+
+export function getStarCountFromNumber(competenceLevel: number): number {
+  if (!competenceLevel) {
+    return 0;
+  } else if (competenceLevel < 200) {
+    switch (competenceLevel) {
+      default:
+      case 0:
+      case 100:
+        return 0;
+      case 110:
+        return 1;
+      case 115:
+        return 2;
+      case 120:
+        return 3;
+      case 130:
+        return 4;
+      case 150:
+        return 5;
+    }
+  } else {
+    const starsNum = competenceLevel.toString()[1];
+    return +starsNum;
+  }
+}

--- a/src/app/modules/common-regobs-api/models/at-aglance-view-model.ts
+++ b/src/app/modules/common-regobs-api/models/at-aglance-view-model.ts
@@ -3,6 +3,8 @@ export interface AtAGlanceViewModel {
   CompetenceLevelTID?: number;
   DtObsTime?: string;
   FirstAttachmentId?: number;
+  FirstAttachmentUrl?: string;
+  AttachmentsCount?: number;
   FormNames?: Array<string>;
   GeoHazardTID?: number;
   Latitude?: number;

--- a/src/assets/images/broken-image-w-bg.svg
+++ b/src/assets/images/broken-image-w-bg.svg
@@ -1,0 +1,7 @@
+<svg width="100" height="106" viewBox="0 0 100 106" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="100" height="106" fill="#EBEBEB"/>
+<path d="M35 38L65 68" stroke="#0B0C0C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M37.385 40.385C36.8216 40.945 36.5033 41.7056 36.5 42.5V63.5C36.5 65.15 37.85 66.5 39.5 66.5H60.5C61.2944 66.4967 62.055 66.1784 62.615 65.615M45.5 39.5H60.5C61.2956 39.5 62.0587 39.8161 62.6213 40.3787C63.1839 40.9413 63.5 41.7044 63.5 42.5V57.5L45.5 39.5Z" stroke="#0B0C0C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M46.34 49.3399C45.9135 49.7374 45.3493 49.9537 44.7664 49.9434C44.1835 49.9332 43.6274 49.697 43.2151 49.2848C42.8029 48.8725 42.5668 48.3164 42.5565 47.7335C42.5462 47.1506 42.7626 46.5864 43.16 46.1599" stroke="#0B0C0C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M39.5 66.5L51.5 54.5M63.5 57.5L56 50L63.5 57.5Z" stroke="#0B0C0C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -58,7 +58,7 @@ export const settings: ISettings = {
         PROD: 'https://api.regobs.no/v5',
         DEMO: 'https://demo-api.regobs.no/v5',
         TEST: 'https://test-api.regobs.no/v5',
-        // 'TEST': 'http://localhost:40001'
+        //TEST: 'http://localhost:40001',
       },
       serviceUrl: {
         PROD: 'https://api.nve.no/hydrology/regobs/v3.5.0',


### PR DESCRIPTION
Etter endringene i api, AtGlance returnerer observasjon med firstAttachmentUrl og attachmentCount. 

Hvis firstAttachmentUrl ikke er null prøver appen å hente bildet. Hvis den feiler så vises en bilde ikone med en strek gjennom for å indikere at bildet kunne ikke lastes ned. 

Hvis firstAttachment er null dropper vi å vise bildet og istedenfor bruker hele map-item-bar bredde beskrivelsen 

showImage er sett til true på starten av show metode fordi map-item-bar komponent er rendered bare en gang i DOMen derfor, kunne jeg ikke bruke onInit metode for å restarte det hver gang man klikker på andre markere på kartet

oppdaterte også kompetanse visning