### PR TITLE
RO-2115: Ikke oppfriske token på resume hvis vi er offline

### DIFF
--- a/src/app/modules/auth/services/regobs-auth-service-override.ts
+++ b/src/app/modules/auth/services/regobs-auth-service-override.ts
@@ -49,7 +49,12 @@ export class RegobsAuthServiceOverride extends AuthService {
       if (shouldClearTokens) {
         await this.clearTokens();
       }
-      this.notifyActionListers(AuthActionBuilder.RefreshFailed(error));
+      // Error message: 'Unable to obtain server configuration' means we didn't reach B2C,
+      // but since we refresh pretty often and we might be offline, we just ignore it.
+      // If we trigger a RefreshFailed action the token will be cleared by the auth library
+      if (error?.message?.toLowerCase().indexOf('unable to obtain server configuration') === -1) {
+        this.notifyActionListers(AuthActionBuilder.RefreshFailed(error));
+      }
     }
   }
 

--- a/src/app/modules/auth/services/regobs-auth.service.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.ts
@@ -14,6 +14,7 @@ import { LoggingService } from '../../shared/services/logging/logging.service';
 import { Location } from '@angular/common';
 import { nowInSeconds, StorageBackend } from '@openid/appauth';
 import { isAndroidOrIos } from 'src/app/core/helpers/ionic/platform-helper';
+import { NetworkStatusService } from 'src/app/core/services/network-status/network-status.service';
 
 const DEBUG_TAG = 'RegobsAuthService';
 export const RETURN_URL_KEY = 'authreturnurl';
@@ -47,7 +48,8 @@ export class RegobsAuthService {
     private accountService: AccountService,
     private storage: StorageBackend,
     private platform: Platform,
-    private accountApi: AccountService
+    private accountApi: AccountService,
+    private networkStatusService: NetworkStatusService
   ) {
     this.initComplete$ = this.authService.initComplete$.pipe(
       filter((isComplete) => isComplete),
@@ -129,13 +131,17 @@ export class RegobsAuthService {
     this.initComplete$
       .pipe(
         switchMap(() => (isAndroidOrIos(this.platform) ? this.platform.resume : from(this.platform.ready()))),
-        withLatestFrom(this.loggedInUser$)
+        withLatestFrom(this.loggedInUser$, this.networkStatusService.connected$)
       )
-      .subscribe(([, user]) => {
+      .subscribe(([, user, connected]) => {
         if (user?.token && this.isTokenOlderThan(user?.tokenIssuedAt, 300)) {
-          //token is older than 5 minutes, so refresh
-          this.logger.debug('App resumed. Refresh token...', DEBUG_TAG);
-          this.refreshToken();
+          if (connected) {
+            //token is older than 5 minutes and we have network, so refresh
+            this.logger.debug('App resumed. Refresh token...', DEBUG_TAG);
+            this.refreshToken();
+          } else {
+            this.logger.debug('App resumed. Refresh token skipped because we are offline', DEBUG_TAG);
+          }
         }
       });
   }

--- a/src/app/modules/auth/services/token-response-full.ts
+++ b/src/app/modules/auth/services/token-response-full.ts
@@ -28,9 +28,9 @@ export class TokenResponseFull extends TokenResponse {
   }
 
   isRefreshTokenValid(buffer: number = AUTH_EXPIRY_BUFFER): boolean {
-    if (this.expiresIn) {
+    if (this.refreshTokenExpiresIn) {
       const now = nowInSeconds();
-      return now < this.issuedAt + this.expiresIn + buffer;
+      return now < this.issuedAt + this.refreshTokenExpiresIn + buffer;
     } else {
       return true;
     }


### PR DESCRIPTION
For å slippe å logge inn støtt og stadig har vi et "refresh-token" som vi prøver å oppfriske hver gang appen våkner hvis vi er logget inn fra før (altså har et token). Dette tokenet har en levetid på 3 mnd hvis vi ikke oppfrisker det.
Hvis oppfriskning av tokenet feiler av en eller annen grunn, sletter vi tokenet. Dette skjedde også hvis vi ikke fikk kontakt med B2C.

Nå venter vi med å oppfriske token til vi har nett etter at appen starter.
Hvis vi likevel ikke får kontakt med B2C, lar vi være å varsle om at oppfriskning feilet, ellers vil vi miste tokenet.

Sjekket også for moro skyld om oppfriskning av token funker på web, og det gjør det. Så brukere av beta.regobs.no skal ikke trenge å logge seg inn på nytt særlig ofte hvis ikke de bytter mellom test/demo/prod.

NB! Denne er kun testet på web og Android, ikke på iOS ennå.
Dette bør testes:
(bruk debugger og filtrer på "auth", så ser du hva som skjer)

1. vær innlogget i appen og start på nytt i flymodus og prøv å sende inn obs. Du skal ikke bli bedt om å logge inn på nytt
2. deaktiver flymodus. Sjekk at token blir fornyet
3. Prøv å blokkere nettverkskall til b2c og gjør 1 og 2 på nytt. Tokenet skal beholdes.
