### PR TITLE
RO-1950+1951: Håndtere at vi ikke er innlogget når vi prøver å sende inn observasjon

### DIFF
--- a/src/app/modules/auth/services/regobs-auth.service.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.ts
@@ -246,16 +246,23 @@ export class RegobsAuthService {
     }
   }
 
-  private async showErrorMessage(status: number, message: string) {
-    const text = status === 401 ? 'UNAUTHORIZED' : status <= 0 ? 'SERVICE_UNAVAILABLE' : 'UNKNOWN_ERROR';
-    const messageText = `LOGIN.${text}`;
-    const extraMessage = text === 'UNKNOWN_ERROR' ? ` ${message}` : '';
+  private async showErrorMessage(status: number, messageFromServer: string) {
+    this.logger.debug(`SignInFailed: Status = ${status}, message = ${messageFromServer}`, DEBUG_TAG);
+    let messageKeyPostFix = 'UNKNOWN_ERROR';
+
+    if (status === 401) {
+      messageKeyPostFix = 'UNAUTHORIZED';
+    } else if (status <= 0 || messageFromServer === 'Unable To Obtain Server Configuration') {
+      messageKeyPostFix = 'SERVICE_UNAVAILABLE';
+    }
+    const messageKey = `LOGIN.${messageKeyPostFix}`;
+    const extraMessage = messageKeyPostFix === 'UNKNOWN_ERROR' ? ` ${messageFromServer}` : '';
     const translations = await lastValueFrom(
-      this.translateService.get(['ALERT.DEFAULT_HEADER', 'ALERT.OK', messageText])
+      this.translateService.get(['ALERT.DEFAULT_HEADER', 'ALERT.OK', messageKey])
     );
     const alert = await this.alertController.create({
       header: translations['ALERT.DEFAULT_HEADER'],
-      message: `${translations[messageText]}${extraMessage}`,
+      message: `${translations[messageKey]}${extraMessage}`,
       buttons: [translations['ALERT.OK']],
     });
     await alert.present();

--- a/src/app/modules/registration/components/send-button/send-button.component.html
+++ b/src/app/modules/registration/components/send-button/send-button.component.html
@@ -5,9 +5,7 @@
         <ion-col class="send-button-col" size="12">
           <ion-button [disabled]="isDisabled$ | async" expand="block" color="varsom-orange" (click)="send()">
             <ion-icon slot="start" name="send"></ion-icon>
-
-            <span *ngIf="draft.error">{{ "REGISTRATION.RESEND" | translate }}</span>
-            <span *ngIf="!draft.error">{{ "REGISTRATION.SEND" | translate }}</span>
+            <span>{{ caption$ | async }}</span>
           </ion-button>
         </ion-col>
       </ion-row>

--- a/src/app/modules/registration/components/send-button/send-button.component.ts
+++ b/src/app/modules/registration/components/send-button/send-button.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input, ChangeDetectionStrategy, OnChanges } from '@angular/core';
 import { AlertController, NavController } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
-import { map, startWith, switchMap } from 'rxjs/operators';
+import { map, startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { RegobsAuthService } from '../../../auth/services/regobs-auth.service';
 import { combineLatest, firstValueFrom, Observable, Subject } from 'rxjs';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
@@ -14,6 +14,7 @@ import {
   ConfirmationModalService,
   PopupResponse,
 } from '../../../../core/services/confirmation-modal/confirmation-modal.service';
+import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 
 const DEBUG_TAG = 'SendButtonComponent';
 const DELETE_OBS_TIMEOUT_MS = 5000;
@@ -24,10 +25,11 @@ const DELETE_OBS_TIMEOUT_MS = 5000;
   styleUrls: ['./send-button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SendButtonComponent implements OnInit, OnChanges {
+export class SendButtonComponent extends NgDestoryBase implements OnInit, OnChanges {
   @Input() draft: RegistrationDraft;
 
   isDisabled$: Observable<boolean>;
+  caption$: Observable<string>; // submit button caption
   private isSending = new Subject<boolean>();
   private hasChanges = new Subject<void>();
 
@@ -42,7 +44,26 @@ export class SendButtonComponent implements OnInit, OnChanges {
     private logger: LoggingService,
     private newAttachmentService: NewAttachmentService,
     private confirmationModalService: ConfirmationModalService
-  ) {}
+  ) {
+    super();
+    this.caption$ = regobsAuthService.loggedInUser$.pipe(
+      takeUntil(this.ngDestroy$),
+      map((user) => {
+        if (user.isLoggedIn) {
+          if (this.draft.error) {
+            return 'RESEND';
+          } else {
+            return 'SEND';
+          }
+        } else if (this.draft.error) {
+          return 'LOG_IN_AND_RESEND';
+        } else {
+          return 'LOG_IN_AND_SEND';
+        }
+      }),
+      switchMap((key) => this.translateService.get(`REGISTRATION.${key}`))
+    );
+  }
 
   ngOnInit(): void {
     const isEmpty$ = combineLatest([

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -473,6 +473,8 @@
     "INVALID_IMAGE": "Sorry, only JPEG images is supported",
     "IN_CM": "In centimeter",
     "IN_FULL_CM": "In centimeters without decimals",
+    "LOG_IN_AND_SEND": "Log in and submit",
+    "LOG_IN_AND_RESEND": "Log in and try to send again",
     "NONE": "Not selected",
     "OBS_LOCATION": {
       "CONFIRM_TEXT": "Confirm location and time",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -121,7 +121,7 @@
     "LOGOUT": "Log out",
     "MY_PROFILE": "My profile",
     "PASSWORD": "Password",
-    "SERVICE_UNAVAILABLE": "Error while connecting to the service. Do you have mobile network? Please wait a few minutes and try again.",
+    "SERVICE_UNAVAILABLE": "Could not connect to the login service. Do you have mobile network? Please wait a few minutes and try again.",
     "TITLE": "Log in",
     "UNAUTHORIZED": "Wrong username or password. Please retry.",
     "UNKNOWN_ERROR": "Error while logging in. Message from server:"

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -121,9 +121,9 @@
     "LOGOUT": "Logg ut",
     "MY_PROFILE": "Min profil",
     "PASSWORD": "Passord",
-    "SERVICE_UNAVAILABLE": "Det er problemer med å nå tjenesten. Har du nett? Det kan hende at serverapplikasjonen må våkne og få seg en dugelig sterk kopp med kaffe først. Gi den noen minutter og prøv igjen.",
+    "SERVICE_UNAVAILABLE": "Vi har problemer med å nå tjenesten for innlogging. Har du nett? Det kan hende at tjenesten må våkne og få seg en dugelig sterk kopp med kaffe først. Gi den noen minutter og prøv igjen.",
     "TITLE": "Logg inn",
-    "UNAUTHORIZED": "Feil brukernavn eller passord. Vennligst fyll inn på nytt og prøv igjen.",
+    "UNAUTHORIZED": "Feil brukernavn eller passord. Vennligst prøv igjen.",
     "UNKNOWN_ERROR": "Det oppsto en feil ved innlogging. Melding fra server:"
   },
   "MAP_CENTER_INFO": {

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -473,6 +473,8 @@
     "INVALID_IMAGE": "Beklager, ugyldig bildeformat. Kun JPEG er støttet",
     "IN_CM": "I centimeter",
     "IN_FULL_CM": "I hele centimeter",
+    "LOG_IN_AND_SEND": "Logg inn for å sende observasjon",
+    "LOG_IN_AND_RESEND": "Logg inn og prøv å sende på nytt",
     "NONE": "Ingen valgt",
     "OBS_LOCATION": {
       "CONFIRM_TEXT": "Bekreft observasjonspunkt og -tid",


### PR DESCRIPTION
Denne løser to saker: RO-1950 og RO-1951.

Det er to endringer i funksjonalitet:

- Nå viser vi en annen tekst på innsendings-knappen om vi ikke er logget inn.

- Hvis vi prøver å logge inn og ikke har kontakt med B2C, vises en mer presis feilmelding enn "Unable to contain server configuration".

### Tips til testing:
Bruk Network request blocking på *b2c* for å simulere at vi ikke får kontakt med B2C

For å teste de to siste variantene av tekst på innsendingsknappe, kan du gjøre flg.:

1. Kommenter ut canActivate: [AuthGuard], i linje 16 i MyObservationsPageModule. Dette gjør at vi kan vise "Mine observasjoner" uten at vi er logget inn.
2. Blokkere POST /Registration for å simulere at vi ikke får sendt inn observasjon.
3. Vær logget inn og send inn en observasjon
4. Logg ut
5. Gå til http://localhost:8100/my-observations og velg en av kladdene som feilet. Da vil knappen vise "Log in and try to send again" og tilsv. på norsk.


