### PR TITLE
RO-1440: Logge tlf-info og forenkling av kode for å sjekke diskplass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4580,6 +4580,11 @@
         "tslib": "^2.1.0"
       }
     },
+    "@capacitor/device": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/device/-/device-4.1.0.tgz",
+      "integrity": "sha512-BlcYb6e6m+vC1SxeyUDIUGfuNXdKEcpFPDCs/kxk2SByFc/BkvXeoy4NjY4qmTderGELofX9bta5Iy9JV7rGUg=="
+    },
     "@capacitor/filesystem": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-4.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21100,12 +21100,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sqli-cordova-disk-space-plugin": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sqli-cordova-disk-space-plugin/-/sqli-cordova-disk-space-plugin-1.0.3.tgz",
-      "integrity": "sha512-oj9Ee/lycbpBqrf8ftvYvWLRaiRaYfHUCblUDkPZNCpqoLev1BSlOyjOquic49xUEjsIzn6wEMLkwGCSkm8I2A==",
-      "dev": true
-    },
     "ssh-config": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/ssh-config/-/ssh-config-1.1.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21100,6 +21100,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sqli-cordova-disk-space-plugin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sqli-cordova-disk-space-plugin/-/sqli-cordova-disk-space-plugin-1.0.3.tgz",
+      "integrity": "sha512-oj9Ee/lycbpBqrf8ftvYvWLRaiRaYfHUCblUDkPZNCpqoLev1BSlOyjOquic49xUEjsIzn6wEMLkwGCSkm8I2A==",
+      "dev": true
+    },
     "ssh-config": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/ssh-config/-/ssh-config-1.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,6 @@
     "plist": "^3.0.5",
     "prettier": "2.7.1",
     "protractor": "~7.0.0",
-    "sqli-cordova-disk-space-plugin": "^1.0.3",
     "ts-node": "^10.2.1",
     "typescript": "4.6.4"
   },
@@ -213,7 +212,6 @@
       "cordova-plugin-safariviewcontroller": {},
       "cordova-plugin-androidx": {},
       "cordova-plugin-androidx-adapter": {},
-      "sqli-cordova-disk-space-plugin": {},
       "cordova-plugin-advanced-http": {
         "ANDROIDBLACKLISTSECURESOCKETPROTOCOLS": "SSLv3,TLSv1"
       }

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "plist": "^3.0.5",
     "prettier": "2.7.1",
     "protractor": "~7.0.0",
+    "sqli-cordova-disk-space-plugin": "^1.0.3",
     "ts-node": "^10.2.1",
     "typescript": "4.6.4"
   },
@@ -212,6 +213,7 @@
       "cordova-plugin-safariviewcontroller": {},
       "cordova-plugin-androidx": {},
       "cordova-plugin-androidx-adapter": {},
