### PR TITLE
RO-2272: Fikset dirty-sjekk for snøskredhendelse

### DIFF
--- a/src/app/core/services/draft/draft-repository.service.ts
+++ b/src/app/core/services/draft/draft-repository.service.ts
@@ -122,9 +122,8 @@ export class DraftRepositoryService {
    * @returns true if given draft has any attachments (new local or already uploaded) for given registration type
    */
   async hasAttachments(draft: RegistrationDraft, registrationTid: RegistrationTid): Promise<boolean> {
-    let hasAttachments = false;
     const existingAttachments = getAllAttachmentsFromEditModel(draft.registration, registrationTid);
-    hasAttachments = existingAttachments.length > 0;
+    let hasAttachments = existingAttachments.length > 0;
 
     if (!hasAttachments) {
       const newAttachments = await firstValueFrom(

--- a/src/app/core/services/draft/draft-repository.service.ts
+++ b/src/app/core/services/draft/draft-repository.service.ts
@@ -112,7 +112,7 @@ export class DraftRepositoryService {
     let isEmpty = isObservationModelEmptyForRegistrationTid(draft.registration, registrationTid);
 
     if (isEmpty) {
-      isEmpty = !this.hasAttachments(draft, registrationTid);
+      isEmpty = !(await this.hasAttachments(draft, registrationTid));
     }
 
     return isEmpty;

--- a/src/app/core/services/draft/draft-repository.service.ts
+++ b/src/app/core/services/draft/draft-repository.service.ts
@@ -112,18 +112,28 @@ export class DraftRepositoryService {
     let isEmpty = isObservationModelEmptyForRegistrationTid(draft.registration, registrationTid);
 
     if (isEmpty) {
-      const existingAttachments = getAllAttachmentsFromEditModel(draft.registration, registrationTid);
-      isEmpty = existingAttachments.length === 0;
-    }
-
-    if (isEmpty) {
-      const newAttachments = await firstValueFrom(
-        this.newAttachmentSerivice.getAttachments(draft.uuid, { registrationTid })
-      );
-      isEmpty = newAttachments.length === 0;
+      isEmpty = !this.hasAttachments(draft, registrationTid);
     }
 
     return isEmpty;
+  }
+
+  /**
+   * @returns true if given draft has any attachments (new local or already uploaded) for given registration type
+   */
+  async hasAttachments(draft: RegistrationDraft, registrationTid: RegistrationTid): Promise<boolean> {
+    let hasAttachments = false;
+    const existingAttachments = getAllAttachmentsFromEditModel(draft.registration, registrationTid);
+    hasAttachments = existingAttachments.length > 0;
+
+    if (!hasAttachments) {
+      const newAttachments = await firstValueFrom(
+        this.newAttachmentSerivice.getAttachments(draft.uuid, { registrationTid })
+      );
+      hasAttachments = newAttachments.length > 0;
+    }
+
+    return hasAttachments;
   }
 
   /**
@@ -225,7 +235,7 @@ export class DraftRepositoryService {
     await this.databaseService.set(key, updatedDraft);
 
     this.logger.debug(
-      `Draft ${draft.uuid} saved in ${this.millisSince(start)} ms 
+      `Draft ${draft.uuid} saved in ${this.millisSince(start)} ms
       in environment ${appMode}`,
       DEBUG_TAG,
       draft

--- a/src/app/modules/registration/pages/base.page.ts
+++ b/src/app/modules/registration/pages/base.page.ts
@@ -118,11 +118,11 @@ export abstract class BasePage extends NgDestoryBase {
   }
 
   async isEmpty(registrationType = this.registrationTid): Promise<boolean> {
-    return this.basePageService.draftRepository.isDraftEmptyForRegistrationType(this.draft, registrationType);
+    return await this.basePageService.draftRepository.isDraftEmptyForRegistrationType(this.draft, registrationType);
   }
 
   protected async hasAttachments(registrationType = this.registrationTid): Promise<boolean> {
-    return this.basePageService.draftRepository.hasAttachments(this.draft, registrationType);
+    return await this.basePageService.draftRepository.hasAttachments(this.draft, registrationType);
   }
 
   /**

--- a/src/app/modules/registration/pages/base.page.ts
+++ b/src/app/modules/registration/pages/base.page.ts
@@ -121,6 +121,10 @@ export abstract class BasePage extends NgDestoryBase {
     return this.basePageService.draftRepository.isDraftEmptyForRegistrationType(this.draft, registrationType);
   }
 
+  protected async hasAttachments(registrationType = this.registrationTid): Promise<boolean> {
+    return this.basePageService.draftRepository.hasAttachments(this.draft, registrationType);
+  }
+
   /**
    * Reset the registration if the user confirms.
    * @returns {boolean} true if the user wants to reset

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -174,11 +174,17 @@ export class AvalancheObsPage extends BasePage {
   }
 
   async isEmpty(): Promise<boolean> {
+    // we need to ignore the default value of DtAvalancheTime
     if (
       this.avalancheObs.DtAvalancheTime &&
       (hasAnyDataBesidesPropertyToExclude(this.avalancheObs, 'DtAvalancheTime') ||
         this.dtAvalancheTimeIsDifferentThanObsTime)
     ) {
+      return false;
+    }
+
+    const hasAttachments = await super.hasAttachments(RegistrationTid.AvalancheObs);
+    if (hasAttachments) {
       return false;
     }
 


### PR DESCRIPTION
Denne fikk ikke med seg om man kun hadde lagt til bilder, så man fikk ikke sendt inn registreringa.
Bildet / bildene ble altså borte fra registreringa hvis man gikk ut av snøskredskjema etter kun å ha lagt til bilder.
Igrunn samme feil som vi fikset i https://github.com/NVE/regObs4/pull/462, men denne gangen altså for snøskredhendelse.
Nå har jeg sjekket alle implementasjoner av isEmpty() i *.page.ts, så vi slipper flere slike feil.
