### PR TITLE
RO-2132: Fiks av kræsj hvis du nekter tilgang til posisjonsdata på tlf: Andre forsøk

### DIFF
--- a/src/app/core/services/geo-position/geo-position.service.ts
+++ b/src/app/core/services/geo-position/geo-position.service.ts
@@ -21,6 +21,7 @@ import { GeoPositionErrorCode } from './geo-position-error.enum';
 import moment from 'moment';
 import { isAndroidOrIos } from '../../helpers/ionic/platform-helper';
 import { DeviceOrientation } from '@ionic-native/device-orientation/ngx';
+import { Capacitor } from '@capacitor/core';
 
 const DEBUG_TAG = 'GeoPositionService';
 
@@ -243,6 +244,11 @@ export class GeoPositionService implements OnDestroy {
             this.createPositionError('Permission denied', GeoPositionErrorCode.PermissionDenied)
           );
           return;
+        } else if (Capacitor.getPlatform() === 'ios') {
+          // I Android vil appen bli pauset når vi kjører askForPermission(),
+          // så startWatchingPosition() vil bli kjørt når appen aktiveres igjen.
+          // I iOS vil ikke appen bli pauset, så vi må kjøre startWatchingPosition() manuelt
+          this.startWatchingPosition();
         }
       }
       this.loggingService.debug(`startTrackingComponent: name = ${name}. Permissions ok = ${permission}`, DEBUG_TAG);
