### PR TITLE
RO:2215 sync offline db with deleted registrations

### DIFF
--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -374,7 +374,7 @@ export class OfflineCapableSearchService extends SearchService {
     const { TotalMatches: appCount } = await firstValueFrom(this.SearchCount(criteria));
 
     if (count !== appCount) {
-      const registrationsWithoutDeleted = await firstValueFrom(super.SearchRegIdsFromDeletedRegistrations(criteria));
+      const registrationsWithoutDeleted = await firstValueFrom(super.SearchGetRegIdsFromDeletedRegistrations(criteria));
       this.logger.debug(`Sync: Deleting registrations: ${registrationsWithoutDeleted}`, DEBUG_TAG);
       await this.sqlite.deleteRegistrations(registrationsWithoutDeleted, appMode);
       this.updateObsService.requestRefresh();

--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -356,6 +356,7 @@ export class OfflineCapableSearchService extends SearchService {
     if (count > 0) {
       for await (const registrations of this.pagedSearch(criteria, count)) {
         this.logger.debug(`Sync: Inserting ${registrations.length} registrations`, DEBUG_TAG);
+        const registrationsWithoutDeleted = await super.SearchRegIdsFromDeletedRegistrations(criteria);
         await this.sqlite.insertRegistrations(registrations, appMode, langKey);
       }
     } else {

--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -363,7 +363,7 @@ export class OfflineCapableSearchService extends SearchService {
     }
   }
 
-  private async fetchAndDeleteRegistrations({ appMode, langKey }: CurrentSyncInfo) {
+  private async removeDeletedRegistrations({ appMode, langKey }: CurrentSyncInfo) {
     const twoWeeksAgo = moment().subtract(14, 'days').format();
     const criteria = {
       FromDtChangeTime: twoWeeksAgo,
@@ -406,7 +406,7 @@ export class OfflineCapableSearchService extends SearchService {
       // so we can fetch registrations added while we request registrations later
       const newSyncTimeMs = moment().valueOf();
       this.logger.debug('New sync time', DEBUG_TAG, { newSyncTimeMs });
-      await Promise.all([this.fetchAndInsertRegistrations(syncInfo), this.fetchAndDeleteRegistrations(syncInfo)]);
+      await Promise.all([this.fetchAndInsertRegistrations(syncInfo), this.removeDeletedRegistrations(syncInfo)]);
       await this.updateSyncTime(syncInfo, newSyncTimeMs);
 
       for (const syncReq of syncRequests) {

--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -364,9 +364,14 @@ export class OfflineCapableSearchService extends SearchService {
   }
 
   private async fetchAndDeleteRegistrations({ appMode, langKey }: CurrentSyncInfo) {
-    const criteria = await this.getSyncSearchCriteria(langKey);
+    const twoWeeksAgo = moment().subtract(14, 'days').format();
+    const criteria = {
+      FromDtChangeTime: twoWeeksAgo,
+      FromDtObsTime: twoWeeksAgo,
+      LangKey: langKey,
+    };
     const { TotalMatches: count } = await firstValueFrom(super.SearchCount(criteria));
-    const appCount = await firstValueFrom(this.SearchCount(criteria));
+    const { TotalMatches: appCount } = await firstValueFrom(this.SearchCount(criteria));
 
     if (count !== appCount) {
       const registrationsWithoutDeleted = await firstValueFrom(super.SearchRegIdsFromDeletedRegistrations(criteria));

--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -352,7 +352,6 @@ export class OfflineCapableSearchService extends SearchService {
     const criteria = await this.getSyncSearchCriteria(langKey);
     this.logger.debug(`Sync criteria`, DEBUG_TAG, { criteria });
     const { TotalMatches: count } = await firstValueFrom(super.SearchCount(criteria));
-    this.SearchCount;
 
     if (count > 0) {
       for await (const registrations of this.pagedSearch(criteria, count)) {

--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -358,6 +358,8 @@ export class OfflineCapableSearchService extends SearchService {
       for await (const registrations of this.pagedSearch(criteria, count)) {
         this.logger.debug(`Sync: Inserting ${registrations.length} registrations`, DEBUG_TAG);
         await this.sqlite.insertRegistrations(registrations, appMode, langKey);
+        const regIdsFromDeletedRegs = await firstValueFrom(super.SearchRegIdsFromDeletedRegistrations(criteria));
+        await this.sqlite.deleteRegistrations(regIdsFromDeletedRegs, appMode, langKey);
       }
     } else {
       this.logger.debug(`Sync: No new registrations to fetch`, DEBUG_TAG, { count, criteria });

--- a/src/app/core/services/search-registration/offline-capable-search-service.ts
+++ b/src/app/core/services/search-registration/offline-capable-search-service.ts
@@ -88,7 +88,7 @@ export class OfflineCapableSearchService extends SearchService {
     addUpdateDeleteRegistrationService: AddUpdateDeleteRegistrationService,
     private toastController: ToastController,
     tabsService: TabsService,
-    updateObsService: UpdateObservationsService
+    private updateObsService: UpdateObservationsService
   ) {
     super(config, http);
 
@@ -109,7 +109,7 @@ export class OfflineCapableSearchService extends SearchService {
           else return new Date(lastFetchedMs);
         })
       )
-      .subscribe((d) => updateObsService.setOfflineObservationsLastFetched(d));
+      .subscribe((d) => this.updateObsService.setOfflineObservationsLastFetched(d));
 
     const canShowOutDatedObsToast$ = combineLatest([
       tabsService.selectedTab$.pipe(map((tab) => [TABS.HOME, TABS.OBSERVATION_LIST].includes(tab))),
@@ -377,6 +377,7 @@ export class OfflineCapableSearchService extends SearchService {
       const registrationsWithoutDeleted = await firstValueFrom(super.SearchRegIdsFromDeletedRegistrations(criteria));
       this.logger.debug(`Sync: Deleting registrations: ${registrationsWithoutDeleted}`, DEBUG_TAG);
       await this.sqlite.deleteRegistrations(registrationsWithoutDeleted, appMode);
+      this.updateObsService.requestRefresh();
     }
   }
 

--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -5,6 +5,7 @@ import {
   combineLatest,
   concatMap,
   distinctUntilChanged,
+  firstValueFrom,
   map,
   Observable,
   of,
@@ -200,6 +201,16 @@ export class SearchRegistrationService {
         this.searchService.SearchCountMyRegistrations(searchCriteria).pipe(map((result) => result.TotalMatches))
     );
   }
+
+  /*async searchRegIdsFromDeletedRegistrations(
+    searchCriteria$: Observable<SearchCriteria>
+  ): Promise<Observable<number[]>> {
+    const searchCriteria = await firstValueFrom(searchCriteria$);
+    const list = await this.searchService.SearchRegIdsFromDeletedRegistrations(
+      searchCriteria as SearchCriteriaRequestDto
+    );
+    return list;
+  }*/
   /**
    * A fast search. Return only a summary of each observation.
    */

--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -5,7 +5,6 @@ import {
   combineLatest,
   concatMap,
   distinctUntilChanged,
-  firstValueFrom,
   map,
   Observable,
   of,
@@ -202,15 +201,6 @@ export class SearchRegistrationService {
     );
   }
 
-  /*async searchRegIdsFromDeletedRegistrations(
-    searchCriteria$: Observable<SearchCriteria>
-  ): Promise<Observable<number[]>> {
-    const searchCriteria = await firstValueFrom(searchCriteria$);
-    const list = await this.searchService.SearchRegIdsFromDeletedRegistrations(
-      searchCriteria as SearchCriteriaRequestDto
-    );
-    return list;
-  }*/
   /**
    * A fast search. Return only a summary of each observation.
    */

--- a/src/app/modules/common-regobs-api/services/search.service.ts
+++ b/src/app/modules/common-regobs-api/services/search.service.ts
@@ -27,57 +27,16 @@ class SearchService extends __BaseService {
   static readonly SearchPostSearchMyRegistrationsPath = '/Search/MyRegistrations';
   static readonly SearchCountMyRegistrationsPath = '/Search/MyRegistrationsCount';
   static readonly SearchCountPath = '/Search/Count';
+  static readonly SearchGetRegIdsFromDeletedRegistrationsPath = '/Search/DeletedRegistrations';
   static readonly SearchGetSearchCriteriaPath = '/Search/SearchCriteria/{geoHazards}/{langKey}';
   static readonly SearchSearchCriteriaPath = '/Search/SearchCriteria';
   static readonly SearchAtAGlancePath = '/Search/AtAGlance';
-  static readonly SearchRegIdsFromDeletedRegistrations = '/Search/DeletedRegIds';
 
   constructor(
     config: __Configuration,
     http: HttpClient
   ) {
     super(config, http);
-  }
-
-  /**
-   * Returns a list of regIds of deleted registrations
-   * @param criteria Use this to filter out registrations and change ordering of them.
-   * The attribute "ObserverGuid" is deprecated and will be removed in the future.
-   * @return OK
-   */
-  SearchRegIdsFromDeletedRegistrationsResponse(criteria: SearchCriteriaRequestDto): __Observable<__StrictHttpResponse<Array<number>>> {
-    let __params = this.newParams();
-    let __headers = new HttpHeaders();
-    let __body: any = null;
-    __body = criteria;
-    let req = new HttpRequest<any>(
-      'POST',
-      this.rootUrl + `/Search/DeletedRegIds`,
-      __body,
-      {
-        headers: __headers,
-        params: __params,
-        responseType: 'json'
-      });
-
-    return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map((_r) => {
-        return _r as __StrictHttpResponse<Array<number>>;
-      })
-    );
-  }
-
-   /**
-   * Returns a list of regIds of deleted registrations
-   * @param criteria Use this to filter out registrations and change ordering of them.
-   * The attribute "ObserverGuid" is deprecated and will be removed in the future.
-   * @return OK
-   */
-  SearchRegIdsFromDeletedRegistrations(criteria: SearchCriteriaRequestDto): __Observable<Array<number>> {
-    return this.SearchRegIdsFromDeletedRegistrationsResponse(criteria).pipe(
-      __map(_r => _r.body as Array<number>)
-    );
   }
 
   /**
@@ -255,6 +214,46 @@ class SearchService extends __BaseService {
   SearchCount(criteria: SearchCriteriaRequestDto): __Observable<SearchCountResponseDto> {
     return this.SearchCountResponse(criteria).pipe(
       __map(_r => _r.body as SearchCountResponseDto)
+    );
+  }
+
+  /**
+   * Returns list of regIds from deleted registrations that can be filtered with criteria model.
+   * Used with offline syncing on mobile devices.
+   * @param criteria Search criteria
+   * @return OK
+   */
+  SearchGetRegIdsFromDeletedRegistrationsResponse(criteria: SearchCriteriaRequestDto): __Observable<__StrictHttpResponse<Array<number>>> {
+    let __params = this.newParams();
+    let __headers = new HttpHeaders();
+    let __body: any = null;
+    __body = criteria;
+    let req = new HttpRequest<any>(
+      'POST',
+      this.rootUrl + `/Search/DeletedRegistrations`,
+      __body,
+      {
+        headers: __headers,
+        params: __params,
+        responseType: 'json'
+      });
+
+    return this.http.request<any>(req).pipe(
+      __filter(_r => _r instanceof HttpResponse),
+      __map((_r) => {
+        return _r as __StrictHttpResponse<Array<number>>;
+      })
+    );
+  }
+  /**
+   * Returns list of regIds from deleted registrations that can be filtered with criteria model.
+   * Used with offline syncing on mobile devices.
+   * @param criteria Search criteria
+   * @return OK
+   */
+  SearchGetRegIdsFromDeletedRegistrations(criteria: SearchCriteriaRequestDto): __Observable<Array<number>> {
+    return this.SearchGetRegIdsFromDeletedRegistrationsResponse(criteria).pipe(
+      __map(_r => _r.body as Array<number>)
     );
   }
 

--- a/src/app/modules/common-regobs-api/services/search.service.ts
+++ b/src/app/modules/common-regobs-api/services/search.service.ts
@@ -39,7 +39,12 @@ class SearchService extends __BaseService {
     super(config, http);
   }
 
-
+  /**
+   * Returns a list of regIds of deleted registrations
+   * @param criteria Use this to filter out registrations and change ordering of them.
+   * The attribute "ObserverGuid" is deprecated and will be removed in the future.
+   * @return OK
+   */
   SearchRegIdsFromDeletedRegistrationsResponse(criteria: SearchCriteriaRequestDto): __Observable<__StrictHttpResponse<Array<number>>> {
     let __params = this.newParams();
     let __headers = new HttpHeaders();
@@ -63,6 +68,12 @@ class SearchService extends __BaseService {
     );
   }
 
+   /**
+   * Returns a list of regIds of deleted registrations
+   * @param criteria Use this to filter out registrations and change ordering of them.
+   * The attribute "ObserverGuid" is deprecated and will be removed in the future.
+   * @return OK
+   */
   SearchRegIdsFromDeletedRegistrations(criteria: SearchCriteriaRequestDto): __Observable<Array<number>> {
     return this.SearchRegIdsFromDeletedRegistrationsResponse(criteria).pipe(
       __map(_r => _r.body as Array<number>)

--- a/src/app/modules/common-regobs-api/services/search.service.ts
+++ b/src/app/modules/common-regobs-api/services/search.service.ts
@@ -30,12 +30,43 @@ class SearchService extends __BaseService {
   static readonly SearchGetSearchCriteriaPath = '/Search/SearchCriteria/{geoHazards}/{langKey}';
   static readonly SearchSearchCriteriaPath = '/Search/SearchCriteria';
   static readonly SearchAtAGlancePath = '/Search/AtAGlance';
+  static readonly SearchRegIdsFromDeletedRegistrations = '/Search/DeletedRegIds';
 
   constructor(
     config: __Configuration,
     http: HttpClient
   ) {
     super(config, http);
+  }
+
+
+  SearchRegIdsFromDeletedRegistrationsResponse(criteria: SearchCriteriaRequestDto): __Observable<__StrictHttpResponse<Array<number>>> {
+    let __params = this.newParams();
+    let __headers = new HttpHeaders();
+    let __body: any = null;
+    __body = criteria;
+    let req = new HttpRequest<any>(
+      'POST',
+      this.rootUrl + `/Search/DeletedRegIds`,
+      __body,
+      {
+        headers: __headers,
+        params: __params,
+        responseType: 'json'
+      });
+
+    return this.http.request<any>(req).pipe(
+      __filter(_r => _r instanceof HttpResponse),
+      __map((_r) => {
+        return _r as __StrictHttpResponse<Array<number>>;
+      })
+    );
+  }
+
+  SearchRegIdsFromDeletedRegistrations(criteria: SearchCriteriaRequestDto): __Observable<Array<number>> {
+    return this.SearchRegIdsFromDeletedRegistrationsResponse(criteria).pipe(
+      __map(_r => _r.body as Array<number>)
+    );
   }
 
   /**

--- a/src/app/pages/view-observation/view-observation.page.html
+++ b/src/app/pages/view-observation/view-observation.page.html
@@ -7,5 +7,20 @@
   </ion-toolbar>
 </ion-header>
 <ion-content *ngIf="registrationViewModel$ | async as registration">
-  <app-observation-list-card [obs]="registration"></app-observation-list-card>
+  <app-observation-list-card *ngIf="registration.reg" [obs]="registration.reg"></app-observation-list-card>
+
+  <ion-card *ngIf="!registration.reg">
+    <ion-card-header>
+      <ion-card-title>Fant ikke observasjonen.</ion-card-title>
+    </ion-card-header>
+
+    <ion-card-content>
+      <p>Det kan være den er slettet fra regobs eller at id-en til observasjonen er ugyldig.</p>
+
+      <div *ngIf="registration.err">
+        <p>Feilmelding:</p>
+        <pre>{{ registration.err.message }}</pre>
+      </div>
+    </ion-card-content>
+  </ion-card>
 </ion-content>

--- a/src/app/pages/view-observation/view-observation.page.ts
+++ b/src/app/pages/view-observation/view-observation.page.ts
@@ -3,10 +3,15 @@ import { ActivatedRoute } from '@angular/router';
 import { RegistrationViewModel } from 'src/app/modules/common-regobs-api/models';
 import { PopupInfoService } from '../../core/services/popup-info/popup-info.service';
 import { NgDestoryBase } from '../../core/helpers/observable-helper';
-import { takeUntil, map } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { takeUntil, map, catchError } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
 import { EditMode } from 'src/app/modules/registration/edit-registration-helper-functions';
 import { SearchService } from 'src/app/modules/common-regobs-api';
+
+interface RegistrationResult {
+  reg?: RegistrationViewModel;
+  err?: Error;
+}
 
 @Component({
   selector: 'app-view-observation',
@@ -16,7 +21,7 @@ import { SearchService } from 'src/app/modules/common-regobs-api';
 })
 export class ViewObservationPage extends NgDestoryBase implements OnInit {
   editMode$: Observable<EditMode>;
-  registrationViewModel$: Observable<RegistrationViewModel>;
+  registrationViewModel$: Observable<RegistrationResult>;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -28,11 +33,20 @@ export class ViewObservationPage extends NgDestoryBase implements OnInit {
 
   ngOnInit() {
     this.popupInfoService.checkObservationInfoPopup().pipe(takeUntil(this.ngDestroy$)).subscribe();
-    const regId = parseInt(this.activatedRoute.snapshot.params['id'], 10);
-    this.registrationViewModel$ = this.searchService
-      .SearchSearch({
-        RegId: regId,
-      })
-      .pipe(map((result) => result[0]));
+    const id = this.activatedRoute.snapshot.params['id'];
+    const regId = parseInt(id, 10);
+
+    if (isNaN(regId)) {
+      this.registrationViewModel$ = of({ err: new Error(`Invalid registration id: "${id}"`) });
+    } else {
+      this.registrationViewModel$ = this.searchService
+        .SearchSearch({
+          RegId: regId,
+        })
+        .pipe(
+          map((result) => ({ reg: result[0] })),
+          catchError((err) => of({ err }))
+        );
+    }
   }
 }


### PR DESCRIPTION
VITKIG: Vi må godkjenne dette først https://dev.azure.com/NVE-devops/Varsom%20Regobs/_git/regobs/pullrequest/3363 

Sjekker om count i api og appen er lik fra den siste synkroniseringen. Hvis api har mindre observasjoner enn app så betyr det at en del må slettes. Tror det kunne vært nyttig og ha en separat kolonne i databasen med syncLastDeleted eller noe så at vi ikke må alltid hente regids fra de to siste ukene men kun fra perioden når sist sletting skjedde. Men det er bare et forslag
Aner ikke hvordan å refreshe observasjoner på kartet etter de blir synket med slettede observasjoner. De forsvinner når jeg flytter på kartet altså når en ny 'api kjøring' skjer. Vet ikke hvordan å bruke det i offline service.

Sletting funka ikke på iphone lokalt hos meg dessverre. Dere kan gjerne teste det selv. Kanskje vi trenger noe mer konfigurasjon? Vanskelig å finne noe på nettet. Den fungerer pent på android.