### PR TITLE
Oppdatere sjekk på skredhendelse skjema om at den ikke inneholder tomme verdier

### DIFF
--- a/src/app/modules/common-registration/helpers/registration.helper.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.ts
@@ -135,12 +135,13 @@ export function isObservationModelEmptyForRegistrationTid(
   in the function. In that case we set hasAnyDataBesidesPropertyToExclude(AvalancheObs, 'DtAvalancheTime')
 */
 export function hasAnyDataBesidesPropertyToExclude<T>(dataModel: T, propertyToExclude: string) {
+  // have to remove the property to exclude from the object and then check values on the rest
+  //
   if (dataModel) {
-    const allValues = Object.values(dataModel);
-    if (dataModel[propertyToExclude] && allValues.length < 2) {
-      return false;
-    }
-    return true;
+    const dataModelCopy = { ...dataModel };
+    delete dataModelCopy[propertyToExclude];
+    const allValues = Object.values(dataModelCopy).filter((v) => v !== propertyToExclude);
+    return allValues.some((v) => v);
   }
 }
 

--- a/src/app/modules/common-registration/helpers/registration.helper.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.ts
@@ -140,7 +140,7 @@ export function hasAnyDataBesidesPropertyToExclude<T>(dataModel: T, propertyToEx
   if (dataModel) {
     const dataModelCopy = { ...dataModel };
     delete dataModelCopy[propertyToExclude];
-    const allValues = Object.values(dataModelCopy).filter((v) => v !== propertyToExclude);
+    const allValues = Object.values(dataModelCopy);
     return allValues.some((v) => v);
   }
 }


### PR DESCRIPTION
Hvis man fyller opp noe feltet i skredhendelse skjema og så nullstiller den får hoved skjema ikke med seg at skredhendelse skjema er tom. Man må gå til skredhendelse skjema igjen og gå tilbake for å se oppdatering i UI. 