### PR TITLE
RO-1734: Nå blir obsturene i kartet oppfrisket når man trykker på knappen

### DIFF
--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -220,13 +220,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     this.observationTripLayers = null;
   }
 
-  private async showOrHideObserverTripsLayer(map: L.Map, geojson: FeatureCollection) {
-    if (geojson == null) {
-      this.removeObserverTripMapLayers(map);
-      this.removeObserverTripEventHandlers.next();
-      return;
-    }
-
+  private async showObserverTripsLayer(map: L.Map, geojson: FeatureCollection) {
     // NB: The side menu icon has the same style
     const geojsonLayer = L.geoJSON(geojson, { style: { dashArray: '4', color: 'red', stroke: true } });
     this.observationTripLayers = [geojsonLayer];
@@ -301,9 +295,16 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       });
 
     if (this.showObserverTrips) {
-      this.observerTripsService.geojson$.pipe(takeUntil(this.ngDestroy$)).subscribe((geojson) => {
-        this.showOrHideObserverTripsLayer(map, geojson);
-      });
+      combineLatest([this.observerTripsService.toggledOn, this.observerTripsService.geojson$])
+        .pipe(takeUntil(this.ngDestroy$))
+        .subscribe(([toggledOn, geojson]) => {
+          if (toggledOn && geojson) {
+            this.showObserverTripsLayer(map, geojson);
+          } else {
+            this.removeObserverTripMapLayers(map);
+            this.removeObserverTripEventHandlers.next();
+          }
+        });
     }
 
     this.offlineTopoLayerGroup.addTo(this.map);


### PR DESCRIPTION
Fikk til å gjenskape feilen i develop på web slik:

1. Logg ut, hvis du var logget inn
2. Logg inn igjen. Obsturer vises ikke og knappen er av
3. Skru på knappen. Obsturer vises
4. Skru av knappen. **Obsturer vises fortsatt**
![image](https://user-images.githubusercontent.com/71138449/220343889-910be582-f6bf-40ce-9826-804dc2af3cbd.png)

Bruk samme test på denne PR for å sjekke om vi har fikset det.