### PR TITLE
White-screen, remove negative z-index

### DIFF
--- a/src/app/modules/shared/components/refresh-with-cancel/refresh-with-cancel.component.scss
+++ b/src/app/modules/shared/components/refresh-with-cancel/refresh-with-cancel.component.scss
@@ -5,7 +5,11 @@
   top: 0px;
   right: 0;
   height: 60px;
-  z-index: -1;
+
+  // White screen css fix. Can be removed when webkit has been fixed.
+  // See https://github.com/ionic-team/ionic-framework/issues/25760 and RO-2083.
+  // Maybe this can be removed, can't see any difference.
+  // z-index: -1;
 }
 
 ion-refresher {

--- a/src/global.scss
+++ b/src/global.scss
@@ -441,9 +441,12 @@ ion-slides {
   align-items: center;
 }
 
-app-header {
-  z-index: -1;
-}
+// White screen css fix. Can be removed when webkit has been fixed.
+// See https://github.com/ionic-team/ionic-framework/issues/25760 and RO-2083.
+// Maybe this can be removed, can't see any difference.
+// app-header {
+//   z-index: -1;
+// }
 
 ion-toast {
   --button-color: var(--ion-color-varsom-blue-light-1);
@@ -488,6 +491,13 @@ ion-toast {
     display: inline-block;
     z-index: -1;
   }
+}
+
+// White screen css fix. Can be removed when webkit has been fixed.
+// See https://github.com/ionic-team/ionic-framework/issues/25760 and RO-2083.
+// This fix removes the shadow below map clusters.
+.ios .cluster-marker:after {
+  display: none;
 }
 
 .obs-marker:hover svg,
@@ -790,4 +800,15 @@ ion-modal.modal-fullscreen::part(content) {
   display: block;
   width: 100%;
   height: 100%;
+}
+
+// White screen css fix for ion-item. See https://github.com/ionic-team/ionic-framework/issues/25760
+// and RO-2083.
+// Removes the negative z-index on the ::after psuedo element
+// This will allow hover, active, and focused states to continue to work. However, the background color will appear on
+// top of any content in ion-item instead of underneath it. If your hover, active, and focused state background colors
+// are too dark, this approach may hide content.
+.ios ion-item::part(native)::after {
+  z-index: 0;
+  pointer-events: none;
 }


### PR DESCRIPTION
Fjerner negativ z-index på ::after pseudo-elementetet til ion-item og et par andre elementer jeg fant.
Ion-item kan være en av synderne som gir hvit-skjerm-feil. Verdt å teste ut dette.

Må testes alle steder endret kode brukes.

Sjekk gjerne at påvirket kode / ui fortsatt ser OK ut, jeg har testet litt selv og syns det fortsatt ser greit ut.