@@ -364,7 +370,6 @@ export class GeoPositionService implements OnDestroy {
       this.loggingService.debug('Geolocation permissions after request', DEBUG_TAG, permissions);
       if (permissions?.location === 'denied') {
         this.showPermissionDeniedToast();
-        //        this.clearCurrentPosition();
         return false;
       }
     } catch (err) {

--- a/src/app/core/services/geo-position/geo-position.service.ts
+++ b/src/app/core/services/geo-position/geo-position.service.ts
@@ -13,7 +13,7 @@ import {
 import { filter, map, distinctUntilChanged, startWith } from 'rxjs/operators';
 import { CallbackID, ClearWatchOptions, Geolocation, Position, WatchPositionCallback } from '@capacitor/geolocation';
 import { LoggingService } from '../../../modules/shared/services/logging/logging.service';
-import { AlertController, ToastController, Platform } from '@ionic/angular';
+import { ToastController, Platform } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
 import { LogLevel } from '../../../modules/shared/services/logging/log-level.model';
 import { GeoPositionLog, PositionError } from './geo-position-log.interface';
@@ -77,7 +77,6 @@ export class GeoPositionService implements OnDestroy {
     private deviceOrientation: DeviceOrientation,
     private platform: Platform,
     private loggingService: LoggingService,
-    private alertController: AlertController,
     private toastController: ToastController,
     private translateService: TranslateService
   ) {
@@ -236,12 +235,17 @@ export class GeoPositionService implements OnDestroy {
   public async startTrackingComponent(name: string, forcePermissionDialog = false): Promise<void> {
     if (forcePermissionDialog) {
       this.loggingService.debug(`startTrackingComponent: name = ${name}. Check permissions...`, DEBUG_TAG);
-      const valid = await this.checkPermissions();
-      if (!valid) {
-        this.gpsPositionLog.next(this.createPositionError('Permission denied', GeoPositionErrorCode.PermissionDenied));
-        return;
+      let permission = await this.checkPermissions();
+      if (!permission) {
+        permission = await this.askForPermission();
+        if (!permission) {
+          this.gpsPositionLog.next(
+            this.createPositionError('Permission denied', GeoPositionErrorCode.PermissionDenied)
+          );
+          return;
+        }
       }
-      this.loggingService.debug(`startTrackingComponent: name = ${name}. Permissions ok = ${valid}`, DEBUG_TAG);
+      this.loggingService.debug(`startTrackingComponent: name = ${name}. Permissions ok = ${permission}`, DEBUG_TAG);
     }
     this.trackingComponents.next([...this.getTrackingComponentsExcludeByName(name), name]);
   }
@@ -254,7 +258,12 @@ export class GeoPositionService implements OnDestroy {
     return this.trackingComponents.value.filter((x) => x !== name);
   }
 
-  private startSubscriptions() {
+  private async startSubscriptions() {
+    const permission = await this.checkPermissions();
+    if (!permission) {
+      this.loggingService.debug('We cannot watch postion or heading due to lacking permissions', DEBUG_TAG);
+      return false;
+    }
     this.startWatchingPosition();
     this.startWatchingHeading();
   }
@@ -280,7 +289,6 @@ export class GeoPositionService implements OnDestroy {
   }
 
   private async startWatchingPosition(): Promise<void> {
-    await this.checkPermissions();
     const watchPositionCallback: WatchPositionCallback = (position: Position, err: any) => {
       if (err) {
         this.loggingService.log('Error when watchPosition', err, LogLevel.Warning, DEBUG_TAG, err);
@@ -341,47 +349,35 @@ export class GeoPositionService implements OnDestroy {
 
   private async checkPermissions(): Promise<boolean> {
     try {
-      if (isAndroidOrIos(this.platform)) {
-        await this.checkPermissionsApp();
-      }
+      const permissions = await Geolocation.checkPermissions();
+      this.loggingService.debug('Geolocation permissions', DEBUG_TAG, permissions);
+      return permissions?.location === 'granted';
     } catch (err) {
-      this.loggingService.error(err, DEBUG_TAG, 'Error asking for location permissions');
-      const errorMessage = this.translateService.instant('GEOLOCATION.POSITION_ERROR.PermissionDenied');
-      this.createToast(errorMessage);
-      return true; // continue anyway on error
+      this.loggingService.error(err, DEBUG_TAG, `Error asking for location permissions: ${err.message}`);
     }
+    return false;
   }
 
-  private async checkPermissionsApp(): Promise<boolean> {
-    const currentPermissions = await Geolocation.checkPermissions();
-    this.loggingService.debug('Geolocation permissions', DEBUG_TAG, currentPermissions);
-    const authorized = currentPermissions.location === 'granted';
-    if (!authorized) {
-      if (this.platform.is('ios')) {
-        await this.showPermissionDeniedError();
+  private async askForPermission(): Promise<boolean> {
+    try {
+      const permissions = await Geolocation.requestPermissions();
+      this.loggingService.debug('Geolocation permissions after request', DEBUG_TAG, permissions);
+      if (permissions?.location === 'denied') {
+        this.showPermissionDeniedToast();
+        //        this.clearCurrentPosition();
         return false;
       }
-      // location is not authorized, request new. This only works on Android
-      const newPermissionsAfterRequest = await Geolocation.requestPermissions();
-      this.loggingService.debug('Geolocation permissions after new request', DEBUG_TAG, newPermissionsAfterRequest);
-      if (newPermissionsAfterRequest?.location === 'denied') {
-        await this.showPermissionDeniedError();
-        return false;
-      }
+    } catch (err) {
+      this.loggingService.error(err, DEBUG_TAG, `Error when requesting location permissions: ${err.message}`);
+      this.showPermissionDeniedToast();
+      return false;
     }
     return true;
   }
 
-  private async showPermissionDeniedError() {
-    const translations = await this.translateService
-      .get(['ALERT.OK', 'PERMISSION.LOCATION_DENIED_HEADER', 'PERMISSION.LOCATION_DENIED_MESSAGE'])
-      .toPromise();
-    const alert = await this.alertController.create({
-      header: translations['PERMISSION.LOCATION_DENIED_HEADER'],
-      message: translations['PERMISSION.LOCATION_DENIED_MESSAGE'],
-      buttons: [translations['ALERT.OK']],
-    });
-    await alert.present();
+  protected showPermissionDeniedToast() {
+    const errorMessage = this.translateService.instant('GEOLOCATION.POSITION_ERROR.PermissionDenied');
+    this.createToast(errorMessage);
   }
 
   private startWatchingHeading() {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -286,10 +286,6 @@
     "UNZIP_ERROR_MESSAGE_GENERIC": "Could not save map package to disk. Please try again",
     "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Could not save map package to disk. Are you sure there is enough disk space?"
   },
-  "PERMISSION": {
-    "LOCATION_DENIED_HEADER": "Permission to location denied",
-    "LOCATION_DENIED_MESSAGE": "Cannot show location in map without permission."
-  },
   "POPUP_DISCLAMER": {
     "ABOUT_OBSERVATIONS": {
       "HEADER": "About observations",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -82,7 +82,7 @@
   "GEOLOCATION": {
     "POSITION_ERROR": {
       "INVALID": "Kan ikke vise posisjonen din pga. ufullstendige posisjonsdata",
-      "PermissionDenied": "For å hente posisjonen din må du endre lokasjonsinnstillinger",
+      "PermissionDenied": "Vi trenger tilgang til nøyaktig posisjon for å vise hvor du er",
       "PositionUnavailable": "Får ikke tak i posisjonen din",
       "Timeout": "Det tok for lang tid å få tak i posisjonen din",
       "UNSUPPORTED": "Enheten kan ikke gi deg posisjonsdata"
@@ -285,10 +285,6 @@
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Klarte ikke lagre kartpakke på disk. Vennligst prøv igjen!",
     "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Klarte ikke lagre kartpakke på disk. Er du sikker på at det er nok plass tilgjengelig?"
-  },
-  "PERMISSION": {
-    "LOCATION_DENIED_HEADER": "Tilgang til posisjon nektet",
-    "LOCATION_DENIED_MESSAGE": "Kan ikke vise posisjonen din i kartet uten godkjenning for bruk av lokasjon."
   },
   "POPUP_DISCLAMER": {
     "ABOUT_OBSERVATIONS": {


### PR DESCRIPTION
Forsøket på å omstrukturere koden for å hente posisjon strandet.

Har nå heller forsøkt på nytt ved å kun løse problemet med feilhåndtering hvis du ikke har gitt appen tilgang til posisjon.
Ikke testet på iPhone ennå. Trenger hjelp til testing både i iOS og Android og sjekk av koden. Her er noen scenarioer som bør testes:

- Teste at det fungerer som før på web. Ingen endringer er gjort på denne delen av koden
- Slette app og installere på nytt. Ber den om tilgang til posisjon når det er naturlig? Greier den å lese posisjon?
- Fjern tilgang til å lese posisjon. Oppfører appen seg fornuftig uten å plage brukeren? Den skal kun klage litt når du trykker på "gps-knappen"
- Skru av gps. Håndterer appen dette bra? Jeg har ikke forsøkt å fikse at appen skal få med seg at gps starter igjen, men den mangelen har vært der lenge. Du må pause appen og aktivere den igjen for at dette skal virke.