### PR TITLE
RO-2225: Ikke søke på nytt når kartusnitt endres hvis vi ikke er i (hoved)kartvisning

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -5,7 +5,6 @@ import {
   BehaviorSubject,
   combineLatest,
   debounceTime,
-  filter,
   firstValueFrom,
   map,
   Observable,
@@ -15,7 +14,6 @@ import {
   startWith,
   Subject,
   tap,
-  withLatestFrom,
 } from 'rxjs';
 import { Immutable } from 'src/app/core/models/immutable';
 import { GeoHazard, LangKey } from 'src/app/modules/common-core/models';
@@ -32,7 +30,6 @@ import { UserSettingService } from '../user-setting/user-setting.service';
 import { UrlParams } from './url-params';
 import { URL_PARAM_NW_LAT, URL_PARAM_NW_LON, URL_PARAM_SE_LAT, URL_PARAM_SE_LON } from './coordinatesUrl';
 import { isoDateTimeToLocalDate, convertToIsoDateTime } from '../../../modules/common-core/helpers/date-converters';
-import { TABS, TabsService } from 'src/app/pages/tabs/tabs.service';
 
 export type SearchCriteriaOrderBy = 'DtObsTime' | 'DtChangeTime';
 

--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -290,9 +290,8 @@ export class OfflineCapableSearchService extends SearchService {
       lastSyncMs = await this.sqlite.readRegistrationsSyncTime(appMode, langKey);
     } catch (error) {
       this.logger.log(`Failed to read last sync ms`, error, LogLevel.Warning, DEBUG_TAG);
-      lastSyncMs = 0;
     }
-    return lastSyncMs;
+    return lastSyncMs || 0;
   }
 
   /**

--- a/src/app/core/services/sqlite/sqlite.service.ts
+++ b/src/app/core/services/sqlite/sqlite.service.ts
@@ -159,12 +159,10 @@ export class SqliteService {
   }
 
   private async reset() {
-    this.ready.next(false);
     this.logger.debug('Reset', DEBUG_TAG);
     await this.closeConn();
     await this.openConn();
     this.logger.debug('Reset done', DEBUG_TAG);
-    this.ready.next(true);
   }
 
   private async openConn() {
@@ -176,6 +174,7 @@ export class SqliteService {
       this.conn = await this.sqlite.createConnection(DATABASE_NAME, false, 'no-encryption', 5, false);
       this.logger.debug('Open connection', DEBUG_TAG);
       await this.conn.open();
+      this.ready.next(true);
     } catch (error) {
       this.logger.error(error, DEBUG_TAG, 'Failed to create/open connection');
       throw error;
@@ -184,6 +183,7 @@ export class SqliteService {
 
   private async closeConn() {
     this.logger.debug('Closing connection', DEBUG_TAG);
+    this.ready.next(false);
     try {
       await this.sqlite.closeConnection(DATABASE_NAME, false);
       this.logger.debug('Connection closed', DEBUG_TAG);
@@ -244,7 +244,7 @@ export class SqliteService {
       `SELECT * FROM registration_sync_time WHERE app_mode='${appMode}' AND lang=${lang};`
     );
     this.logger.debug('Sync time', DEBUG_TAG, result);
-    return result.values[0].sync_time_ms;
+    return result.values[0]?.sync_time_ms;
   }
 
   private searchCriteriaToWhere(searchCriteria: SearchCriteria): string {

--- a/src/app/modules/common-regobs-api/services/search.service.ts
+++ b/src/app/modules/common-regobs-api/services/search.service.ts
@@ -86,6 +86,7 @@ class SearchService extends __BaseService {
    * @return OK
    */
   SearchSearch(criteria: SearchCriteriaRequestDto): __Observable<Array<RegistrationViewModel>> {
+    console.log('[DEBUG][SearchService] SearchSearch triggered', criteria); //TODO: Fjerne dette når vi ikke har bruk for logging lengre
     return this.SearchSearchResponse(criteria).pipe(
       __map(_r => _r.body as Array<RegistrationViewModel>)
     );
@@ -136,6 +137,7 @@ class SearchService extends __BaseService {
    * @return OK
    */
   SearchPostSearchMyRegistrations(criteria: SearchCriteriaExclUserRequestDto): __Observable<Array<RegistrationViewModel>> {
+    console.log('[DEBUG][SearchService] SearchPostSearchMyRegistrations triggered', criteria); //TODO: Fjerne dette når vi ikke har bruk for logging lengre
     return this.SearchPostSearchMyRegistrationsResponse(criteria).pipe(
       __map(_r => _r.body as Array<RegistrationViewModel>)
     );
@@ -389,6 +391,7 @@ class SearchService extends __BaseService {
    * @return OK
    */
   SearchAtAGlance(criteria: SearchCriteriaRequestDto): __Observable<Array<AtAGlanceViewModel>> {
+    console.log('[DEBUG][SearchService] SearchAtAGlance triggered', criteria); //TODO: Fjerne dette når vi ikke har bruk for logging lengre
     return this.SearchAtAGlanceResponse(criteria).pipe(
       __map(_r => _r.body as Array<AtAGlanceViewModel>)
     );

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -560,6 +560,10 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private updateMapView() {
+    this.loggingService.debug(
+      `updateMapView: updateMapViewOnExtentChange = ${this.updateMapViewOnExtentChange}, isActive = ${this.isActive.value}`,
+      DEBUG_TAG
+    );
     if (this.updateMapViewOnExtentChange && this.isActive.value) {
       this.mapService.updateMapView({
         bounds: this.map.getBounds(),

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -92,6 +92,11 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() showObserverTrips = false;
 
   /**
+   * Update MapService.mapView$ when extent changes
+   */
+  @Input() updateMapViewOnExtentChange = false;
+
+  /**
    * Set to true to show the user location in map.
    * NB: activateFollowModeOnStartup controls if the map should start following the user or not.
    */
@@ -373,7 +378,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     });
 
     this.zone.runOutsideAngular(() => {
-      this.map.on('moveend', () => this.onMapMoveEnd());
+      this.map.on('moveend', () => this.updateMapView());
     });
 
     this.fullscreenService.isFullscreen$.pipe(takeUntil(this.ngDestroy$)).subscribe(() => {
@@ -545,10 +550,6 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     this.mapService.sendMapMoveStart();
   }
 
-  private onMapMoveEnd() {
-    this.updateMapView();
-  }
-
   private disableFollowMode() {
     if (!this.isDoingMoveAction) {
       this.loggingService.debug('Disable follow mode!', DEBUG_TAG);
@@ -559,11 +560,13 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private updateMapView() {
-    this.mapService.updateMapView({
-      bounds: this.map.getBounds(),
-      center: this.map.getCenter(),
-      zoom: this.map.getZoom(),
-    });
+    if (this.updateMapViewOnExtentChange && this.isActive.value) {
+      this.mapService.updateMapView({
+        bounds: this.map.getBounds(),
+        center: this.map.getCenter(),
+        zoom: this.map.getZoom(),
+      });
+    }
   }
 
   private getTileLayerDefaultOptions(useRetinaMap = false): IRegObsTileLayerOptions {

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -560,10 +560,6 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private updateMapView() {
-    this.loggingService.debug(
-      `updateMapView: updateMapViewOnExtentChange = ${this.updateMapViewOnExtentChange}, isActive = ${this.isActive.value}`,
-      DEBUG_TAG
-    );
     if (this.updateMapViewOnExtentChange && this.isActive.value) {
       this.mapService.updateMapView({
         bounds: this.map.getBounds(),

--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -14,7 +14,6 @@ import {
   skipWhile,
   take,
   filter,
-  withLatestFrom,
 } from 'rxjs/operators';
 import { IMapViewAndArea } from './map-view-and-area.interface';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
@@ -28,7 +27,6 @@ import {
   URL_PARAM_SE_LAT,
   URL_PARAM_SE_LON,
 } from 'src/app/core/services/search-criteria/coordinatesUrl';
-import { TABS, TabsService } from 'src/app/pages/tabs/tabs.service';
 
 const DEBUG_TAG = 'MapService';
 
@@ -122,11 +120,7 @@ export class MapService {
     this._showUserLocationSubject.next(value);
   }
 
-  constructor(
-    private userSettingService: UserSettingService,
-    private loggingService: LoggingService,
-    tabsService: TabsService
-  ) {
+  constructor(private userSettingService: UserSettingService, private loggingService: LoggingService) {
     this._showUserLocationSubject = new BehaviorSubject<boolean>(true);
     this._showUserLocationObservable = this._showUserLocationSubject.asObservable();
     this._followModeSubject = new BehaviorSubject<boolean>(false);
@@ -138,16 +132,6 @@ export class MapService {
     this._mapView$ = this._mapViewSubject.asObservable().pipe(
       debounceTime(200),
       tap((val) => this.loggingService.debug('MapView updated', DEBUG_TAG, val)),
-      withLatestFrom(tabsService.selectedTab$),
-      filter(([, tab]) => {
-        if (tab === TABS.HOME) {
-          return true;
-        }
-        this.loggingService.debug('Ignored last mapView update because home page is not active', DEBUG_TAG);
-        return false;
-      }), //only mapView changes when home page is active is relevant
-      map(([mapView]) => mapView),
-      tap((val) => this.loggingService.debug('MapView updated when home page is active', DEBUG_TAG, val)),
       shareReplay(1)
     );
     this._relevantMapChange$ = this.getMapViewThatHasRelevantChange();

--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -54,6 +54,10 @@ export const parseCoordinatesFromUrl = (url: URL): IMapView => {
   }
 };
 
+/**
+ * Common data and functions for MapComponent.
+ * Some functions and data are based on the map on HomePage only
+ */
 @Injectable({
   providedIn: 'root',
 })
@@ -71,14 +75,23 @@ export class MapService {
   private _mapMoveStart$: Observable<IMapView>;
   private _relevantMapChange$: Observable<IMapView>;
 
+  /**
+   * Extent, center and zoom for the map in HomePage
+   */
   get mapView$(): Observable<IMapView> {
     return this._mapView$;
   }
 
+  /**
+   * Extent, center, zoom and area info for the map in HomePage
+   */
   get mapViewAndAreaObservable$(): Observable<IMapViewAndArea> {
     return this._mapViewAndAreaObservable;
   }
 
+  /**
+   * Noticeable changes in extent, center and zoom for the map in HomePage
+   */
   get relevantMapChange$(): Observable<IMapView> {
     return this._relevantMapChange$;
   }

--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -14,6 +14,7 @@ import {
   skipWhile,
   take,
   filter,
+  withLatestFrom,
 } from 'rxjs/operators';
 import { IMapViewAndArea } from './map-view-and-area.interface';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
@@ -27,6 +28,7 @@ import {
   URL_PARAM_SE_LAT,
   URL_PARAM_SE_LON,
 } from 'src/app/core/services/search-criteria/coordinatesUrl';
+import { TABS, TabsService } from 'src/app/pages/tabs/tabs.service';
 
 const DEBUG_TAG = 'MapService';
 
@@ -120,7 +122,11 @@ export class MapService {
     this._showUserLocationSubject.next(value);
   }
 
-  constructor(private userSettingService: UserSettingService, private loggingService: LoggingService) {
+  constructor(
+    private userSettingService: UserSettingService,
+    private loggingService: LoggingService,
+    tabsService: TabsService
+  ) {
     this._showUserLocationSubject = new BehaviorSubject<boolean>(true);
     this._showUserLocationObservable = this._showUserLocationSubject.asObservable();
     this._followModeSubject = new BehaviorSubject<boolean>(false);
@@ -132,6 +138,16 @@ export class MapService {
     this._mapView$ = this._mapViewSubject.asObservable().pipe(
       debounceTime(200),
       tap((val) => this.loggingService.debug('MapView updated', DEBUG_TAG, val)),
+      withLatestFrom(tabsService.selectedTab$),
+      filter(([, tab]) => {
+        if (tab === TABS.HOME) {
+          return true;
+        }
+        this.loggingService.debug('Ignored last mapView update because home page is not active', DEBUG_TAG);
+        return false;
+      }), //only mapView changes when home page is active is relevant
+      map(([mapView]) => mapView),
+      tap((val) => this.loggingService.debug('MapView updated when home page is active', DEBUG_TAG, val)),
       shareReplay(1)
     );
     this._relevantMapChange$ = this.getMapViewThatHasRelevantChange();

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
@@ -4,6 +4,7 @@
     [showSupportMaps]="false"
     (mapReady)="onMapReady($event)"
     [center]="locationMarker.getLatLng()"
+    [geoTag]="'SetLocationInMapComponent'"
   ></app-map>
   <div class="bottom-background flex-row">
     <div class="bottom-info flex-col flex-grow">

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.spec.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.spec.ts
@@ -1,25 +1,44 @@
-// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { latLng } from 'leaflet';
+import { IMapView } from 'src/app/modules/map/services/map/map-view.interface';
+import { mapCenterIsStableOrNotAvailable } from './set-location-in-map.component';
 
-// import { SetLocationInMapComponent } from './set-location-in-map.component';
+describe('SetLocationInMapComponent', () => {
+  it('mapCenterIsStableOrNotAvailable() should work', () => {
+    const london: IMapView = {
+      bounds: null,
+      zoom: null,
+      center: latLng(0, 0),
+    };
+    const nearLondon: IMapView = {
+      bounds: null,
+      zoom: null,
+      center: latLng(0.0000001, 0),
+    };
+    const nve: IMapView = {
+      bounds: null,
+      zoom: null,
+      center: latLng(59.9315, 10.7192),
+    };
+    const noCenter: IMapView = {
+      bounds: null,
+      zoom: null,
+      center: null,
+    };
 
-// describe('SetLocationInMapComponent', () => {
-//   let component: SetLocationInMapComponent;
-//   let fixture: ComponentFixture<SetLocationInMapComponent>;
+    // current map center is not available
+    expect(mapCenterIsStableOrNotAvailable(null, null)).toBeTrue();
+    expect(mapCenterIsStableOrNotAvailable(noCenter, noCenter)).toBeTrue();
+    expect(mapCenterIsStableOrNotAvailable(null, noCenter)).toBeTrue();
+    expect(mapCenterIsStableOrNotAvailable(london, null)).toBeTrue();
+    expect(mapCenterIsStableOrNotAvailable(london, noCenter)).toBeTrue();
 
-//   beforeEach(async(() => {
-//     TestBed.configureTestingModule({
-//       declarations: [ SetLocationInMapComponent ]
-//     })
-//     .compileComponents();
-//   }));
+    // current map center has not changed
+    expect(mapCenterIsStableOrNotAvailable(london, london)).toBeTrue();
+    expect(mapCenterIsStableOrNotAvailable(london, nearLondon)).toBeTrue();
 
-//   beforeEach(() => {
-//     fixture = TestBed.createComponent(SetLocationInMapComponent);
-//     component = fixture.componentInstance;
-//     fixture.detectChanges();
-//   });
-
-//   it('should create', () => {
-//     expect(component).toBeTruthy();
-//   });
-// });
+    // current map center has changed
+    expect(mapCenterIsStableOrNotAvailable(noCenter, london)).toBeFalse();
+    expect(mapCenterIsStableOrNotAvailable(null, london)).toBeFalse();
+    expect(mapCenterIsStableOrNotAvailable(london, nve)).toBeFalse();
+  });
+});

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -234,9 +234,15 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
         });
     }
 
-    this.mapView.pipe(distinctUntilChanged(), takeUntil(this.ngDestroy$)).subscribe(() => {
-      this.updateMapViewInfo();
-    });
+    this.mapView
+      .pipe(
+        // ikke søke på nytt hvis kartsenter ikke flytter seg nevneverdig (f.eks. ved zoom)
+        distinctUntilChanged((prev, curr) => curr?.center?.distanceTo(prev?.center) < 5),
+        takeUntil(this.ngDestroy$)
+      )
+      .subscribe(() => {
+        this.updateMapViewInfo();
+      });
 
     this.mapService.followMode$.pipe(takeUntil(this.ngDestroy$)).subscribe((val) => {
       this.followMode = val;

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -227,9 +227,8 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
         this.isLoading = true;
       });
     });
-    this.map.on('dragend', () => {
-      this.mapView.next(this.getCurrentMapView());
-    });
+    this.map.on('dragend', () => this.mapView.next(this.getCurrentMapView()));
+    this.map.on('zoomend', () => this.mapView.next(this.getCurrentMapView()));
     this.map.on('drag', () => this.moveLocationMarkerToCenter());
 
     if (this.showPreviousUsedLocations) {

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -6,6 +6,7 @@
     [geoTag]="'HomePage'"
     [showObserverTrips]="true"
     [activateFollowModeOnStartup]="activateFollowModeInMapOnStartup"
+    [updateMapViewOnExtentChange]="true"
   ></app-map>
 
   <app-map-center-info *ngIf="userSettingService.showMapCenter$ | async"></app-map-center-info>

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -242,11 +242,11 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked {
   async onEnter() {
     this.checkIfShouldSearchCriteriaUpdateOnEnter();
     this.loggingService.debug('Home page ionViewDidEnter.', DEBUG_TAG);
-    const userSettings = await this.userSettingService.userSetting$.pipe(take(1)).toPromise();
-    if (userSettings.showGeoSelectInfo) {
-      this.loggingService.debug('Display coachmarks, wait with starting geopostion', DEBUG_TAG);
-      return;
-    }
+    // const userSettings = await this.userSettingService.userSetting$.pipe(take(1)).toPromise();
+    // if (userSettings.showGeoSelectInfo) {
+    //   this.loggingService.debug('Display coachmarks, wait with starting geopostion', DEBUG_TAG);
+    //   return;
+    // }
     this.loggingService.debug('Activate map updates and GeoLocation', DEBUG_TAG);
     this.mapComponent.componentIsActive(true);
     this.updateInfoBoxHeight();

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -241,13 +241,7 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked {
 
   async onEnter() {
     this.checkIfShouldSearchCriteriaUpdateOnEnter();
-    this.loggingService.debug('Home page ionViewDidEnter.', DEBUG_TAG);
-    // const userSettings = await this.userSettingService.userSetting$.pipe(take(1)).toPromise();
-    // if (userSettings.showGeoSelectInfo) {
-    //   this.loggingService.debug('Display coachmarks, wait with starting geopostion', DEBUG_TAG);
-    //   return;
-    // }
-    this.loggingService.debug('Activate map updates and GeoLocation', DEBUG_TAG);
+    this.loggingService.debug('Home page onEnter, so activate map updates and GeoLocation', DEBUG_TAG);
     this.mapComponent.componentIsActive(true);
     this.updateInfoBoxHeight();
   }


### PR DESCRIPTION
Jeg har nå tatt Jørgen på ordet og heller forsøkt å gå til bunns i når kartutsnittet (MapService.mapView$) endres.
Det står en lengre avhandling om dette i Jira-saken.

Hypotesen jeg ville prøve ut var:
_Hva om vi kun setter MapService.mapView$ fra kartet som brukes i HomePage?
Jeg tror at MapService.mapView$ opprinnelig var ment å være gjeldende kartutsnitt for HomePage. MapService er en singleton og det blir trøbbel når andre instanser av MapComponent endrer MapService.mapView$._
Eneste stedet vi trenger kartutsnitt/kartsenter fra andre instanser av MapComponent er i SetLocationInMapComponent, der vi henter lokasjoner i kartutsnittet.

Dette har jeg gjort:
- MapComponent påvirker nå ikke MapService.mapView$, hvis ikke det er "skrudd på"  med ny parameter. Kun HomePage gjør dette nå
- Jeg har forsøkt å dokumentere i koden hva jeg tror mapView$ og dens søstre er til, så flere slipper å lure på det. Kanskje burde vi skille MapService i to, en for kartet i HomePage og en generell som kan brukes for alle kart-instanser.
- Under stedfesting har vi nå en lokal variant av mapView$ som bare er for kartet du bruker til stedfesting.
- Litt optimalisering under stedfesting for å unngå at vi kaller API-funksjoner flere ganger enn nødvendig
- Lagt til logging av søk mot API'et slik vi hadde tidligere. Denne forsvant i siste modell-generering
- Har også fjernet koden som gjorde at MapComponent ikke ble satt til aktiv i HomePage når vegviseren ble vist (første-gangs-oppstart). Jørgen løste dette på en bedre måte i servicen som hånterer gps-data.

Gjenstår:
- [x] Teste på iPhone

Dette bør testes:

- å endre på størrelsen på vinduet når du er i listevisning. Ingen søk skal trigges.
- endre kartutsnitt på offlinekart-sida. Ingen søk skal trigges.
- hente lokasjoner under stedfesting på is. Ingen observasjoner skal hentes
- endre kartusnitt under stedfesting. Sjekk at nye lokasjoner hentes, men ingen observasjoner skal hentes
- sjekk også at vi søker som før ved oppstart av appen både i kart- og listevisning og med og uten kartutsnitt i url
- sjekk at vi søker når vi bytter til kart- og listevisning
NB! Vi søker fortsatt for mange ganger ved oppstart og ved bytte til kart- eller listevisning. Det er egen Jira-sak på det: RO-2237.
- at vi viser observasjoner også første gang vi starter app, både på web og tlf