### PR TITLE
RO-2129+2058: Ikke trigge søk for listevisning når vi er i kart

### DIFF
--- a/src/app/pages/observation-list/observation-list.page.ts
+++ b/src/app/pages/observation-list/observation-list.page.ts
@@ -131,7 +131,7 @@ export class ObservationListPage implements OnInit {
   ionViewWillEnter(): void {
     this.logger.debug('ionViewWillEnter', 'PagedSearchResult');
     this.content.scrollToTop();
-    // TODO: this.searchCriteriaService.setExtentFilterActive(true);
+    this.searchCriteriaService.setExtentFilterActive(true);
   }
 
   loadNextPage(): void {


### PR DESCRIPTION
Denne fikser både RO-2129 og RO-2058.
Nå kjøres ikke søk som er trigget av listevisninga når vi er i kartvisning.
Denne prøver å løse det samme som #436. Hvis vi er fornøyd med denne løsninga, kan vi kanskje lukke #436?

Har også fjernet et kall som gjorde at vi fikk to "ticks" på kartutsnitt-kriteria, slik at vi søkte to ganger når man valgte listevisning.  Virker ikke som vi trenger dette kallet for å sette "I kartutsnitt"-velgeren i riktig modus.

