### PR TITLE
Add new attachment service for web

### DIFF
--- a/src/app/core/services/add-update-delete-registration/add-update-delete-registration.service.ts
+++ b/src/app/core/services/add-update-delete-registration/add-update-delete-registration.service.ts
@@ -4,7 +4,9 @@ import { AppCustomDimension } from 'src/app/modules/analytics/enums/app-custom-d
 import { AnalyticService } from 'src/app/modules/analytics/services/analytic.service';
 import { LangKey } from 'src/app/modules/common-core/models';
 import { removeEmptyRegistrations } from 'src/app/modules/common-registration/registration.helpers';
-import { RegistrationService, RegistrationViewModel } from 'src/app/modules/common-regobs-api';
+import { AttachmentUploadEditModel } from 'src/app/modules/common-registration/registration.models';
+import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
+import { RegistrationEditModel, RegistrationService, RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 import { RegistrationDraft, RegistrationEditModelWithRemoteOrLocalAttachments } from '../draft/draft-model';
 import { UploadAttachmentsService } from '../upload-attachments/upload-attachments.service';
 import { UserSettingService } from '../user-setting/user-setting.service';
@@ -21,6 +23,7 @@ import { addAttachmentToRegistration } from './attachmentHelpers';
 })
 export class AddUpdateDeleteRegistrationService {
   constructor(
+    private newAttachmentsService: NewAttachmentService,
     private uploadAttachmentsService: UploadAttachmentsService,
     private regobsApiRegistrationService: RegistrationService,
     private userSettings: UserSettingService,
@@ -56,7 +59,8 @@ export class AddUpdateDeleteRegistrationService {
    */
   async add(draft: RegistrationDraft): Promise<RegistrationViewModel> {
     const draftWithoutEmptyRegistrations = removeEmptyRegistrations(draft);
-    const { registration } = await this.uploadAttachments(draftWithoutEmptyRegistrations);
+    const uploadedAttachments = await this.uploadAttachments(draftWithoutEmptyRegistrations);
+    const registration = this.addAttachmentToRegistration(uploadedAttachments, draft.registration);
     const langKey = await firstValueFrom(this.userSettings.language$);
     const registrationWithMeta = this.addMetadata(registration, draft);
 
@@ -95,7 +99,8 @@ export class AddUpdateDeleteRegistrationService {
 
     const langKey = await firstValueFrom(this.userSettings.language$);
     const draftWithoutEmptyRegistrations = removeEmptyRegistrations(draft);
-    const { registration } = await this.uploadAttachments(draftWithoutEmptyRegistrations);
+    const uploadedAttachments = await this.uploadAttachments(draftWithoutEmptyRegistrations);
+    const registration = this.addAttachmentToRegistration(uploadedAttachments, draft.registration);
     const registrationWithMeta = this.addMetadata(registration, draft);
 
     // Send registration to regobs
@@ -138,21 +143,20 @@ export class AddUpdateDeleteRegistrationService {
   /**
    * @returns A new draft with updated attachment info
    */
-  private async uploadAttachments(draft: RegistrationDraft): Promise<RegistrationDraft> {
+  private async uploadAttachments(draft: RegistrationDraft): Promise<AttachmentUploadEditModel[]> {
     const uploadedAttachments = await this.uploadAttachmentsService.uploadAllAttachments(draft);
+    return uploadedAttachments;
+  }
 
-    // Add attachment info to draft
-    let registration = draft.registration;
-    for (const attachment of uploadedAttachments) {
+  private addAttachmentToRegistration(attachments: AttachmentUploadEditModel[], registration: RegistrationEditModel) {
+    let updatedRegistration = { ...registration };
+    for (const attachment of attachments) {
       if (attachment) {
-        registration = addAttachmentToRegistration(attachment, registration);
+        // Legg til fotograf / copyright info her ?
+        updatedRegistration = addAttachmentToRegistration(attachment, updatedRegistration);
       }
     }
-
-    return {
-      ...draft,
-      registration,
-    };
+    return updatedRegistration;
   }
 
   private addMetadata(registration: RegistrationEditModelWithRemoteOrLocalAttachments, draft: RegistrationDraft) {

--- a/src/app/core/services/add-update-delete-registration/add-update-delete-registration.service.ts
+++ b/src/app/core/services/add-update-delete-registration/add-update-delete-registration.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { catchError, firstValueFrom, Observable, Subject, take, tap, timeout } from 'rxjs';
+import { firstValueFrom, Observable, Subject, tap, timeout } from 'rxjs';
 import { AppCustomDimension } from 'src/app/modules/analytics/enums/app-custom-dimension.enum';
 import { AnalyticService } from 'src/app/modules/analytics/services/analytic.service';
 import { LangKey } from 'src/app/modules/common-core/models';

--- a/src/app/core/services/upload-attachments/upload-attachments.service.spec.ts
+++ b/src/app/core/services/upload-attachments/upload-attachments.service.spec.ts
@@ -1,4 +1,3 @@
-import { HttpErrorResponse, HttpEventType, HttpResponse } from '@angular/common/http';
 import { AlertController } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
 import cloneDeep from 'clone-deep';
@@ -6,7 +5,6 @@ import { Observable, of } from 'rxjs';
 import { AttachmentUploadEditModel, SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
 import { DateHelperService } from 'src/app/modules/shared/services/date-helper/date-helper.service';
-import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { RegistrationDraft } from '../draft/draft-model';
 import { UserSettingService } from '../user-setting/user-setting.service';
 import { UploadAttachmentsService } from './upload-attachments.service';

--- a/src/app/core/services/upload-attachments/upload-attachments.service.spec.ts
+++ b/src/app/core/services/upload-attachments/upload-attachments.service.spec.ts
@@ -14,10 +14,11 @@ import { UploadSingleAttachmentService } from './upload-single-attachment.servic
 
 describe('UploadAttachmentsService', () => {
   let service: UploadAttachmentsService;
+  beforeEach(() => {
+    service = new UploadAttachmentsService(null, null, null, null, null, null, null);
+  });
 
   it('should not upload attachments with AttachmentUploadId (already uploaded)', async () => {
-    const httpClient = jasmine.createSpyObj('HttpClient', ['post']);
-
     // List of fake attachments that fake newAttachmentsService will return
     const fakeAttachments: AttachmentUploadEditModel[] = [
       { id: '1234', type: 'Attachment', AttachmentUploadId: '1234' },
@@ -37,7 +38,7 @@ describe('UploadAttachmentsService', () => {
       {} as UploadSingleAttachmentService,
       {} as TranslateService,
       {} as DateHelperService,
-      {} as LoggingService,
+      jasmine.createSpyObj('LoggingService', ['debug', 'error']),
       {
         userSetting$: of({}),
       } as UserSettingService,
@@ -56,32 +57,13 @@ describe('UploadAttachmentsService', () => {
 
     const result = await service.uploadAllAttachments(draft);
 
-    // Test that post is not called at all
-    expect(httpClient.post.calls.any()).toBe(false);
     // Test that uploadAllAttachments just returns the attachments,
     // as they are already uploaded
     expect(result).toEqual(fakeAttachmentsCopy);
   });
 
   it('should upload attachments for attachments without AttachmentUploadId', async () => {
-    const httpClient = jasmine.createSpyObj('HttpClient', ['post']);
     const responseAttachmentUploadId = '12345-test-id';
-
-    httpClient.post.and.returnValue(
-      of(
-        {
-          type: HttpEventType.UploadProgress,
-          loaded: 500,
-          total: 1000,
-        },
-        {
-          type: HttpEventType.UploadProgress,
-          loaded: 1000,
-          total: 1000,
-        },
-        new HttpResponse({ body: responseAttachmentUploadId })
-      )
-    );
 
     const fakeAttachments: AttachmentUploadEditModel[] = [
       { id: '1234', type: 'Attachment', AttachmentUploadId: '1234' },
@@ -96,6 +78,30 @@ describe('UploadAttachmentsService', () => {
     const saveAttachmentMeta$ = jasmine.createSpy();
     saveAttachmentMeta$.and.returnValue(of(true));
 
+    const alertController = {
+      create: async (): Promise<HTMLIonAlertElement> => {
+        return { present: () => null } as HTMLIonAlertElement;
+      },
+    };
+
+    const translateService = {
+      get: (): Observable<any> => {
+        return of('Tranlsation');
+      },
+    };
+
+    const dateHelperService = {
+      formatDateString: (): Observable<string> => {
+        return of('today');
+      },
+    };
+
+    const uploadSingleAttachmentService = {
+      upload: async () => {
+        return { id: '5678', type: 'Attachment', AttachmentUploadId: '12345-test-id' };
+      },
+    };
+
     const newAttachmentService = {
       getAttachments: (): Observable<AttachmentUploadEditModel[]> => {
         return of(fakeAttachments);
@@ -105,17 +111,16 @@ describe('UploadAttachmentsService', () => {
       },
       saveAttachmentMeta$: saveAttachmentMeta$,
     };
-
     service = new UploadAttachmentsService(
       newAttachmentService as unknown as NewAttachmentService,
-      {} as UploadSingleAttachmentService,
-      {} as TranslateService,
-      {} as DateHelperService,
-      jasmine.createSpyObj('LoggingService', ['debug']),
+      uploadSingleAttachmentService as unknown as UploadSingleAttachmentService,
+      translateService as unknown as TranslateService,
+      dateHelperService as unknown as DateHelperService,
+      jasmine.createSpyObj('LoggingService', ['debug', 'error']),
       {
         userSetting$: of({}),
       } as UserSettingService,
-      {} as AlertController
+      alertController as unknown as AlertController
     );
 
     const draft: RegistrationDraft = {
@@ -130,56 +135,12 @@ describe('UploadAttachmentsService', () => {
 
     const result = await service.uploadAllAttachments(draft);
 
-    // Test that we call post one time as we have one image to upload
-    expect(httpClient.post).toHaveBeenCalledTimes(1);
-
     // Test that uploadAllAttachments just returns the attachments,
     // as they are already uploaded
     expect(result).toEqual(addAttachmentsResult);
   });
 
   it('should return failed attachment upload as undefined', async () => {
-    const httpClient = jasmine.createSpyObj('HttpClient', ['post']);
-    const responseAttachmentUploadId = '12345-test-id';
-
-    httpClient.post.and.returnValues(
-      of(
-        {
-          type: HttpEventType.UploadProgress,
-          loaded: 500,
-          total: 1000,
-        },
-        {
-          type: HttpEventType.UploadProgress,
-          loaded: 1000,
-          total: 1000,
-        },
-        new HttpResponse({ body: responseAttachmentUploadId })
-      ),
-      // Second upload will fail, it starts to upload, but gets a server error
-      of(
-        {
-          type: HttpEventType.UploadProgress,
-          loaded: 200,
-          total: 1000,
-        },
-        {
-          type: HttpEventType.UploadProgress,
-          loaded: 500,
-          total: 1000,
-        },
-        {
-          type: HttpEventType.UploadProgress,
-          loaded: 700,
-          total: 1000,
-        },
-        new HttpErrorResponse({
-          error: new Error('Something failed'),
-          status: 500,
-        })
-      )
-    );
-
     const attachmentIdThatFails = '3-abc';
     const fakeAttachments: AttachmentUploadEditModel[] = [
       { id: '1-abc', type: 'Attachment', AttachmentUploadId: '1234' },
@@ -206,18 +167,30 @@ describe('UploadAttachmentsService', () => {
       saveAttachmentMeta$: saveAttachmentMeta$,
     };
 
+    const alertController = {
+      create: async (): Promise<HTMLIonAlertElement> => {
+        return { present: () => null } as HTMLIonAlertElement;
+      },
+    };
+
+    const dateHelperService = {
+      formatDateString: (): Observable<string> => {
+        return of('today');
+      },
+    };
+
     const loggingService = jasmine.createSpyObj('LoggingService', ['debug', 'error']);
 
     service = new UploadAttachmentsService(
       newAttachmentService as unknown as NewAttachmentService,
       {} as UploadSingleAttachmentService,
       translateService as unknown as TranslateService,
-      {} as DateHelperService,
+      dateHelperService as unknown as DateHelperService,
       loggingService,
       {
         userSetting$: of({}),
       } as UserSettingService,
-      {} as AlertController
+      alertController as unknown as AlertController
     );
 
     const regUuid = '12345-abc';
@@ -233,13 +206,12 @@ describe('UploadAttachmentsService', () => {
 
     const expected: AttachmentUploadEditModel[] = [
       { id: '1-abc', type: 'Attachment', AttachmentUploadId: '1234' },
-      { id: '2-abc', type: 'Attachment', AttachmentUploadId: '12345-test-id' },
+      undefined,
       undefined,
     ];
     // Test that uploadAllAttachments returns one fulfilled promise without value
     await expectAsync(service.uploadAllAttachments(draft)).toBeResolvedTo(expected);
 
     expect(loggingService.error).toHaveBeenCalled();
-    expect(httpClient.post).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/core/services/upload-attachments/upload-attachments.service.spec.ts
+++ b/src/app/core/services/upload-attachments/upload-attachments.service.spec.ts
@@ -1,16 +1,16 @@
 import { HttpErrorResponse, HttpEventType, HttpResponse } from '@angular/common/http';
-import { AlertController, ToastController } from '@ionic/angular';
+import { AlertController } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
 import cloneDeep from 'clone-deep';
 import { Observable, of } from 'rxjs';
 import { AttachmentUploadEditModel, SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
-import { AttachmentEditModel, AttachmentService } from 'src/app/modules/common-regobs-api';
 import { DateHelperService } from 'src/app/modules/shared/services/date-helper/date-helper.service';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { RegistrationDraft } from '../draft/draft-model';
 import { UserSettingService } from '../user-setting/user-setting.service';
-import { UploadAttachmentError, UploadAttachmentsService } from './upload-attachments.service';
+import { UploadAttachmentsService } from './upload-attachments.service';
+import { UploadSingleAttachmentService } from './upload-single-attachment.service';
 
 describe('UploadAttachmentsService', () => {
   let service: UploadAttachmentsService;
@@ -33,9 +33,8 @@ describe('UploadAttachmentsService', () => {
     };
 
     service = new UploadAttachmentsService(
-      httpClient,
       newAttachmentService as unknown as NewAttachmentService,
-      {} as AttachmentService,
+      {} as UploadSingleAttachmentService,
       {} as TranslateService,
       {} as DateHelperService,
       {} as LoggingService,
@@ -108,9 +107,8 @@ describe('UploadAttachmentsService', () => {
     };
 
     service = new UploadAttachmentsService(
-      httpClient,
       newAttachmentService as unknown as NewAttachmentService,
-      {} as AttachmentService,
+      {} as UploadSingleAttachmentService,
       {} as TranslateService,
       {} as DateHelperService,
       jasmine.createSpyObj('LoggingService', ['debug']),
@@ -198,15 +196,6 @@ describe('UploadAttachmentsService', () => {
       },
     };
 
-    const toastController = {
-      create: (): string => {
-        return '';
-      },
-      present: (): string => {
-        return '';
-      },
-    };
-
     const newAttachmentService = {
       getAttachments: (): Observable<AttachmentUploadEditModel[]> => {
         return of(fakeAttachments);
@@ -220,9 +209,8 @@ describe('UploadAttachmentsService', () => {
     const loggingService = jasmine.createSpyObj('LoggingService', ['debug', 'error']);
 
     service = new UploadAttachmentsService(
-      httpClient,
       newAttachmentService as unknown as NewAttachmentService,
-      {} as AttachmentService,
+      {} as UploadSingleAttachmentService,
       translateService as unknown as TranslateService,
       {} as DateHelperService,
       loggingService,

--- a/src/app/core/services/upload-attachments/upload-single-attachment.service.ts
+++ b/src/app/core/services/upload-attachments/upload-single-attachment.service.ts
@@ -1,0 +1,77 @@
+import { HttpClient, HttpErrorResponse, HttpEvent, HttpEventType, HttpResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { filter, firstValueFrom, map, Observable, tap } from 'rxjs';
+import { AttachmentUploadEditModel } from 'src/app/modules/common-registration/registration.models';
+import { AttachmentService as ApiAttachmentService } from 'src/app/modules/common-regobs-api';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+
+const DEBUG_TAG = 'UploadSingleAttachmentService';
+
+/**
+ * Upload a single registration attachment (only images yet)
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class UploadSingleAttachmentService {
+  constructor(
+    private httpClient: HttpClient,
+    private apiAttachmentService: ApiAttachmentService,
+    private loggingService: LoggingService
+  ) {}
+
+  private onHttpEvent(event: HttpEvent<any>, attachment: AttachmentUploadEditModel) {
+    this.loggingService.debug('Attachment upload http event', DEBUG_TAG, event);
+    // Here we can keep track of upload progress if we want to
+    // if (event.type === HttpEventType.UploadProgress) {
+    //   // Track upload progress
+    // }
+  }
+
+  private onHttpResponseEvent(event: HttpResponse<string>) {
+    if (event instanceof HttpErrorResponse) {
+      // This is already an error and contains useful info, so we can just throw it
+      throw event;
+    }
+    if (!event.ok) {
+      throw new Error(`Could not upload attachment: Status: ${event.statusText}`);
+    }
+    return event.body;
+  }
+
+  private sendPostRequestWithImageBlob(blob: Blob) {
+    const attachmentPostPath = `${this.apiAttachmentService.rootUrl}${ApiAttachmentService.AttachmentPostPath}`;
+
+    const formData = new FormData();
+    formData.append('file', blob);
+
+    return this.httpClient.post(attachmentPostPath, formData, {
+      responseType: 'json',
+      // reportProgress makes this a stream that returns HttpEvents, not just the final response.
+      // We can use the events to track the upload progress.
+      reportProgress: true,
+      observe: 'events',
+      headers: { 'ngsw-bypass': '' },
+    }) as Observable<HttpEvent<string>>;
+  }
+
+  async upload(attachment: AttachmentUploadEditModel, blob: Blob) {
+    this.loggingService.debug('Uploading attachment', DEBUG_TAG, { attachment, size: blob.size });
+    // TODO: Add error handling
+
+    const request = this.sendPostRequestWithImageBlob(blob).pipe(
+      tap((event) => this.onHttpEvent(event, attachment)),
+      filter((event) => event.type === HttpEventType.Response || event instanceof HttpErrorResponse),
+      map((event: HttpResponse<string>) => this.onHttpResponseEvent(event)),
+      tap((result) => this.loggingService.debug(`Attachment uploaded with attachment id: ${result}`))
+    );
+
+    const uploadedAttachment = {
+      ...attachment,
+      // The response body contains only the AttachmentUploadId
+      AttachmentUploadId: await firstValueFrom(request),
+    };
+
+    return uploadedAttachment;
+  }
+}

--- a/src/app/core/services/upload-attachments/upload-single-attachment.service.ts
+++ b/src/app/core/services/upload-attachments/upload-single-attachment.service.ts
@@ -60,7 +60,6 @@ export class UploadSingleAttachmentService {
 
   async upload(attachment: AttachmentUploadEditModel, blob: Blob, onHttpEvent?: HttpEventClb) {
     this.loggingService.debug('Uploading attachment', DEBUG_TAG, { attachment, size: blob.size });
-    // TODO: Add error handling
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const clb: HttpEventClb = onHttpEvent || (() => {});

--- a/src/app/modules/common-registration/registration.module.ts
+++ b/src/app/modules/common-registration/registration.module.ts
@@ -14,6 +14,7 @@ import FileAttachmentService from './services/add-new-attachment/file-attachment
 import { isPlatform } from '@ionic/angular';
 import { RegobsApiModuleWithConfig } from '../common-regobs-api';
 import { LocalStorageAttachmentService } from './services/add-new-attachment/local-storage.attachment.service';
+import { WebAttachmentService } from './services/add-new-attachment/web-attachment.service';
 
 export function offlineDbServiceOptionsFactory(options?: IRegistrationModuleOptions): OfflineDbServiceOptions {
   const offlineDbServiceOptions = new OfflineDbServiceOptions();
@@ -75,7 +76,7 @@ export class RegistrationModule {
         },
         {
           provide: NewAttachmentService,
-          useClass: isPlatform('hybrid') ? FileAttachmentService : LocalStorageAttachmentService,
+          useClass: isPlatform('hybrid') ? FileAttachmentService : WebAttachmentService,
         },
         TranslateService,
       ],

--- a/src/app/modules/common-registration/services/add-new-attachment/new-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/new-attachment.service.ts
@@ -1,14 +1,4 @@
-import {
-  distinctUntilChanged,
-  map,
-  Observable,
-  take,
-  catchError,
-  of,
-  forkJoin,
-  switchMap,
-  OperatorFunction,
-} from 'rxjs';
+import { map, Observable, take, catchError, of, forkJoin, switchMap, OperatorFunction, BehaviorSubject } from 'rxjs';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import {
@@ -35,12 +25,20 @@ export interface GetAttachmentFilterOptions {
 
 type AttachmentFilter = OperatorFunction<AttachmentUploadEditModel[], AttachmentUploadEditModel[]>;
 
+export interface AddAttachmentState {
+  id: AttachmentUploadEditModel['id'];
+  state: 'done' | 'error' | 'in-progress';
+  progress?: number;
+}
+
 /**
  * Handle storage of new registration attachments on client before they are sent to server
  */
 export abstract class NewAttachmentService {
   protected logger: LoggingService;
   protected DEBUG_TAG = 'NewAttachmentService';
+
+  addNewAttachmentState = new BehaviorSubject<AddAttachmentState[]>([]);
 
   abstract addAttachment(
     registrationId: string,

--- a/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
@@ -91,6 +91,10 @@ export class WebAttachmentService extends NewAttachmentService {
     return this.database.get<string>(key);
   }
 
+  /**
+   * This code is based on a codepen by Mirco Bellagamba.
+   * See https://codepen.io/mirco-bellagamba/pen/vYGpBGO
+   */
   private createPreviewBlob(data: Blob): Promise<Blob> {
     this.logger.debug('Creating preview blob', this.DEBUG_TAG, { size: data.size });
     const blobUrl = window.URL.createObjectURL(data);
@@ -217,7 +221,10 @@ export class WebAttachmentService extends NewAttachmentService {
   }
 }
 
-// TODO: https://labs.madisoft.it/javascript-image-compression-and-resizing/
+/**
+ * This code is based on a codepen by Mirco Bellagamba.
+ * See https://codepen.io/mirco-bellagamba/pen/vYGpBGO
+ */
 function calculateSize(img: HTMLImageElement) {
   let width = img.width;
   let height = img.height;

--- a/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
@@ -1,0 +1,238 @@
+import { Injectable } from '@angular/core';
+import { debounceTime, filter, from, map, Observable, startWith, Subject, switchMap, tap } from 'rxjs';
+import { DatabaseService } from 'src/app/core/services/database/database.service';
+import { UploadSingleAttachmentService } from 'src/app/core/services/upload-attachments/upload-single-attachment.service';
+import { uuidv4 } from 'src/app/modules/common-core/helpers';
+import { GeoHazard } from 'src/app/modules/common-core/models';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { AttachmentType, AttachmentUploadEditModel } from '../../models/attachment-upload-edit.interface';
+import { RegistrationTid } from '../../registration.models';
+import { NewAttachmentService } from './new-attachment.service';
+
+const METADATA_KEY = 'REGOBS_IMAGE_METADATA';
+const IMAGE_PREFIX = 'REGOBS_IMAGE';
+const MAX_PREVIEW_WIDTH = 500;
+const MAX_PREVIEW_HEIGHT = 500;
+const PREVIEW_JPG_QUALITY = 1;
+
+@Injectable()
+export class WebAttachmentService extends NewAttachmentService {
+  protected DEBUG_TAG = 'WebAttachmentService';
+  private hasChange = new Subject<void>();
+
+  constructor(
+    protected logger: LoggingService,
+    private uploadSingleAttachmentService: UploadSingleAttachmentService,
+    private database: DatabaseService
+  ) {
+    super();
+  }
+
+  async addAttachment(
+    registrationId: string,
+    data: Blob,
+    mimeType: string,
+    geoHazard: GeoHazard,
+    registrationTid: RegistrationTid,
+    type?: AttachmentType,
+    ref?: string
+  ): Promise<void> {
+    const attachmentId = uuidv4();
+    const attachment: AttachmentUploadEditModel = {
+      GeoHazardTID: geoHazard,
+      RegistrationTID: registrationTid,
+      AttachmentMimeType: mimeType,
+      id: attachmentId,
+      type,
+      fileSize: data.size,
+      fileAddedTime: Date.now(),
+      ref,
+    };
+
+    const [uploadedAttachment, previewBlob] = await Promise.all([
+      this.uploadSingleAttachmentService.upload(attachment, data),
+      this.createPreviewBlob(data),
+    ]);
+
+    await this.saveImageToDB(previewBlob, attachmentId);
+    this.saveAttachmentMeta(registrationId, uploadedAttachment);
+  }
+
+  private blobToBase64(data: Blob): Promise<string> {
+    this.logger.debug('Converting image data to base64', this.DEBUG_TAG, { size: data.size });
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(data);
+      reader.onloadend = () => {
+        const dataAsBase64 = reader.result;
+        resolve(dataAsBase64 as string);
+      };
+      reader.onerror = (err) => {
+        reject(err);
+      };
+    });
+  }
+
+  private getImageKey(attachmentId: string) {
+    return `${IMAGE_PREFIX}_${attachmentId}`;
+  }
+
+  private async saveImageToDB(data: Blob, attachmentId: string): Promise<void> {
+    const key = this.getImageKey(attachmentId);
+    this.logger.debug('Saving image to db', this.DEBUG_TAG, { attachmentId, size: data.size, key });
+    const base64 = await this.blobToBase64(data);
+    await this.database.set(key, base64);
+    this.hasChange.next();
+  }
+
+  private readImageFromDB(attachmentId: string) {
+    const key = this.getImageKey(attachmentId);
+    this.logger.debug('Reading image from db', this.DEBUG_TAG, { attachmentId, key });
+    return this.database.get<string>(key);
+  }
+
+  private createPreviewBlob(data: Blob): Promise<Blob> {
+    this.logger.debug('Creating preview blob', this.DEBUG_TAG, { size: data.size });
+    const blobUrl = window.URL.createObjectURL(data);
+    const image = new Image();
+    return new Promise<Blob>((resolve, reject) => {
+      image.src = blobUrl;
+
+      image.onerror = (err) => {
+        window.URL.revokeObjectURL(blobUrl); // Clean up memory
+        // TODO: err can be string or event, handle properly
+        reject(err);
+      };
+
+      image.onload = () => {
+        window.URL.revokeObjectURL(blobUrl);
+        const [newWidth, newHeight] = calculateSize(image);
+        const canvas = document.createElement('canvas');
+        canvas.width = newWidth;
+        canvas.height = newHeight;
+        const context = canvas.getContext('2d');
+        context.drawImage(image, 0, 0, newWidth, newHeight);
+        canvas.toBlob(
+          (previewBlob) => {
+            this.logger.debug('Image preview created', this.DEBUG_TAG, {
+              originalSize: data.size,
+              previewSize: previewBlob.size,
+              previewWidth: newWidth,
+              previewHeight: newHeight,
+            });
+            resolve(previewBlob);
+          },
+          'image/jpg',
+          PREVIEW_JPG_QUALITY
+        );
+      };
+    });
+  }
+
+  private getMetadataKey(registrationId: string) {
+    return `${METADATA_KEY}_${registrationId}`;
+  }
+
+  private async saveAttachmentMeta(registrationId: string, meta: AttachmentUploadEditModel) {
+    const key = this.getMetadataKey(registrationId);
+    this.logger.debug('Saving attachment metadata', this.DEBUG_TAG, { meta, registrationId, key });
+    const existingAttachments = await this.readMetadataFromDb(registrationId);
+    const otherAttachments = existingAttachments.filter((a) => a.id !== meta.id);
+    await this.database.set(key, [...otherAttachments, meta]);
+    this.hasChange.next();
+  }
+
+  saveAttachmentMeta$(registrationId: string, meta: AttachmentUploadEditModel): Observable<unknown> {
+    return from(this.saveAttachmentMeta(registrationId, meta));
+  }
+
+  private async readMetadataFromDb(registrationId: string) {
+    const key = this.getMetadataKey(registrationId);
+    this.logger.debug('Reading metadata from db', this.DEBUG_TAG, { key });
+    const metadata = await this.database.get<AttachmentUploadEditModel[]>(key);
+    return metadata || [];
+  }
+
+  protected getAttachmentsObservable(registrationId: string): Observable<AttachmentUploadEditModel[]> {
+    return this.hasChange.pipe(
+      startWith(true),
+      debounceTime(500),
+      switchMap(() => this.readMetadataFromDb(registrationId)),
+      tap((metadata) => this.logger.debug('Metadata', this.DEBUG_TAG, { metadata }))
+    );
+  }
+
+  getBlob(registrationId: string, attachmentId: string): Observable<Blob> {
+    return this.getAttachmentsObservable(registrationId).pipe(
+      map((attachmens) => attachmens.find((a) => a.id === attachmentId)),
+      filter((a) => a != null),
+      switchMap(() => this.readImageFromDB(attachmentId)),
+      switchMap((base64) => fetch(base64).then((res) => res.blob()))
+    );
+  }
+
+  private async removeAttachmentInner(registrationId: string, attachmentId: string) {
+    const imageKey = this.getImageKey(attachmentId);
+    const metadataKey = this.getMetadataKey(registrationId);
+    this.logger.debug('Remove attachment', this.DEBUG_TAG, { metadataKey, imageKey });
+    try {
+      await this.database.remove(imageKey);
+    } catch (error) {
+      this.logger.error(error, this.DEBUG_TAG, 'Failed to remove image from db');
+    }
+    const metadata = await this.readMetadataFromDb(registrationId);
+    const newMeta = metadata.filter((m) => m.id !== attachmentId);
+    await this.database.set(metadataKey, newMeta);
+    this.hasChange.next();
+    return true;
+  }
+
+  removeAttachment(registrationId: string, attachmentId: string): void {
+    this.removeAttachmentInner(registrationId, attachmentId);
+  }
+
+  removeAttachment$(registrationId: string, attachmentId: string): Observable<boolean> {
+    return from(this.removeAttachmentInner(registrationId, attachmentId));
+  }
+
+  async removeAttachments(registrationId: string): Promise<void> {
+    this.logger.debug('Remove all attachments', this.DEBUG_TAG, { registrationId });
+    const metadataKey = this.getMetadataKey(registrationId);
+    const metadata = await this.readMetadataFromDb(registrationId);
+    const imageKeys = metadata.map((m) => this.getImageKey(m.id));
+    const removeAttachment = async (key: string) => {
+      try {
+        await this.database.remove(key);
+      } catch (error) {
+        this.logger.error(error, this.DEBUG_TAG, 'Failed to remove image from db');
+      }
+    };
+    await Promise.allSettled(imageKeys.map((k) => removeAttachment(k)));
+    await this.database.remove(metadataKey);
+    this.hasChange.next();
+  }
+
+  removeAttachments$(registrationId: string): Observable<void> {
+    return from(this.removeAttachments(registrationId));
+  }
+}
+
+// TODO: https://labs.madisoft.it/javascript-image-compression-and-resizing/
+function calculateSize(img: HTMLImageElement) {
+  let width = img.width;
+  let height = img.height;
+
+  // calculate the width and height, constraining the proportions
+  if (width > height) {
+    if (width > MAX_PREVIEW_WIDTH) {
+      height = Math.round((height * MAX_PREVIEW_WIDTH) / width);
+      width = MAX_PREVIEW_WIDTH;
+    }
+  } else {
+    if (height > MAX_PREVIEW_HEIGHT) {
+      width = Math.round((width * MAX_PREVIEW_HEIGHT) / height);
+      height = MAX_PREVIEW_HEIGHT;
+    }
+  }
+  return [width, height];
+}

--- a/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
@@ -84,9 +84,15 @@ export class WebAttachmentService extends NewAttachmentService {
 
     // Wait for upload to finish, then save updated metadata with attachment id
     // TODO: After attachment has been uploaded, check if it has been deleted in the meantime, if so just forget it
-    const uploadedAttachment = await uploadAttachmentPromise;
-    await this.saveAttachmentMeta(registrationId, uploadedAttachment);
-    this.logger.debug('Metadata updated with upload id', this.DEBUG_TAG, logInfo);
+    let uploadedAttachment: AttachmentUploadEditModel;
+    try {
+      uploadedAttachment = await uploadAttachmentPromise;
+      await this.saveAttachmentMeta(registrationId, uploadedAttachment);
+      this.logger.debug('Metadata updated with upload id', this.DEBUG_TAG, logInfo);
+    } catch (error) {
+      await this.removeAttachmentInner(registrationId, attachment.id);
+      throw error;
+    }
   }
 
   private uploadStarted(attachment: AttachmentUploadEditModel) {

--- a/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
@@ -11,9 +11,9 @@ import { NewAttachmentService } from './new-attachment.service';
 
 const METADATA_KEY = 'REGOBS_IMAGE_METADATA';
 const IMAGE_PREFIX = 'REGOBS_IMAGE';
-const MAX_PREVIEW_WIDTH = 500;
-const MAX_PREVIEW_HEIGHT = 500;
-const PREVIEW_JPG_QUALITY = 1;
+const MAX_PREVIEW_WIDTH = 1000;
+const MAX_PREVIEW_HEIGHT = 1000;
+const PREVIEW_JPG_QUALITY = 0.5;
 
 @Injectable()
 export class WebAttachmentService extends NewAttachmentService {

--- a/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
@@ -78,6 +78,7 @@ export class WebAttachmentService extends NewAttachmentService {
     this.logger.debug('Metadata and preview image saved', this.DEBUG_TAG, logInfo);
 
     // Wait for upload to finish, then save updated metadata with attachment id
+    // TODO: After attachment has been uploaded, check if it has been deleted in the meantime, if so just forget it
     const uploadedAttachment = await uploadAttachmentPromise;
     await this.saveAttachmentMeta(registrationId, uploadedAttachment);
     this.logger.debug('Metadata updated with upload id', this.DEBUG_TAG, logInfo);

--- a/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
+++ b/src/app/modules/common-registration/services/add-new-attachment/web-attachment.service.ts
@@ -65,11 +65,8 @@ export class WebAttachmentService extends NewAttachmentService {
         const progress = event.loaded / event.total;
         if (progress < 1) {
           this.handleUploadProgress(progress, attachment);
-          return;
         }
       }
-
-      this.handleUploadFinished(attachment);
     };
 
     this.logger.debug('Creating preview image and starting image upload', this.DEBUG_TAG, logInfo);
@@ -92,6 +89,8 @@ export class WebAttachmentService extends NewAttachmentService {
     } catch (error) {
       await this.removeAttachmentInner(registrationId, attachment.id);
       throw error;
+    } finally {
+      this.handleUploadFinished(attachment);
     }
   }
 

--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -24,6 +24,12 @@
   <div class="image-wrapper" *ngFor="let attachment of newAttachments$ | async; trackBy: trackNew">
     <!-- <img [src]="convertFileSrc(image.PictureImageBase64)" /> -->
     <ro-blob-image [imgBlob]="attachment.blob"></ro-blob-image>
+    <div class="upload-progress" *ngIf="attachment.state === 'in-progress'">
+      <ion-progress-bar
+        [type]="attachment.progress === 0 ? 'indeterminate' : 'determinate'"
+        [value]="attachment.progress"
+      ></ion-progress-bar>
+    </div>
     <ion-fab class="ion-no-margin" slot="fixed" vertical="top" horizontal="end">
       <ion-fab-button size="small" color="dark" class="map-control-fab" (click)="removeNewImage(attachment)">
         <ion-icon name="close"></ion-icon>

--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -31,7 +31,13 @@
       ></ion-progress-bar>
     </div>
     <ion-fab class="ion-no-margin" slot="fixed" vertical="top" horizontal="end">
-      <ion-fab-button size="small" color="dark" class="map-control-fab" (click)="removeNewImage(attachment)">
+      <ion-fab-button
+        size="small"
+        color="dark"
+        class="map-control-fab"
+        (click)="removeNewImage(attachment)"
+        [disabled]="attachment.state === 'in-progress'"
+      >
         <ion-icon name="close"></ion-icon>
       </ion-fab-button>
     </ion-fab>

--- a/src/app/modules/registration/components/edit-images/edit-images.component.scss
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.scss
@@ -20,5 +20,19 @@
       padding: 8px;
       margin: unset;
     }
+
+    .upload-progress {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba($color: #fff, $alpha: 0.8);
+
+      ion-progress-bar {
+        position: absolute;
+        top: 50%;
+      }
+    }
   }
 }

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -299,7 +299,7 @@ export class EditImagesComponent implements OnInit {
         .getFile(droppedFile)
         .then((file) => this.attachImageToDraft(file, MIME_TYPE))
         .catch((err) => {
-          this.logger.error(err, 'Could not add attachment');
+          this.logger.error(err, DEBUG_TAG, 'Could not add attachment');
           this.showErrorToast('Could not add image'); // TODO: Add better error message
         });
     }

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -276,15 +276,15 @@ export class EditImagesComponent implements OnInit {
     return attachment.id;
   }
 
-  async dropped(droppedFiles: NgxFileDropEntry[]): Promise<void> {
+  dropped(droppedFiles: NgxFileDropEntry[]) {
     for (const droppedFile of droppedFiles) {
-      try {
-        const file = await this.dropZoneService.getFile(droppedFile);
-        this.attachImageToDraft(file, MIME_TYPE);
-      } catch (err) {
-        this.logger.error(err, 'Could not add attachment');
-        this.showErrorToast('Could not add image'); // TODO: Add better error message
-      }
+      this.dropZoneService
+        .getFile(droppedFile)
+        .then((file) => this.attachImageToDraft(file, MIME_TYPE))
+        .catch((err) => {
+          this.logger.error(err, 'Could not add attachment');
+          this.showErrorToast('Could not add image'); // TODO: Add better error message
+        });
     }
   }
 }


### PR DESCRIPTION
Denne endringen legger til en attachment service for web som skal håndtere bilder i alle slags størrelser.

For å komme rundt det at vi ikke har tilgang til opplastede bilder, lagrer servicen en versjon av bildene med lavere oppløsning i lokal db.

Gjenstår:

- [x] Fikse tester
- [x] Todoer i koden
- [x] Bedre forhåndsvisning ?
- [x] Lag oppgave på bedre feilhåndtering ved opplasting av for store bilder (håndtere 413 fra apiet)

~Vi bør lage en bedre forhåndsvisning av opplastede bilder, eventuelt se om vi kan bruke den opplastede blob-en i stedet for preview-bloben så lenge man er i samme sesjon. Preview blob-en har dårlig oppløsning sånn som jeg har laget det nå, derfor ser det rart ut.~

~Vi kan eventuelt teste med å øke oppløsning på preview-bildene.~

Prøvde å sette preview-bildet til maks 1000 x 1000 px, virker som det fungerer OK så langt.

Jeg har ikke sett så nøye på ytelse og om vi løser ting på best mulig måte når vi lager prevew blob osv. Det konvertes til/fra base 64 osv. Mulig vi kan optimalisere den biten.

Bør testes:

- [x] Bildeopplasting på ios / android
- [x] Redigering av obs med eksisterende bilder
- [x] Sende inn bilder med kommentarer
- [x] Velge bilder på ulike måter, dra inn fra mappe etc
- [ ] Hvor går grensa for størrelse på bilder osv, hvor mange bilder kan vi laste opp om gangen / ha i minnet?