### PR TITLE
RO-2215: sync offline db with deleted registrations

### DIFF
--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -356,6 +356,7 @@ export class OfflineCapableSearchService extends SearchService {
     if (count > 0) {
       for await (const registrations of this.pagedSearch(criteria, count)) {
         this.logger.debug(`Sync: Inserting ${registrations.length} registrations`, DEBUG_TAG);
+        const registrationsWithoutDeleted = await super.SearchRegIdsFromDeletedRegistrations(criteria);
         await this.sqlite.insertRegistrations(registrations, appMode, langKey);
       }
     } else {

--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -356,8 +356,9 @@ export class OfflineCapableSearchService extends SearchService {
     if (count > 0) {
       for await (const registrations of this.pagedSearch(criteria, count)) {
         this.logger.debug(`Sync: Inserting ${registrations.length} registrations`, DEBUG_TAG);
-        const registrationsWithoutDeleted = await super.SearchRegIdsFromDeletedRegistrations(criteria);
         await this.sqlite.insertRegistrations(registrations, appMode, langKey);
+        const regIdsFromDeletedRegs = await firstValueFrom(super.SearchRegIdsFromDeletedRegistrations(criteria));
+        await this.sqlite.deleteRegistrations(regIdsFromDeletedRegs, appMode, langKey);
       }
     } else {
       this.logger.debug(`Sync: No new registrations to fetch`, DEBUG_TAG, { count, criteria });

--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -5,6 +5,7 @@ import {
   combineLatest,
   concatMap,
   distinctUntilChanged,
+  firstValueFrom,
   map,
   Observable,
   of,
@@ -200,6 +201,16 @@ export class SearchRegistrationService {
         this.searchService.SearchCountMyRegistrations(searchCriteria).pipe(map((result) => result.TotalMatches))
     );
   }
+
+  /*async searchRegIdsFromDeletedRegistrations(
+    searchCriteria$: Observable<SearchCriteria>
+  ): Promise<Observable<number[]>> {
+    const searchCriteria = await firstValueFrom(searchCriteria$);
+    const list = await this.searchService.SearchRegIdsFromDeletedRegistrations(
+      searchCriteria as SearchCriteriaRequestDto
+    );
+    return list;
+  }*/
   /**
    * A fast search. Return only a summary of each observation.
    */

--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -5,7 +5,6 @@ import {
   combineLatest,
   concatMap,
   distinctUntilChanged,
-  firstValueFrom,
   map,
   Observable,
   of,
@@ -202,15 +201,6 @@ export class SearchRegistrationService {
     );
   }
 
-  /*async searchRegIdsFromDeletedRegistrations(
-    searchCriteria$: Observable<SearchCriteria>
-  ): Promise<Observable<number[]>> {
-    const searchCriteria = await firstValueFrom(searchCriteria$);
-    const list = await this.searchService.SearchRegIdsFromDeletedRegistrations(
-      searchCriteria as SearchCriteriaRequestDto
-    );
-    return list;
-  }*/
   /**
    * A fast search. Return only a summary of each observation.
    */

--- a/src/app/modules/common-regobs-api/services/search.service.ts
+++ b/src/app/modules/common-regobs-api/services/search.service.ts
@@ -39,7 +39,12 @@ class SearchService extends __BaseService {
     super(config, http);
   }
 
-
+  /**
+   * Returns a list of regIds of deleted registrations
+   * @param criteria Use this to filter out registrations and change ordering of them.
+   * The attribute "ObserverGuid" is deprecated and will be removed in the future.
+   * @return OK
+   */
   SearchRegIdsFromDeletedRegistrationsResponse(criteria: SearchCriteriaRequestDto): __Observable<__StrictHttpResponse<Array<number>>> {
     let __params = this.newParams();
     let __headers = new HttpHeaders();
@@ -63,6 +68,12 @@ class SearchService extends __BaseService {
     );
   }
 
+   /**
+   * Returns a list of regIds of deleted registrations
+   * @param criteria Use this to filter out registrations and change ordering of them.
+   * The attribute "ObserverGuid" is deprecated and will be removed in the future.
+   * @return OK
+   */
   SearchRegIdsFromDeletedRegistrations(criteria: SearchCriteriaRequestDto): __Observable<Array<number>> {
     return this.SearchRegIdsFromDeletedRegistrationsResponse(criteria).pipe(
       __map(_r => _r.body as Array<number>)

--- a/src/app/modules/common-regobs-api/services/search.service.ts
+++ b/src/app/modules/common-regobs-api/services/search.service.ts
@@ -30,12 +30,43 @@ class SearchService extends __BaseService {
   static readonly SearchGetSearchCriteriaPath = '/Search/SearchCriteria/{geoHazards}/{langKey}';
   static readonly SearchSearchCriteriaPath = '/Search/SearchCriteria';
   static readonly SearchAtAGlancePath = '/Search/AtAGlance';
+  static readonly SearchRegIdsFromDeletedRegistrations = '/Search/DeletedRegIds';
 
   constructor(
     config: __Configuration,
     http: HttpClient
   ) {
     super(config, http);
+  }
+
+
+  SearchRegIdsFromDeletedRegistrationsResponse(criteria: SearchCriteriaRequestDto): __Observable<__StrictHttpResponse<Array<number>>> {
+    let __params = this.newParams();
+    let __headers = new HttpHeaders();
+    let __body: any = null;
+    __body = criteria;
+    let req = new HttpRequest<any>(
+      'POST',
+      this.rootUrl + `/Search/DeletedRegIds`,
+      __body,
+      {
+        headers: __headers,
+        params: __params,
+        responseType: 'json'
+      });
+
+    return this.http.request<any>(req).pipe(
+      __filter(_r => _r instanceof HttpResponse),
+      __map((_r) => {
+        return _r as __StrictHttpResponse<Array<number>>;
+      })
+    );
+  }
+
+  SearchRegIdsFromDeletedRegistrations(criteria: SearchCriteriaRequestDto): __Observable<Array<number>> {
+    return this.SearchRegIdsFromDeletedRegistrationsResponse(criteria).pipe(
+      __map(_r => _r.body as Array<number>)
+    );
   }
 
   /**


### PR DESCRIPTION
Count sjekker bare om det er nye observasjoner. Den vil ikke gi beskjed til appen hvis en observasjon ble faktisk slettet derfor denne biten av kode some inserter nye observasjoner men også sletter de som ble slettet på web vil ikke kjøre om count er 0. 
Burde vi også ha noen DeleteCount i tillegg? Hvis ikke så vil appen bli oppdatert med slettede observasjoner bare hvis noen legger til en ny observasjon i mellomtiden.