+      "sqli-cordova-disk-space-plugin": {},
       "cordova-plugin-advanced-http": {
         "ANDROIDBLACKLISTSECURESOCKETPROTOCOLS": "SSLv3,TLSv1"
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@capacitor/camera": "^4.1.2",
     "@capacitor/clipboard": "^4.0.1",
     "@capacitor/core": "^4.0.1",
+    "@capacitor/device": "^4.1.0",
     "@capacitor/filesystem": "^4.1.0",
     "@capacitor/geolocation": "^4.0.1",
     "@capacitor/ios": "^4.0.1",

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
+import { Device } from '@capacitor/device';
 import { Directory, Encoding, FileInfo, Filesystem } from '@capacitor/filesystem';
 import { WebView } from '@ionic-native/ionic-webview/ngx';
 import { AlertController, Platform } from '@ionic/angular';
@@ -441,7 +442,7 @@ export class OfflineMapService {
       const neededSpace = await this.getNeededDiskSpaceForPackage(packageMetadataCombined);
 
       this.loggingService.debug(
-        `Available storage is ${this.helperService.humanReadableByteSize(this.availableDiskspace.available)}. 
+        `Available storage is ${this.helperService.humanReadableByteSize(this.availableDiskspace.available)}.
       Needs ${this.helperService.humanReadableByteSize(neededSpace)}`,
         DEBUG_TAG
       );
@@ -516,18 +517,21 @@ export class OfflineMapService {
     alert.present();
   }
 
-  private getDeviceFreeDiskSpace(externalStorage = false): Promise<number> {
+  private getDeviceFreeDiskSpace(): Promise<number> {
     if (!isAndroidOrIos(this.platform)) {
       return Promise.resolve(0);
     }
 
     return new Promise((resolve, reject) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)?.DiskSpacePlugin?.info(
-        { location: externalStorage ? 2 : 1 },
-        (success) => resolve(success.free),
-        (err) => reject(err)
-      );
+      Device.getInfo()
+        .then((info) => {
+          if (info?.realDiskFree) {
+            resolve(info.realDiskFree);
+          } else {
+            resolve(0);
+          }
+        })
+        .catch((err) => reject(err));
     });
   }
 

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
-import { Device } from '@capacitor/device';
 import { Directory, Encoding, FileInfo, Filesystem } from '@capacitor/filesystem';
 import { WebView } from '@ionic-native/ionic-webview/ngx';
 import { AlertController, Platform } from '@ionic/angular';
@@ -517,21 +516,18 @@ export class OfflineMapService {
     alert.present();
   }
 
-  private getDeviceFreeDiskSpace(): Promise<number> {
+  private getDeviceFreeDiskSpace(externalStorage = false): Promise<number> {
     if (!isAndroidOrIos(this.platform)) {
       return Promise.resolve(0);
     }
 
     return new Promise((resolve, reject) => {
-      Device.getInfo()
-        .then((info) => {
-          if (info?.realDiskFree) {
-            resolve(info.realDiskFree);
-          } else {
-            resolve(0);
-          }
-        })
-        .catch((err) => reject(err));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any)?.DiskSpacePlugin?.info(
+        { location: externalStorage ? 2 : 1 },
+        (success) => resolve(success.free),
+        (err) => reject(err)
+      );
     });
   }
 

--- a/src/app/modules/shared/services/logging/file-logging.service.ts
+++ b/src/app/modules/shared/services/logging/file-logging.service.ts
@@ -38,6 +38,8 @@ import { EmailComposer, EmailComposerOptions } from '@ionic-native/email-compose
 import { EmailComposerService } from '../email-composer/email-composer.service';
 import { settings } from 'src/settings';
 import { LogLevel } from './log-level.model';
+import { AppVersionService } from 'src/app/core/services/app-version/app-version.service';
+import { Device } from '@capacitor/device';
 
 @Injectable({
   providedIn: 'root',
@@ -58,7 +60,8 @@ export class FileLoggingService {
     private file: File,
     private platform: Platform,
     private emailComposer: EmailComposer,
-    private emailComposerService: EmailComposerService
+    private emailComposerService: EmailComposerService,
+    private appVersionService: AppVersionService
   ) {
     this.defaultConfig = new LogProviderConfig({
       enableMetaLogging: false,
@@ -104,6 +107,7 @@ export class FileLoggingService {
         return Promise.resolve();
       }
       this.debug_metaLog('Data directory: ' + this.config.baseDir);
+      this.logVersionAndDeviceInfo();
       return this.file
         .checkDir(this.config.baseDir, this.config.logDir)
         .then(() => {
@@ -115,6 +119,24 @@ export class FileLoggingService {
           return this.createLogDir();
         });
     });
+  }
+
+  private logVersionAndDeviceInfo() {
+    let deviceInfoFormatted = 'no device info available';
+    Device.getInfo()
+      .then((deviceInfo) => {
+        if (deviceInfo) {
+          deviceInfoFormatted = `manufacturer = ${deviceInfo.manufacturer}, model = ${deviceInfo.model}, os = ${deviceInfo.operatingSystem}, osVersion = ${deviceInfo.osVersion}, webViewVersion = ${deviceInfo.webViewVersion}`;
+        }
+      })
+      .finally(() => {
+        const versionInfo = this.appVersionService.getAppVersion();
+        this.log(
+          `Version = ${versionInfo.version}, build = ${versionInfo.buildNumber}, ${deviceInfoFormatted}`,
+          null,
+          LogLevel.Info
+        );
+      });
   }
 
   isReady(): boolean {

--- a/src/app/modules/shared/services/logging/sentry.service.ts
+++ b/src/app/modules/shared/services/logging/sentry.service.ts
@@ -19,7 +19,6 @@ export class SentryService implements LoggingService {
 
   constructor(appVersionService: AppVersionService, private fileLoggingService: FileLoggingService) {
     this.versionInfo = appVersionService.getAppVersion();
-    this.log(`Version = ${this.versionInfo.version}, build = ${this.versionInfo.buildNumber}`, null, LogLevel.Info);
   }
 
   error(error: Error, tag?: string, message?: string, ...optionalParams: any[]) {


### PR DESCRIPTION
Nå logger vi info om telefonen til fil. Slik skal det se ut i loggen nå. Nye felter er uthevet:
[2023-02-23 13:55:56.620] [INFO] Version = 4.7.2, build = 220902425**, manufacturer = samsung, model = SM-G970F, os = android, osVersion = 11, webViewVersion = 110.0.5481.65**

Denne er kun testet på Android foreløpig. Du må kjøre npm run build:prod for at tlf. skal logge til fil og deretter sende loggen til deg sjøl.
Jeg måtte installere en ny Capacitor-plugin for å få tak i disse dataene, og da jeg så at denne også hadde en funksjon for å hente ledig diskplass, har jeg skrevet om koden vi hadde for dette i OfflineMapService. Dette gjør at vi kan kvitte oss med Cordova-plugin'en vi brukte til å hente ledig diskplass. Ledig diskplass vises i oversikten over offlinekart og bør sammenlignes med det som ligger i Testflight eller 4.7.6, i tilfelle Capacitor-plugin'en gir feil tall.

    