### PR TITLE
RO-2185: Observasjoner i kartet tegnes ikke på nytt når jeg bytter miljø / app-modus

### DIFF
--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -141,6 +141,9 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked {
 
   ngOnInit() {
     this.fullscreen$ = this.fullscreenService.isFullscreen$;
+    this.userSettingService.appMode$.subscribe((v) => {
+      this.initSearch();
+    });
     this.checkForFirstStartup();
   }
 


### PR DESCRIPTION
Nå skal home page abonnere på endring av appModus$ og starte initSearch på nytt hver gang den bytter