### PR TITLE
RO-2182: Vise gps-posisjon og strek mellom denne og observasjonspunkt ved stedfesting

### DIFF
--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, NgZone, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { Capacitor } from '@capacitor/core';
 import { Position } from '@capacitor/geolocation';
 import { IonInput } from '@ionic/angular';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
@@ -67,7 +68,11 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
   @Input() locationTitle = 'REGISTRATION.OBS_LOCATION.TITLE';
   @Input() selectedLocation: ObsLocationsResponseDtoV2;
   @Output() mapReady = new EventEmitter<L.Map>();
-  @Input() showPolyline = true;
+
+  /**
+   * Show a dotted line between the location you choose and the location of the device. Defaults to true in native mode.
+   */
+  @Input() showPolyline = Capacitor.isNativePlatform();
   @Input() allowEditLocationName = false;
   @Input() setObsTime = false;
   @Input() localDate: string;

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -77,6 +77,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
   private map: L.Map;
   followMode = false;
   private userposition: Position;
+  private pathLine: L.Polyline; // line between observation location and device location
   distanceToObservationText = '';
   viewInfo: ViewInfo;
   isLoading = false;
@@ -390,14 +391,32 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
       : this.userposition
       ? L.latLng(this.userposition.coords.latitude, this.userposition.coords.longitude)
       : this.locationMarker.getLatLng();
+
     const locationMarkerLatLng = this.locationMarker.getLatLng();
-    const path = [locationMarkerLatLng, from];
+
     if (this.map) {
+      const path = [locationMarkerLatLng, from];
+
+      if (!this.pathLine) {
+        this.pathLine = L.polyline(path, {
+          color: 'black',
+          weight: 6,
+          opacity: 0.9,
+          dashArray: '1,12',
+        });
+        if (this.showPolyline) {
+          this.pathLine.addTo(this.map);
+        }
+      } else {
+        this.pathLine.setLatLngs(path);
+      }
       if (this.fromMarker) {
         if (this.fromMarker.getLatLng().equals(this.locationMarker.getLatLng())) {
           this.fromMarker.setOpacity(0);
+          this.pathLine.setStyle({ opacity: 0 });
         } else {
           this.fromMarker.setOpacity(1);
+          this.pathLine.setStyle({ opacity: 0.9 });
         }
       }
     }


### PR DESCRIPTION
Korden for å vise dette forsvant i [denne](https://github.com/NVE/regObs4/commit/bfbe25edbbf5fabbe85d7ac1ce9b8205224b12f0#diff-8c9a6221c0f158f8da6f650aaac4ccbbd99c00bddb04139be25db0a2b19175f9) commit'en som hadde med å tegne polygoner å gjøre.
Jeg har bare tryllet den fram igjen.
Kan være koden ble fjernet for å prøve å fikse [denne feilen](https://nveprojects.atlassian.net/browse/RO-161), men jeg tror ikke jeg har gjenintrodusert den.
Jeg fant riktignok en annen feil på stedfesting av skred som jeg ikke løser her:
https://nveprojects.atlassian.net/browse/RO-2201

**I RO-2182 står det også at man i app skal gå til GPS-posisjon automatisk. Vi gjør ikke det nå, men jeg lurer på om det kan være bedre å ha det slik vi har det, i tilfelle observatøren har panorert kartet til et annet sted enn der hun er med vilje. Man kan alltids trykke på gps-knappen for å gå til gps-posisjonen.**
 
Det er også problemer med panorering og zoom ifm stedfesting på web, men det er en separat sak på dette:
https://nveprojects.atlassian.net/browse/RO-2183

Jeg har ikke testet fiksen i iOS ennå. Det bør gjøres.