### PR TITLE
RO-2247: Skjul filtrene som ikke støttes

### DIFF
--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -6,7 +6,7 @@
   <app-date-range *ngIf="!isIosOrAndroid"></app-date-range>
   <app-update-observations></app-update-observations>
 
-  <ng-container *ngIf="filterSupportPerPlatform[this.platformType].observationType">
+  <ng-container *ngIf="isSupported('observationType')">
     <ion-list-header color="varsom-blue" class="ion-no-margin">
       <app-selected-items-counter-label
         [selectedItemsCount]="observationTypesSelectedCount"
@@ -30,7 +30,7 @@
     </ion-item>
   </ng-container>
 
-  <ng-container *ngIf="filterSupportPerPlatform[this.platformType].competence">
+  <ng-container *ngIf="isSupported('competence')">
     <ion-list-header color="varsom-blue" class="ion-no-margin">
       <ion-label>
         {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.TITLE" | translate }}
@@ -65,7 +65,7 @@
     </ion-item>
   </ng-container>
 
-  <ng-container *ngIf="filterSupportPerPlatform[this.platformType].nickName">
+  <ng-container *ngIf="isSupported('nickName')">
     <ion-item>
       <ion-label class="no-margin-bottom" color="dark" position="stacked">{{
         "OBSERVATION_FILTER.NICK_FILTER.TITLE" | translate

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -5,70 +5,82 @@
   <app-observations-days-back *ngIf="isIosOrAndroid"></app-observations-days-back>
   <app-date-range *ngIf="!isIosOrAndroid"></app-date-range>
   <app-update-observations></app-update-observations>
-  <ion-list-header color="varsom-blue" class="ion-no-margin">
-    <app-selected-items-counter-label
-      [selectedItemsCount]="observationTypesSelectedCount"
-    ></app-selected-items-counter-label>
-  </ion-list-header>
 
-  <ion-item>
-    <ion-list lines="none">
-      <ng-container *ngFor="let type of observationTypesOptions">
-        <ion-item class="item-height">
-          <ion-checkbox
-            [checked]="type.isChecked"
-            (click)="setNewType($event, type.parentId, type.id)"
-            color="varsom-dark-blue"
-          >
-          </ion-checkbox>
-          <ion-label class="ion-padding-start">{{ type.name }}</ion-label>
-        </ion-item>
-      </ng-container>
-    </ion-list>
-  </ion-item>
+  <ng-container *ngIf="filterSupportPerPlatform[this.platformType].observationType">
+    <ion-list-header color="varsom-blue" class="ion-no-margin">
+      <app-selected-items-counter-label
+        [selectedItemsCount]="observationTypesSelectedCount"
+      ></app-selected-items-counter-label>
+    </ion-list-header>
 
-  <ion-list-header color="varsom-blue" class="ion-no-margin">
-    <ion-label>
-      {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.TITLE" | translate }}
-    </ion-label>
-  </ion-list-header>
-  <ion-item *ngIf="competenceOptions">
-    <ion-label class="no-margin-bottom" color="dark" position="stacked">{{
-      "OBSERVATION_FILTER.COMPETANCE_FILTER.LABEL" | translate
-    }}</ion-label>
-    <ion-select [interface]="popupType" [value]="chosenCompetenceValue" (ionChange)="onSelectCompetenceChange($event)">
-      <ion-select-option *ngFor="let co of competenceOptions" [value]="co">
-        {{ co.name }}
-      </ion-select-option>
-    </ion-select>
-  </ion-item>
-  <ion-item *ngIf="automaticStationCompetenceItem">
-    <ion-checkbox
-      [checked]="isAutomaticStationChecked"
-      color="varsom-dark-blue"
-      mode="md"
-      [value]="automaticStationCompetenceItem"
-      (ionChange)="onCheckAutomaticStations($event)"
-    >
-    </ion-checkbox>
-    <ion-label class="ion-padding-start"
-      >{{ "OBSERVATION_FILTER.COMPETANCE_FILTER.AUTOMATIC_STATIONS" | translate }}
-    </ion-label>
-  </ion-item>
-  <ion-item>
-    <ion-label class="no-margin-bottom" color="dark" position="stacked">{{
-      "OBSERVATION_FILTER.NICK_FILTER.TITLE" | translate
-    }}</ion-label>
-    <ion-searchbar
-      [value]="nickName"
-      [debounce]="1000"
-      mode="ios"
-      class="ion-no-padding"
-      [placeholder]="'OBSERVATION_FILTER.NICK_FILTER.PLACEHOLDER' | translate"
-      (ionChange)="setNickName($event)"
-    >
-    </ion-searchbar>
-  </ion-item>
+    <ion-item>
+      <ion-list lines="none">
+        <ng-container *ngFor="let type of observationTypesOptions">
+          <ion-item class="item-height">
+            <ion-checkbox
+              [checked]="type.isChecked"
+              (click)="setNewType($event, type.parentId, type.id)"
+              color="varsom-dark-blue"
+            >
+            </ion-checkbox>
+            <ion-label class="ion-padding-start">{{ type.name }}</ion-label>
+          </ion-item>
+        </ng-container>
+      </ion-list>
+    </ion-item>
+  </ng-container>
+
+  <ng-container *ngIf="filterSupportPerPlatform[this.platformType].competence">
+    <ion-list-header color="varsom-blue" class="ion-no-margin">
+      <ion-label>
+        {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.TITLE" | translate }}
+      </ion-label>
+    </ion-list-header>
+    <ion-item *ngIf="competenceOptions">
+      <ion-label class="no-margin-bottom" color="dark" position="stacked">{{
+        "OBSERVATION_FILTER.COMPETANCE_FILTER.LABEL" | translate
+      }}</ion-label>
+      <ion-select
+        [interface]="popupType"
+        [value]="chosenCompetenceValue"
+        (ionChange)="onSelectCompetenceChange($event)"
+      >
+        <ion-select-option *ngFor="let co of competenceOptions" [value]="co">
+          {{ co.name }}
+        </ion-select-option>
+      </ion-select>
+    </ion-item>
+    <ion-item *ngIf="automaticStationCompetenceItem">
+      <ion-checkbox
+        [checked]="isAutomaticStationChecked"
+        color="varsom-dark-blue"
+        mode="md"
+        [value]="automaticStationCompetenceItem"
+        (ionChange)="onCheckAutomaticStations($event)"
+      >
+      </ion-checkbox>
+      <ion-label class="ion-padding-start"
+        >{{ "OBSERVATION_FILTER.COMPETANCE_FILTER.AUTOMATIC_STATIONS" | translate }}
+      </ion-label>
+    </ion-item>
+  </ng-container>
+
+  <ng-container *ngIf="filterSupportPerPlatform[this.platformType].nickName">
+    <ion-item>
+      <ion-label class="no-margin-bottom" color="dark" position="stacked">{{
+        "OBSERVATION_FILTER.NICK_FILTER.TITLE" | translate
+      }}</ion-label>
+      <ion-searchbar
+        [value]="nickName"
+        [debounce]="1000"
+        mode="ios"
+        class="ion-no-padding"
+        [placeholder]="'OBSERVATION_FILTER.NICK_FILTER.PLACEHOLDER' | translate"
+        (ionChange)="setNickName($event)"
+      >
+      </ion-searchbar>
+    </ion-item>
+  </ng-container>
 
   <ion-item>
     <ion-button (click)="onResetFilters()" class="resetFiltersButton" type="button" fill="clear">

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -97,7 +97,7 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
       nickName: true,
     },
     web: {
-      observationType: false,
+      observationType: true,
       competence: true,
       nickName: true,
     },

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -28,9 +28,10 @@ interface ObservationTypeView {
 }
 
 type PlatformType = 'app' | 'web';
+type FilterType = 'observationType' | 'competence' | 'nickName';
 
 type FilterSupportPerPlatform = {
-  [platformType in PlatformType]: { [filter: string]: boolean };
+  [platformType in PlatformType]: { [filter in FilterType]: boolean };
 };
 
 interface CompetenceItem {
@@ -96,7 +97,7 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
       nickName: true,
     },
     web: {
-      observationType: true,
+      observationType: false,
       competence: true,
       nickName: true,
     },
@@ -150,6 +151,10 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
       this.nickName = criteria.ObserverNickName;
       this.cdr.markForCheck();
     });
+  }
+
+  isSupported(filterType: FilterType): boolean {
+    return this.filterSupportPerPlatform[this.platformType][filterType];
   }
 
   async onResetFilters() {

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -27,6 +27,12 @@ interface ObservationTypeView {
   parentId: number;
 }
 
+type PlatformType = 'app' | 'web';
+
+type FilterSupportPerPlatform = {
+  [platformType in PlatformType]: { [filter: string]: boolean };
+};
+
 interface CompetenceItem {
   name: string;
   value: string;
@@ -73,6 +79,7 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
   popupType: SelectInterface;
   isIosOrAndroid: boolean;
   isMobileWeb: boolean;
+  platformType: PlatformType;
   nickName: string | null = null;
   observationTypesOptions: ObservationTypeView[] = [];
   competenceOptions: CompetenceItem[] = [];
@@ -81,6 +88,19 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
   currentGeoHazard: GeoHazard[];
   chosenCompetenceValue: CompetenceItem;
   observationTypesSelectedCount = 0;
+
+  filterSupportPerPlatform: FilterSupportPerPlatform = {
+    app: {
+      observationType: false,
+      competence: true,
+      nickName: true,
+    },
+    web: {
+      observationType: true,
+      competence: true,
+      nickName: true,
+    },
+  };
 
   constructor(
     private platform: Platform,
@@ -97,6 +117,7 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     this.popupType = isAndroidOrIos(this.platform) ? 'action-sheet' : 'popover';
     this.isIosOrAndroid = isAndroidOrIos(this.platform);
     this.isMobileWeb = this.platform.is('mobileweb');
+    this.platformType = this.isIosOrAndroid ? 'app' : 'web';
 
     combineLatest([
       //combining both searchCriteria and currentGeoHazard to ensure they both are being resolved in a proper order


### PR DESCRIPTION
Tenkte at det er kanskje lurt å ha alt i  filterComponent så det er mer tilgjengelig siden det er denne komponenten som faktisk viser filtrene. Appen sjekker hvilken platform kjøres og så basert på den filtrene tilpasser seg i viewet.  