### PR TITLE
RO-1952: Vise tydeligere at vi er offline etter at vi har forsøkt å sende inn observasjon

### DIFF
--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.html
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.html
@@ -5,8 +5,11 @@
       <h3 class="ion-text-uppercase">{{ "MY_OBSERVATIONS.MY_SENT_OBSERVATIONS" | translate }}</h3>
     </ion-row>
     <ion-row>
-      <ion-label class="ion-text-wrap" color="medium">
+      <ion-label *ngIf="loadedRegistrations?.length" class="ion-text-wrap" color="medium">
         {{ "MY_OBSERVATIONS.SENT_SUBTITLE" | translate }}
+      </ion-label>
+      <ion-label *ngIf="!loadedRegistrations?.length && (isOffline$ | async)" class="ion-text-wrap" color="medium">
+        {{ "MY_OBSERVATIONS.OFFLINE" | translate }}
       </ion-label>
     </ion-row>
   </ion-grid>

--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.ts
@@ -5,7 +5,6 @@ import {
   EventEmitter,
   NgZone,
   OnDestroy,
-  OnInit,
   Output,
 } from '@angular/core';
 import { IonInfiniteScroll } from '@ionic/angular';
@@ -13,6 +12,7 @@ import { combineLatest, Observable, of, Subject } from 'rxjs';
 import { distinctUntilChanged, finalize, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { enterZone, toPromiseWithCancel } from 'src/app/core/helpers/observable-helper';
 import { AddUpdateDeleteRegistrationService } from 'src/app/core/services/add-update-delete-registration/add-update-delete-registration.service';
+import { NetworkStatusService } from 'src/app/core/services/network-status/network-status.service';
 import { ObservationService } from 'src/app/core/services/observation/observation.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
@@ -45,6 +45,7 @@ export class SentListComponent implements OnDestroy {
   loadingMore = false;
   pageIndex: number;
   myObservationsUrl$: Observable<string>;
+  isOffline$: Observable<boolean>;
   private ngDestroy$ = new Subject<void>();
 
   constructor(
@@ -54,8 +55,14 @@ export class SentListComponent implements OnDestroy {
     private regobsAuthService: RegobsAuthService,
     private changeDetectorRef: ChangeDetectorRef,
     private loggingService: LoggingService,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    networkStatusService: NetworkStatusService
   ) {
+    this.isOffline$ = networkStatusService.connected$.pipe(
+      takeUntil(this.ngDestroy$),
+      map((connected) => !connected)
+    );
+
     this.myObservationsUrl$ = this.createMyObservationsUrl$();
 
     addUpdateDeleteRegistrationService.changedRegistrations$

--- a/src/app/pages/my-observations/components/sync-item/sync-item.component.html
+++ b/src/app/pages/my-observations/components/sync-item/sync-item.component.html
@@ -17,7 +17,7 @@
   </ion-label>
 
   <!-- Show error icon if the app failed to post this draft -->
-  <ion-icon *ngIf="!loading && draft.error" slot="end" name="warning"></ion-icon>
+  <ion-icon *ngIf="!loading && draft.error" slot="end" [name]="getErrorIconName(draft.error)"></ion-icon>
 
   <!-- Show loading spinner if this draft is being posted right now -->
   <ion-spinner *ngIf="loading" slot="end"></ion-spinner>

--- a/src/app/pages/my-observations/components/sync-item/sync-item.component.ts
+++ b/src/app/pages/my-observations/components/sync-item/sync-item.component.ts
@@ -1,6 +1,10 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import { SyncStatus } from 'src/app/modules/common-registration/registration.models';
-import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
+import {
+  RegistrationDraft,
+  RegistrationDraftError,
+  RegistrationDraftErrorCode,
+} from 'src/app/core/services/draft/draft-model';
 import { ObsLocationViewModel } from 'src/app/modules/common-regobs-api';
 
 @Component({
@@ -30,5 +34,15 @@ export class SyncItemComponent {
       (this.draft.registration.ObsLocation as ObsLocationViewModel)?.Title ||
       ''
     );
+  }
+
+  getErrorIconName(draftError: RegistrationDraftError): string {
+    switch (draftError?.code) {
+      case RegistrationDraftErrorCode.NoNetworkOrTimedOut:
+        return 'cloud-offline-outline';
+      case RegistrationDraftErrorCode.ConflictError:
+        return 'shuffle-outline';
+    }
+    return 'warning'; // default error icon
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -207,7 +207,8 @@
     "MY_SENT_OBSERVATIONS": "My sent observations",
     "NO_OBSERVATIONS": "Share your observations!",
     "NO_OBSERVATIONS_TEXT": "Your observations will appear here. Share your observations, pictures and assessements with others on Varsom.",
-    "SENT_SUBTITLE": "The following observations have been submitted and are now stored in Regobs.",
+    "OFFLINE": "We cannot fetch your submitted observations. Are you offline?",
+    "SENT_SUBTITLE": "The following observations have been submitted and are stored in Regobs.",
     "TITLE": "My observations"
   },
   "MY_PROFILE": {
@@ -377,7 +378,7 @@
       }
     },
     "DRAFTS": "My drafts",
-    "DRAFTS_DESCRIPTION": "These observations are in progress and not submitted.",
+    "DRAFTS_DESCRIPTION": "These observations are not submitted yet.",
     "EDIT": "Edit observation",
     "EMAIL": {
       "BODY": "Hi! I have problems sending this registration. Can you help me?",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -207,6 +207,7 @@
     "MY_SENT_OBSERVATIONS": "Mine innsendte observasjoner",
     "NO_OBSERVATIONS": "Del dine observasjoner!",
     "NO_OBSERVATIONS_TEXT": "Her vil observasjoner du selv har gjort ligge. Det er lett å dele observasjoner, bilder og vurderinger med andre.",
+    "OFFLINE": "Vi får ikke hentet observasjoner du har sendt inn. Har du nett?",
     "SENT_SUBTITLE": "Disse observasjonene er sendt inn og lagret i Regobs.",
     "TITLE": "Mine observasjoner"
   },
@@ -377,7 +378,7 @@
       }
     },
     "DRAFTS": "Mine kladder",
-    "DRAFTS_DESCRIPTION": "Disse observasjonene er under arbeid og ikke sendt inn.",
+    "DRAFTS_DESCRIPTION": "Disse observasjonene er ikke sendt inn ennå.",
     "EDIT": "Rediger observasjon",
     "EMAIL": {
       "BODY": "Hei! Jeg har problemer med å sende inn denne registreringen. Kan dere hjelpe meg?",


### PR DESCRIPTION
Bør testes i app i flymodus. Observasjoner som ikke ble sendt inn pga. manglende nett får et eget ikon (sky med strek over) og vi viser en spesiell feilmelding for dette under "Mine innsendte observasjoner":
![image](https://user-images.githubusercontent.com/71138449/219587250-70e24635-22bb-49cd-8156-269ba19dfdbe.png)
