### PR TITLE
RO-2193 Set default avalanche time to obstime

### DIFF
--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -96,6 +96,9 @@ export class AvalancheObsPage extends BasePage {
       this.draft.registration.Incident = {};
     }
     this.maxDate = this.getMaxDateForNow();
+    if (!this.avalancheObs.DtAvalancheTime) {
+      this.avalancheObs.DtAvalancheTime = this.draft.registration.DtObsTime
+    }
   }
 
   getMaxDateForNow() {


### PR DESCRIPTION
One side effect of this is that an avalanche obs is registered as soon as you enter this form. However, you can still reset everything by clicking "Nullstill denne siden".