### PR TITLE
RO-2129: Stop unnecessary api calls on Search and AtGlance when switching tabs

### DIFF
--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -132,7 +132,7 @@ export class PagedSearchResult<TViewModel extends HasRegId> {
     searchCriteria: SearchCriteria,
     fetchFunc: (criteria: SearchCriteriaRequestDto) => Observable<TViewModel[]>
   ): Observable<TViewModel[]> {
-    this.resetPaging(); // Reset state when a new search is created
+    //this.resetPaging(); // Reset state when a new search is created
 
     return this.pageInfo.pipe(
       // Add page info to search criteria

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -123,6 +123,7 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked {
         })
       )
       .subscribe();
+    console.log('completed');
   }
 
   get appname(): string {

--- a/src/app/pages/observation-list/observation-list.page.ts
+++ b/src/app/pages/observation-list/observation-list.page.ts
@@ -98,7 +98,7 @@ export class ObservationListPage implements OnInit {
     this.logger.debug('ionViewWillEnter', 'PagedSearchResult');
     this.content.scrollToTop();
     this.searchResult.isActiveStream$.next(true);
-    this.refresh();
+    //this.refresh();
   }
 
   ionViewWillLeave(): void {

--- a/src/app/pages/observation-list/observation-list.page.ts
+++ b/src/app/pages/observation-list/observation-list.page.ts
@@ -97,11 +97,13 @@ export class ObservationListPage implements OnInit {
   ionViewWillEnter(): void {
     this.logger.debug('ionViewWillEnter', 'PagedSearchResult');
     this.content.scrollToTop();
+    this.searchResult.isActiveStream$.next(true);
     this.refresh();
   }
 
   ionViewWillLeave(): void {
     // this.loaded = false;
+    this.searchResult.isActiveStream$.next(false);
   }
 
   loadNextPage(): void {

--- a/src/app/pages/observation-list/observation-list.page.ts
+++ b/src/app/pages/observation-list/observation-list.page.ts
@@ -97,13 +97,13 @@ export class ObservationListPage implements OnInit {
   ionViewWillEnter(): void {
     this.logger.debug('ionViewWillEnter', 'PagedSearchResult');
     this.content.scrollToTop();
-    this.searchResult.isActiveStream$.next(true);
+    this.searchResult.isStreamActive.next(true);
     //this.refresh();
   }
 
   ionViewWillLeave(): void {
     // this.loaded = false;
-    this.searchResult.isActiveStream$.next(false);
+    this.searchResult.isStreamActive.next(false);
   }
 
   loadNextPage(): void {


### PR DESCRIPTION
Siden både SearchResult og PagedSearchResult abonnerer på searchCritera, strømmen ikke stopper selv om man bytter tabene, og både subscriptions fortsetter å kjøre samtidig etter hver av de har blitt initialisert (på home.page og observation-list.page). 
Derfor lagde jeg en 'isStreamActive' observable som egentlig stopper searchCritera.subscription når taben hvor SearchResult eller PagedSearchResult brukes  ikke er aktiv. Jeg abonnerer på endringer i 'isStreamActive' og basert på hvilke verdi det er, den lytter på searchCriteria pipen og oppdaterer registreringer. 

På home.page initialiserer searchResult i initSearch metode som er asynk derfor onEnter metode vil kaste feil på this.searchResult.isStreamActive.next(true);  hvis searchResult ikke er initalisert enda og den kjører raskere enn asynk kode er ferdig.
Derfor må jeg kjøre this.searchResult.isStreamActive.next(true); rett etter initSearch returnerer searchResult.
Det skjer ikke i observation-list.page siden searchResult er initalisert i konstruktoren på en synkron måte som gjør at ionViewWillEnter() ikke klager på manglende searchResult. 

Kanksje det finnes en bedre måte å gjøre alt dette her, men det er mitt foreløpig forslag ihvertfall.  