### PR TITLE
RO-2219: double multiselect filters after changing language

### DIFF
--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -17,7 +17,7 @@
         <ion-item class="item-height">
           <ion-checkbox
             [checked]="type.isChecked"
-            (ionChange)="setNewType($event, type.parentId, type.id)"
+            (click)="setNewType($event, type.parentId, type.id)"
             color="varsom-dark-blue"
           >
           </ion-checkbox>

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -176,12 +176,12 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     }
   }
 
-  setNewType(event: CustomEvent, parentId: number, typeId?: number) {
+  setNewType(event, parentId: number, typeId?: number) {
     //if parentid and subtypeid are the same it means there is no subtypes
     let obsType: RegistrationTypeCriteriaDto;
     if (parentId == typeId) obsType = { Id: parentId, SubTypes: [] };
     else obsType = { Id: parentId, SubTypes: [typeId] };
-    if (event.detail.checked) this.searchCriteriaService.setObservationType(obsType);
+    if (!event.currentTarget.checked) this.searchCriteriaService.setObservationType(obsType);
     else this.searchCriteriaService.removeObservationType(obsType);
   }
 


### PR DESCRIPTION
endret ionchange til click så at den ikke trigges hvis man laster siden etter språk endringene. kunne ikke finne noen type på currentTarget.changed så satt event til any 