### PR TITLE
RO-2249 and RO-2153: move closing on click on entire map and changed height on the close button in modal-map-image

### DIFF
--- a/src/app/modules/map/pages/modal-map-image/modal-map-image.page.html
+++ b/src/app/modules/map/pages/modal-map-image/modal-map-image.page.html
@@ -1,5 +1,5 @@
-<ion-content (click)="close()">
-  <ion-fab-button class="close-button">
+<ion-content>
+  <ion-fab-button (click)="close()" class="close-button">
     <ion-icon name="close"></ion-icon>
   </ion-fab-button>
   <app-map-image [location]="location" [allowZoom]="true"></app-map-image>

--- a/src/app/modules/map/pages/modal-map-image/modal-map-image.page.scss
+++ b/src/app/modules/map/pages/modal-map-image/modal-map-image.page.scss
@@ -4,7 +4,7 @@
 
 .close-button {
   position: absolute;
-  top: 10px;
+  top: calc(10px + env(safe-area-inset-top));
   right: 10px;
   z-index: 9999;
 }


### PR DESCRIPTION
Nå skal map-modal lukkes bare når man trykker på X knappen derfor måte jeg også flytte høyde på knappen så at den er bedre tilgjengelig på mobiler med notchen