### PR TITLE
RO-2231: Støtte filter på kompetanse

### DIFF
--- a/src/app/core/services/sqlite/sqlite.service.ts
+++ b/src/app/core/services/sqlite/sqlite.service.ts
@@ -35,6 +35,8 @@ const toJson = (o: any) => {
 
 const DEBUG_TAG = 'OfflineCapableSearchService - Sqlite';
 const DATABASE_NAME = 'regobs-v2';
+// IMPORTANT! Remember that you have to let sqlite know which version it should start with after you update the db.
+// Check the createConnection() methods
 const UPGRADE_STATEMENTS = [
   {
     toVersion: 1,
@@ -171,7 +173,7 @@ export class SqliteService {
     // https://github.com/capacitor-community/sqlite/issues/157#issuecomment-895877446
     try {
       this.logger.debug('Create connection reference', DEBUG_TAG);
-      this.conn = await this.sqlite.createConnection(DATABASE_NAME, false, 'no-encryption', 4, false);
+      this.conn = await this.sqlite.createConnection(DATABASE_NAME, false, 'no-encryption', 5, false);
       this.logger.debug('Open connection', DEBUG_TAG);
       await this.conn.open();
     } catch (error) {
@@ -283,7 +285,7 @@ export class SqliteService {
       where.push(`lon >= ${searchCriteria.Extent.TopLeft.Longitude}`);
     }
     if (searchCriteria.ObserverCompetence != null) {
-      where.push(`observer_competence IN ${searchCriteria.ObserverCompetence.join(',')}`);
+      where.push(`observer_competence IN (${searchCriteria.ObserverCompetence.join(',')})`);
     }
 
     if (where.length) {
@@ -403,7 +405,7 @@ export class SqliteService {
     const regToValues = (r: RegistrationViewModel) =>
       `(${r.RegId},${r.GeoHazardTID},${r.Observer.ObserverID},'${r.Observer.NickName}', '${toJson(r)}',` +
       `${dateToMs(r.DtObsTime)},${dateToMs(r.DtRegTime)},${dateToMs(r.DtChangeTime)},'${appMode}',` +
-      `${r.ObsLocation.Latitude},${r.ObsLocation.Longitude},${lang}, '${r.Observer.CompetenceLevelTID}')`;
+      `${r.ObsLocation.Latitude},${r.ObsLocation.Longitude},${lang},${r.Observer.CompetenceLevelTID})`;
 
     const statements = registrations.map(regToValues);
 

--- a/src/app/core/services/sqlite/sqlite.service.ts
+++ b/src/app/core/services/sqlite/sqlite.service.ts
@@ -93,7 +93,11 @@ const UPGRADE_STATEMENTS = [
   },
   {
     toVersion: 5,
-    statements: ['ALTER TABLE registration ADD COLUMN observer_competence INTEGER;'],
+    statements: [
+      'ALTER TABLE registration ADD COLUMN observer_competence INTEGER;',
+      // Remove sync time to force a new sync with observer_competence
+      'DELETE FROM registration_sync_time;',
+    ],
   },
 ];
 
@@ -280,7 +284,7 @@ export class SqliteService {
     if (searchCriteria.Extent?.TopLeft?.Longitude != null) {
       where.push(`lon >= ${searchCriteria.Extent.TopLeft.Longitude}`);
     }
-    if (!searchCriteria.ObserverCompetence?.length) {
+    if (searchCriteria.ObserverCompetence?.length) {
       where.push(`observer_competence IN (${searchCriteria.ObserverCompetence.join(',')})`);
     }
 

--- a/src/app/core/services/sqlite/sqlite.service.ts
+++ b/src/app/core/services/sqlite/sqlite.service.ts
@@ -173,6 +173,7 @@ export class SqliteService {
     // https://github.com/capacitor-community/sqlite/issues/157#issuecomment-895877446
     try {
       this.logger.debug('Create connection reference', DEBUG_TAG);
+      // Remember to update version if you added changes to tables
       this.conn = await this.sqlite.createConnection(DATABASE_NAME, false, 'no-encryption', 5, false);
       this.logger.debug('Open connection', DEBUG_TAG);
       await this.conn.open();
@@ -295,14 +296,6 @@ export class SqliteService {
     }
   }
 
-  // competance = [105, 120, 130, 150];
-  // return either one competence or OR LIKE 105
-  private async queryCompetences(competenceIds: number[]) {
-    if (competenceIds.length == 1) {
-      return;
-    }
-  }
-
   private async cleanupRegistrations() {
     const twoWeeksAgo = moment().subtract(14, 'days').valueOf();
     const statement = `DELETE FROM registration WHERE reg_time < ${twoWeeksAgo}`;
@@ -403,7 +396,7 @@ export class SqliteService {
     // ].join(',')})`;
 
     const regToValues = (r: RegistrationViewModel) =>
-      `(${r.RegId},${r.GeoHazardTID},${r.Observer.ObserverID},'${r.Observer.NickName}', '${toJson(r)}',` +
+      `(${r.RegId},${r.GeoHazardTID},${r.Observer.ObserverID},'${r.Observer.NickName}','${toJson(r)}',` +
       `${dateToMs(r.DtObsTime)},${dateToMs(r.DtRegTime)},${dateToMs(r.DtChangeTime)},'${appMode}',` +
       `${r.ObsLocation.Latitude},${r.ObsLocation.Longitude},${lang},${r.Observer.CompetenceLevelTID})`;
 

--- a/src/app/core/services/sqlite/sqlite.service.ts
+++ b/src/app/core/services/sqlite/sqlite.service.ts
@@ -89,6 +89,10 @@ const UPGRADE_STATEMENTS = [
       'DELETE FROM registration_sync_time;',
     ],
   },
+  {
+    toVersion: 5,
+    statements: ['ALTER TABLE registration ADD COLUMN observer_competence INTEGER;'],
+  },
 ];
 
 @Injectable({
@@ -281,6 +285,14 @@ export class SqliteService {
     }
   }
 
+  // competance = [105, 120, 130, 150];
+  // return either one competence or OR LIKE 105
+  private async queryCompetences(competenceIds: number[]) {
+    if (competenceIds.length == 1) {
+      return;
+    }
+  }
+
   private async cleanupRegistrations() {
     const twoWeeksAgo = moment().subtract(14, 'days').valueOf();
     const statement = `DELETE FROM registration WHERE reg_time < ${twoWeeksAgo}`;
@@ -351,6 +363,7 @@ export class SqliteService {
       'geo_hazard',
       'observer_id',
       'observer_nick',
+      'observer_competence',
       'data',
       'obs_time',
       'reg_time',
@@ -369,6 +382,7 @@ export class SqliteService {
     //   reg.GeoHazardTID,
     //   reg.Observer.ObserverID,
     //   `'${reg.Observer.NickName}'`,
+    //   `'${reg.Observer.CompetenceLevelTID}'`
     //   `'${JSON.stringify(reg)}'`,
     //   dateToMs(reg.DtObsTime),
     //   dateToMs(reg.DtRegTime),
@@ -379,7 +393,9 @@ export class SqliteService {
     // ].join(',')})`;
 
     const regToValues = (r: RegistrationViewModel) =>
-      `(${r.RegId},${r.GeoHazardTID},${r.Observer.ObserverID},'${r.Observer.NickName}','${toJson(r)}',` +
+      `(${r.RegId},${r.GeoHazardTID},${r.Observer.ObserverID},'${r.Observer.NickName}','${
+        r.Observer.CompetenceLevelTID
+      }', '${toJson(r)}',` +
       `${dateToMs(r.DtObsTime)},${dateToMs(r.DtRegTime)},${dateToMs(r.DtChangeTime)},'${appMode}',` +
       `${r.ObsLocation.Latitude},${r.ObsLocation.Longitude},${lang})`;
 

--- a/src/app/core/services/sqlite/sqlite.service.ts
+++ b/src/app/core/services/sqlite/sqlite.service.ts
@@ -93,12 +93,7 @@ const UPGRADE_STATEMENTS = [
   },
   {
     toVersion: 5,
-    statements: [
-      'ALTER TABLE registration ADD COLUMN observer_competence INTEGER;',
-      'ALTER TABLE registration_sync_time ADD COLUMN observer_competence INTEGER;',
-      // Remove sync time to force a new sync with observer_competence
-      'DELETE FROM registration_sync_time;',
-    ],
+    statements: ['ALTER TABLE registration ADD COLUMN observer_competence INTEGER;'],
   },
 ];
 
@@ -285,7 +280,7 @@ export class SqliteService {
     if (searchCriteria.Extent?.TopLeft?.Longitude != null) {
       where.push(`lon >= ${searchCriteria.Extent.TopLeft.Longitude}`);
     }
-    if (searchCriteria.ObserverCompetence != null) {
+    if (!searchCriteria.ObserverCompetence?.length) {
       where.push(`observer_competence IN (${searchCriteria.ObserverCompetence.join(',')})`);
     }
 


### PR DESCRIPTION
 Oppdaterte sqlite db til versjon 5 med kolonne observer_competence som henter CompetenceLevelTID fra observasjoner. 

Vi bruker sqlite sin IN query metode for å filtrere kompetanser basert på ObserverCompetence arrayet
