### PR TITLE
RO-2181: Ikke slett bilder som hører til snøprofilskjema om skjema er tomt når vi lukker skjema

### DIFF
--- a/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.ts
+++ b/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.ts
@@ -73,7 +73,7 @@ export class SnowProfilePage extends BasePage {
   }
 
   isEmpty() {
-    const isEmptyResult = this.noLayersInSnowProfile() && this.noTestsIncludedInSnowProfile();
+    const isEmptyResult = this.noLayersInSnowProfile() && this.noTestsIncludedInSnowProfile() && super.isEmpty();
     return Promise.resolve(isEmptyResult);
   }
 


### PR DESCRIPTION
BasePage.isEmpty() sjekker om skjemaet har bilder og returnerer false hvis det finnes bilder.
Denne funksjonen var overrida i SnowProfilePage uten å kalle super.isEmpty().
Derfor "så" vi ikke at det var bilder der.