### PR TITLE
Fix stop trip error

### DIFF
--- a/src/app/core/services/trip-logger/trip-logger.service.ts
+++ b/src/app/core/services/trip-logger/trip-logger.service.ts
@@ -170,16 +170,15 @@ export class TripLoggerService {
         concatMap(() => this.deleteLegacyTripsFromDb()),
         concatMap(() => this.infoMessage(false))
       )
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.tripStartedSubject.next(false);
         },
-        async (error) => {
+        error: async (error) => {
           this.loggingService.error(error, DEBUG_TAG, 'Could not stop trip');
-          this.tripStartedSubject.next(false);
           await this.showTripErrorMessage(false);
-        }
-      );
+        },
+      });
   }
 
   private deleteLegacyTripsFromDb() {


### PR DESCRIPTION
Fikser problemet med at det ser ut som turen er stoppet i appen selv om den egentlig ikke er det.

Har denne som en draft, siden logikken i `callStopLegacyTripApiAndDeleteFromDb` er ganske skjør.
Feks: Requesten for å stoppe tur kan gå gjennom, men lagringen i db feile, da vil denne fiksen virke mot sin hensikt.