### PR TITLE
Some small fixes for search results and search criteria

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -185,10 +185,10 @@ export class SearchCriteriaService {
     const criteria = this.readUrlParams();
     this.logger.debug('Criteria from URL params: ', DEBUG_TAG, criteria);
 
+    // Log last 10 changes made (nb, does not include langKey, extent etc, and only logs the change, not entire critera)
     this.searchCriteriaChanges
-      .pipe(scan((history, currentCriteriaChange) => [...history, currentCriteriaChange], []))
-      // Log last 10 choices made
-      .subscribe((history) => this.logger.debug('Change history (last 10)', DEBUG_TAG, history.slice(-10)));
+      .pipe(scan((history, currentCriteriaChange) => [...history, currentCriteriaChange].slice(-10), []))
+      .subscribe((history) => this.logger.debug('Change history (last 10)', DEBUG_TAG, history));
 
     this.searchCriteria$ = combineLatest([
       this.searchCriteriaChanges.pipe(

--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -14,7 +14,7 @@ import {
   tap,
 } from 'rxjs';
 import { SearchCriteria } from 'src/app/core/models/search-criteria';
-import { getUniqueRegistrations } from 'src/app/modules/common-registration/registration.helpers';
+import { getUniqueRegistrations, HasRegId } from 'src/app/modules/common-registration/registration.helpers';
 import {
   AtAGlanceViewModel,
   RegistrationViewModel,
@@ -51,7 +51,7 @@ export class SearchResult<TViewModel> {
   }
 }
 
-export class PagedSearchResult<TViewModel extends Pick<RegistrationViewModel, 'RegId'>> {
+export class PagedSearchResult<TViewModel extends HasRegId> {
   static DEBUG_TAG = 'PagedSearchResult';
   static PAGE_SIZE = 10;
   static MAX_ITEMS = 100;

--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -14,6 +14,7 @@ import {
   tap,
 } from 'rxjs';
 import { SearchCriteria } from 'src/app/core/models/search-criteria';
+import { getUniqueRegistrations } from 'src/app/modules/common-registration/registration.helpers';
 import {
   AtAGlanceViewModel,
   RegistrationViewModel,
@@ -50,7 +51,7 @@ export class SearchResult<TViewModel> {
   }
 }
 
-export class PagedSearchResult<TViewModel> {
+export class PagedSearchResult<TViewModel extends Pick<RegistrationViewModel, 'RegId'>> {
   static DEBUG_TAG = 'PagedSearchResult';
   static PAGE_SIZE = 10;
   static MAX_ITEMS = 100;
@@ -134,11 +135,13 @@ export class PagedSearchResult<TViewModel> {
         )
       ),
       // Accumulate results if offset > 0
-      // TODO: Filter out duplicates
       scan(
         (accumulated, { searchCriteria, result }) => (searchCriteria.Offset > 0 ? [...accumulated, ...result] : result),
         [] // Start with an empty array
-      )
+      ),
+      // Return unique registrations. If a new page result comes in after a registration has been submitted,
+      // we would get duplicates
+      map((regs) => getUniqueRegistrations(regs))
     );
   }
 }

--- a/src/app/modules/common-registration/helpers/registration.helper.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.ts
@@ -201,3 +201,19 @@ function getDefaultValue(registrationTid: RegistrationTid) {
     return {};
   }
 }
+
+/**
+ * Return a list with only unique registrations.
+ *
+ * Only uses RegID when comparing registrations.
+ */
+export function getUniqueRegistrations<T extends Pick<RegistrationViewModel, 'RegId'>>(regs: T[]) {
+  const regIds = new Set();
+  return regs.filter((reg) => {
+    if (regIds.has(reg.RegId)) {
+      return false;
+    }
+    regIds.add(reg.RegId);
+    return true;
+  });
+};

--- a/src/app/modules/common-registration/helpers/registration.helper.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.ts
@@ -202,12 +202,14 @@ function getDefaultValue(registrationTid: RegistrationTid) {
   }
 }
 
+export type HasRegId = Pick<RegistrationViewModel, 'RegId'>;
+
 /**
  * Return a list with only unique registrations.
  *
  * Only uses RegID when comparing registrations.
  */
-export function getUniqueRegistrations<T extends Pick<RegistrationViewModel, 'RegId'>>(regs: T[]) {
+export function getUniqueRegistrations<T extends HasRegId>(regs: T[]): T[] {
   const regIds = new Set();
   return regs.filter((reg) => {
     if (regIds.has(reg.RegId)) {
@@ -216,4 +218,4 @@ export function getUniqueRegistrations<T extends Pick<RegistrationViewModel, 'Re
     regIds.add(reg.RegId);
     return true;
   });
-};
+}

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -16,6 +16,7 @@ import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-up
 import { ObservationService } from 'src/app/core/services/observation/observation.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
+import { getUniqueRegistrations } from 'src/app/modules/common-registration/registration.helpers';
 import { RegistrationViewModel } from 'src/app/modules/common-regobs-api/models';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { settings } from 'src/settings';
@@ -23,17 +24,6 @@ import { settings } from 'src/settings';
 const DEBUG_TAG = 'SentListComponent';
 const PAGE_SIZE = 10;
 const MAX_REGISTRATIONS_COUNT = 100;
-
-const getUniqueRegistrations = (regs: RegistrationViewModel[]) => {
-  const regIds = new Set();
-  return regs.filter((reg) => {
-    if (regIds.has(reg.RegId)) {
-      return false;
-    }
-    regIds.add(reg.RegId);
-    return true;
-  });
-};
 
 @Component({
   selector: 'app-sent-list',


### PR DESCRIPTION
Se commit historikk for liste over endringer.

Største endringen er at et ekstra api-kall unngås (rødt i skjermdumpen under), som skjedde hver eneste gang man endret et søkekritere, feks sorteringen eller nickname.

![image](https://user-images.githubusercontent.com/8558332/211844866-86f7e873-0381-4830-b04a-80e7e44964f6.png)
