### PR TITLE
RO-2074: nullstill filtrene når naturfare endres

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -56,9 +56,10 @@ describe('SearchCriteriaService', () => {
   });
 
   it('filter should contain language and geo hazard', fakeAsync(async () => {
-    tick(1);
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(150);
     //check default criteria
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.LangKey).toEqual(LangKey.nb);
     expect(criteria.SelectedGeoHazards).toEqual([GeoHazard.Snow]);
     await service.applyQueryParams();
@@ -71,7 +72,7 @@ describe('SearchCriteriaService', () => {
       language: LangKey.en,
       currentGeoHazard: [GeoHazard.Soil, GeoHazard.Water],
     });
-    tick(1);
+    tick(500);
     const criteria2 = await firstValueFrom(service.searchCriteria$);
     expect(criteria2.LangKey).toEqual(LangKey.en);
     expect(criteria2.SelectedGeoHazards).toEqual([GeoHazard.Soil, GeoHazard.Water]);
@@ -82,8 +83,9 @@ describe('SearchCriteriaService', () => {
 
   it('default days-back filter should work', fakeAsync(async () => {
     jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
-
-    const criteria = await firstValueFrom(service.searchCriteria$);
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(150);
     //check that criteria contains correct from time. Should be 2 days earlier at midnight
     expect(criteria.FromDtObsTime).toEqual('2000-12-22T00:00:00.000+01:00');
 
@@ -93,13 +95,13 @@ describe('SearchCriteriaService', () => {
     const url = new URL(document.location.href);
     expect(url.searchParams.get('fromDate')).toEqual('2000-12-22');
   }));
-
   it('nick name filter should work', fakeAsync(async () => {
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
     service.setObserverNickName('Nick');
-    tick(1);
-
+    tick(500);
     //check that current criteria contains expected nick name
-    const criteria = await firstValueFrom(service.searchCriteria$);
+
     expect(criteria.ObserverNickName).toEqual('Nick');
     await service.applyQueryParams();
     //check that url contains nickname filter
@@ -108,10 +110,11 @@ describe('SearchCriteriaService', () => {
   }));
 
   it('competence filter should set the right criteria and url', fakeAsync(async () => {
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
     service.setCompetence([150, 105]);
-    tick();
+    tick(500);
 
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.ObserverCompetence).toEqual([150, 105]);
     await service.applyQueryParams();
     const url = new URL(document.location.href);
@@ -121,7 +124,7 @@ describe('SearchCriteriaService', () => {
   it('set new observation type should be ok', fakeAsync(async () => {
     const obsType = { Id: 81, SubTypes: [13] };
     service.setObservationType(obsType);
-    tick(1);
+    tick(500);
     //check that current criteria contains expected type
     const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.SelectedRegistrationTypes).toEqual([obsType]);
@@ -131,12 +134,16 @@ describe('SearchCriteriaService', () => {
   }));
 
   it('remove observation type should be ok', fakeAsync(async () => {
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
     const obsType1 = { Id: 81, SubTypes: [13, 26] };
     const obsType2 = { Id: 81, SubTypes: [26] };
+    tick(500);
     await service.setObservationType(obsType1);
+    tick(500);
     await service.removeObservationType(obsType2);
+    tick(500);
     //check that criteria contains only obsType2
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.SelectedRegistrationTypes).toEqual([{ Id: 81, SubTypes: [13] }]);
     await service.applyQueryParams();
     const url = new URL(document.location.href);
@@ -144,21 +151,27 @@ describe('SearchCriteriaService', () => {
   }));
 
   it('remove observation type with wrong parameter, should return the same object', fakeAsync(async () => {
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
     const obsType1 = { Id: 81, SubTypes: [13, 26] };
     const obsType2 = { Id: 40, SubTypes: [26] };
+    tick(500);
     await service.setObservationType(obsType1);
     await service.removeObservationType(obsType2);
-    const criteria = await firstValueFrom(service.searchCriteria$);
+    tick(500);
     expect(criteria.SelectedRegistrationTypes).toEqual([{ Id: 81, SubTypes: [13, 26] }]);
+
     await service.applyQueryParams();
     const url = new URL(document.location.href);
     expect(url.searchParams.get('type')).toEqual('81.13~81.26');
   }));
 
   it('remove observation type when criteria empty, should return null', fakeAsync(async () => {
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
     const obsType2 = { Id: 40, SubTypes: [26] };
+    tick(500);
     await service.removeObservationType(obsType2);
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.SelectedRegistrationTypes).toEqual(null);
     await service.applyQueryParams();
     const url = new URL(document.location.href);
@@ -167,10 +180,11 @@ describe('SearchCriteriaService', () => {
 
   orderByTestCases.forEach((test) => {
     it('orderBy filter should work', fakeAsync(async () => {
+      let criteria;
+      service.searchCriteria$.subscribe((c) => (criteria = c));
       service.setOrderBy(test.apiValue as SearchCriteriaOrderBy);
-      tick();
+      tick(100);
       //check that current criteria contains expected orderBy
-      const criteria = await firstValueFrom(service.searchCriteria$);
       expect(criteria.OrderBy).toEqual(test.apiValue);
       await service.applyQueryParams();
       const url = new URL(document.location.href);
@@ -180,11 +194,12 @@ describe('SearchCriteriaService', () => {
 
   it('fromDate url param should be set or updated', fakeAsync(async () => {
     jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
     service.setFromDate(moment(new Date('2000-12-24T00:00:00+01:00')).toISOString(true), false);
 
     tick(100);
 
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.FromDtObsTime).toEqual('2000-12-24T00:00:00.000+01:00');
     await service.applyQueryParams();
     const url = new URL(document.location.href);
@@ -193,11 +208,12 @@ describe('SearchCriteriaService', () => {
 
   it('toDate url param should be set or updated', fakeAsync(async () => {
     jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
     service.setToDate(moment(new Date('2000-12-24T00:00:00+01:00')).toISOString(true));
 
     tick(100);
 
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.ToDtObsTime).toEqual('2000-12-24T23:59:59.999+01:00');
     await service.applyQueryParams();
     const url = new URL(document.location.href);
@@ -207,8 +223,6 @@ describe('SearchCriteriaService', () => {
   it('toDate url param should be removed when updating fromDate with true', fakeAsync(async () => {
     jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
     service.setFromDate(moment(new Date('2000-12-24T00:00:00')).toISOString(true), true);
-
-    tick(100);
 
     const url = new URL(document.location.href);
     expect(url.searchParams.get('toDate')).toBeNull();
@@ -257,8 +271,9 @@ describe('SearchCriteriaService url parsing', () => {
       mapService as unknown as MapService,
       new TestLoggingService()
     );
-    tick();
-    const criteria = await firstValueFrom(service.searchCriteria$);
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     expect(criteria.ObserverCompetence).toEqual([150, 105]);
   }));
 
@@ -269,8 +284,9 @@ describe('SearchCriteriaService url parsing', () => {
       mapService as unknown as MapService,
       new TestLoggingService()
     );
-    tick();
-    const criteria = await firstValueFrom(service.searchCriteria$);
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     expect(criteria.SelectedGeoHazards).toEqual([10]);
   }));
 
@@ -281,8 +297,9 @@ describe('SearchCriteriaService url parsing', () => {
       mapService as unknown as MapService,
       new TestLoggingService()
     );
-    tick();
-    const criteria = await firstValueFrom(service.searchCriteria$);
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     expect(criteria.ObserverCompetence).toEqual(undefined);
   }));
 
@@ -294,9 +311,10 @@ describe('SearchCriteriaService url parsing', () => {
       new TestLoggingService()
     );
 
-    tick();
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     //check that current criteria contains expected nick name
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.ObserverNickName).toEqual('Oluf');
   }));
 
@@ -308,8 +326,9 @@ describe('SearchCriteriaService url parsing', () => {
       new TestLoggingService()
     );
 
-    tick();
-    const criteria = await firstValueFrom(service.searchCriteria$);
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     expect(criteria.SelectedRegistrationTypes).toEqual([
       { Id: 10, SubTypes: [] },
       { Id: 81, SubTypes: [13, 26] },
@@ -324,9 +343,9 @@ describe('SearchCriteriaService url parsing', () => {
         mapService as unknown as MapService,
         new TestLoggingService()
       );
-
-      tick();
-      const criteria = await firstValueFrom(service.searchCriteria$);
+      let criteria;
+      service.searchCriteria$.subscribe((c) => (criteria = c));
+      tick(100);
       expect(criteria.SelectedRegistrationTypes).toEqual(undefined);
     }));
   });
@@ -339,9 +358,11 @@ describe('SearchCriteriaService url parsing', () => {
       new TestLoggingService()
     );
 
-    tick();
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     //check that current criteria contains expected orderBy
-    const criteria = await firstValueFrom(service.searchCriteria$);
+
     expect(criteria.OrderBy).toEqual('DtChangeTime');
   }));
 
@@ -353,9 +374,10 @@ describe('SearchCriteriaService url parsing', () => {
       new TestLoggingService()
     );
 
-    tick();
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     //check that current criteria contains expected orderBy
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.OrderBy).toEqual('DtObsTime');
   }));
 
@@ -367,9 +389,10 @@ describe('SearchCriteriaService url parsing', () => {
       new TestLoggingService()
     );
 
-    tick();
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     //check that current criteria contains expected geo hazard
-    const criteria = await firstValueFrom(service.searchCriteria$);
     expect(criteria.SelectedGeoHazards).toEqual([70]);
   }));
 
@@ -381,9 +404,11 @@ describe('SearchCriteriaService url parsing', () => {
       new TestLoggingService()
     );
 
-    tick();
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
     //check that current criteria contains expected geo hazard
-    const criteria = await firstValueFrom(service.searchCriteria$);
+
     expect(criteria.SelectedGeoHazards).toEqual([10]);
   }));
 
@@ -397,10 +422,12 @@ describe('SearchCriteriaService url parsing', () => {
       new TestLoggingService()
     );
 
-    tick();
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
 
     //check that criteria contains correct from time. Should be 1 day earlier at midnight
-    const criteria = await firstValueFrom(service.searchCriteria$);
+
     expect(criteria.FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
   }));
 
@@ -416,9 +443,9 @@ describe('SearchCriteriaService url parsing', () => {
       new TestLoggingService()
     );
 
-    tick();
-
-    const criteria = await firstValueFrom(service.searchCriteria$);
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
 
     expect(criteria.FromDtObsTime).toEqual('2020-12-24T00:00:00.000+01:00');
     expect(criteria.ToDtObsTime).toEqual('2022-12-24T23:59:59.999+01:00');

--- a/src/app/modules/side-menu/components/date-range/date-range.component.ts
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.ts
@@ -8,7 +8,6 @@ import { IonAccordionGroup } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
 import { getLangKeyString } from '../../../common-core/helpers';
 import { RadioGroupChangeEventDetail as IRadioGroupRadioGroupChangeEventDetail } from '@ionic/core/dist/types/components/radio-group/radio-group-interface';
-import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-date-range',
@@ -51,7 +50,8 @@ export class DateRangeComponent extends NgDestoryBase implements OnInit {
   }
 
   ngOnInit() {
-    this.searchCriteriaService.searchCriteria$.pipe(takeUntil(this.ngDestroy$), take(1)).subscribe((criteria) => {
+    this.searchCriteriaService.resetEvent.subscribe(() => this.mode.next('predefined'));
+    this.searchCriteriaService.searchCriteria$.pipe(takeUntil(this.ngDestroy$)).subscribe((criteria) => {
       this.fromDate = criteria.FromDtObsTime;
       this.toDate = criteria.ToDtObsTime;
       if (this.cachedDays === null || this.cachedDays !== 0) {

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -93,7 +93,10 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     this.popupType = isAndroidOrIos(this.platform) ? 'action-sheet' : 'popover';
     this.isIosOrAndroid = isAndroidOrIos(this.platform);
     this.isMobileWeb = this.platform.is('mobileweb');
-    this.searchCriteriaService.resetEvent.subscribe(() => (this.isAutomaticStationChecked = true));
+    this.searchCriteriaService.resetEvent.subscribe(() => {
+      this.isAutomaticStationChecked = true;
+      this.nickName = '';
+    });
     const searchCriteria = await firstValueFrom(this.searchCriteriaService.searchCriteria$);
 
     combineLatest([

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -93,7 +93,7 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     this.popupType = isAndroidOrIos(this.platform) ? 'action-sheet' : 'popover';
     this.isIosOrAndroid = isAndroidOrIos(this.platform);
     this.isMobileWeb = this.platform.is('mobileweb');
-
+    this.searchCriteriaService.resetEvent.subscribe(() => (this.isAutomaticStationChecked = true));
     const searchCriteria = await firstValueFrom(this.searchCriteriaService.searchCriteria$);
 
     combineLatest([
@@ -123,15 +123,17 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
   }
 
   onSelectCompetenceChange(event) {
-    this.chosenCompetenceValue = event.detail.value;
-    const ids = event.detail.value.ids;
-    if (this.isAutomaticStationChecked && event.detail.value.value === 'All') {
-      this.searchCriteriaService.setCompetence(null);
-    } else if (this.isAutomaticStationChecked) {
-      ids.push(105);
-      this.searchCriteriaService.setCompetence(ids);
-    } else {
-      this.searchCriteriaService.setCompetence(ids);
+    if (event.detail.value) {
+      this.chosenCompetenceValue = event.detail.value;
+      const ids = event.detail.value.ids;
+      if (this.isAutomaticStationChecked && event.detail.value.value === 'All') {
+        this.searchCriteriaService.setCompetence(null);
+      } else if (this.isAutomaticStationChecked) {
+        ids.push(105);
+        this.searchCriteriaService.setCompetence(ids);
+      } else {
+        this.searchCriteriaService.setCompetence(ids);
+      }
     }
   }
 

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -126,17 +126,20 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
   }
 
   onSelectCompetenceChange(event) {
-    if (event.detail.value) {
-      this.chosenCompetenceValue = event.detail.value;
-      const ids = event.detail.value.ids;
-      if (this.isAutomaticStationChecked && event.detail.value.value === 'All') {
-        this.searchCriteriaService.setCompetence(null);
-      } else if (this.isAutomaticStationChecked) {
-        ids.push(105);
-        this.searchCriteriaService.setCompetence(ids);
-      } else {
-        this.searchCriteriaService.setCompetence(ids);
-      }
+    if (!event.detail.value) {
+      return;
+    }
+
+    this.chosenCompetenceValue = event.detail.value;
+    const ids = event.detail.value.ids;
+
+    if (this.isAutomaticStationChecked && event.detail.value.value === 'All') {
+      this.searchCriteriaService.setCompetence(null);
+    } else if (this.isAutomaticStationChecked) {
+      ids.push(105);
+      this.searchCriteriaService.setCompetence(ids);
+    } else {
+      this.searchCriteriaService.setCompetence(ids);
     }
   }
 

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -189,13 +189,16 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked {
       scan((previousCriterias, current) => [...previousCriterias.splice(-1), current], [null, null]),
       filter(([prev, current]) => {
         //will prevent zoom in to trigger new search
-        const currentBounds = withinExtentCriteriaToBounds(current.Extent);
-        if (!prev) {
-          this.loggingService.debug('First search critera request, so need to fetch observations', DEBUG_TAG);
-          return this.rememberExtent(currentBounds);
+        let currentBounds;
+        if (current.Extent) {
+          currentBounds = withinExtentCriteriaToBounds(current.Extent);
+          if (!prev) {
+            this.loggingService.debug('First search critera request, so need to fetch observations', DEBUG_TAG);
+            return this.rememberExtent(currentBounds);
+          }
         }
-        const previousCriteriaWithoutExtent = { ...prev, Extent: undefined };
-        const currentCriteriaWithoutExtent = { ...current, Extent: undefined };
+        const previousCriteriaWithoutExtent = { ...prev, Extent: null };
+        const currentCriteriaWithoutExtent = { ...current, Extent: null };
         if (JSON.stringify(previousCriteriaWithoutExtent) === JSON.stringify(currentCriteriaWithoutExtent)) {
           //only extent is changed in criteria
           if (this.lastSearchBounds?.contains(currentBounds)) {


### PR DESCRIPTION
Legger reset funksjonalitet i search criteria. Legger til debounce() for å unngå masse meldinger i konsolet. 

I filter-menu-component lagt jeg til en sjekk på onSelectCompetenceChange fordi den trigga event emit onInit (default ionic select behaviour) som endra ObserverCompetence i searchCriteria rett ved starten av appen. 

I date-range.component fjernet jeg take(1) siden vi vil at dato filter oppdateres hver gang searchCriteria endres ikke bare en gang.

I home.page lagde jeg en sjekk om criteria.Extent eksisterer før vi kjører withinExtentCriteriaToBounds ellers så fikk jeg masse feil i konsolet. Si fra om jeg burde fjerne det fra denne PRen og lage en separat en. 

I testene måtte jeg endre måte på hvordan vi henter searchCriteria. firstValueFrom var vanskelig å sette opp pga debounceTime i search-criteria.service. derfor henter vi criteria via subscription istedenfor.

Test gjerne om alle filtrene nullstilles på en riktig måte. Det kommer en PR til på å nullstille filtrene med knapp og den vil ha flere endringer i filter-menu (suspense is rising). Stay tuned