### PR TITLE
RO-2134: Bedre forklaring hvis vi får "no token defined" ved innsending av observasjon

### DIFF
--- a/src/app/core/services/draft/draft-model.ts
+++ b/src/app/core/services/draft/draft-model.ts
@@ -19,6 +19,7 @@ export declare const enum RegistrationDraftErrorCode {
   GoneError = 27,
   ServerError = 30,
   Unknown = 40,
+  Unauthorized = 50,
 }
 
 export interface RegistrationDraftError {

--- a/src/app/core/services/draft/draft-to-registration.service.ts
+++ b/src/app/core/services/draft/draft-to-registration.service.ts
@@ -221,6 +221,9 @@ function handleError(error: Error): { code: RegistrationDraftErrorCode; message:
       code = RegistrationDraftErrorCode.Unknown;
       message = error.message || `Got an unknown http error: ${error.status} - ${error.statusText}`;
     }
+  } else if (error.message == 'No Token Defined!') {
+    code = RegistrationDraftErrorCode.Unauthorized;
+    message = error.message;
   } else {
     // Handle unknown errors
     code = RegistrationDraftErrorCode.Unknown;

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.html
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.html
@@ -15,6 +15,9 @@
       <ion-label class="ion-text-wrap" *ngIf="unknownError">
         {{ "REGISTRATION.FAILED.PROBLEM" | translate }}
       </ion-label>
+      <ion-label class="ion-text-wrap" *ngIf="unauthorizedError">
+        {{ "REGISTRATION.FAILED.UNAUTHORIZED" | translate }}
+      </ion-label>
       <ion-label class="ion-text-wrap" *ngIf="registrationError">
         {{ "REGISTRATION.FAILED.PROBLEM" | translate }}
         <ng-container *ngIf="draft.error.message">

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.ts
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.ts
@@ -52,6 +52,10 @@ export class FailedRegistrationComponent {
     return this.draft.error.code === RegistrationDraftErrorCode.ServerError;
   }
 
+  get unauthorizedError() {
+    return this.draft.error.code === RegistrationDraftErrorCode.Unauthorized;
+  }
+
   async openForEdit() {
     await this.draftService.save({
       ...this.draft,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -396,7 +396,8 @@
       "SEND_EMAIL": "Send to us by email",
       "SUBMIT_NEW": "Submit as new observation",
       "SUBTITLE": "Missing network or submission took too long. We'll try again after a while and hope that the network has improved.",
-      "TITLE": "Submission failed"
+      "TITLE": "Submission failed",
+      "UNAUTHORIZED": "Authorization failed. Could you please try to log out and in again and then try to submit the observation again?"
     },
     "FETCH_FOR_EDIT_FAILED": {
       "CONFIRM_BUTTON": "Edit observation",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -396,7 +396,8 @@
       "SEND_EMAIL": "Send til oss på e-post",
       "SUBMIT_NEW": "Send inn som ny observasjon",
       "SUBTITLE": "Mangler nettverk eller innsending tok for lang tid. Vi prøver igjen etter en stund og håper at nettet har bedret seg.",
-      "TITLE": "Innsending feilet"
+      "TITLE": "Innsending feilet",
+      "UNAUTHORIZED": "Vi lykkes ikke med å sjekke om du har tilgang. Prøv å sende inn på nytt. Om dette ikke hjelper, kan du forsøke å logge ut og inn igjen før du prøver å sende inn på nytt?"
     },
     "FETCH_FOR_EDIT_FAILED": {
       "CONFIRM_BUTTON": "Rediger observasjon",


### PR DESCRIPTION
Nå får du denne feilmeldinga om innlogging skulle skjære seg når du sender inn en observasjon:
![image](https://user-images.githubusercontent.com/71138449/218164531-2f1f6170-cd41-4985-86e9-4f5e0195c271.png)

I Jira-saken ser du hvordan du kan gjenskape feilen og samme framgangsmåte kan brukes for å teste at fiksen virker.
