### PR TITLE
RO-2246: bruker kan velge antall observasjoner per side i obs list

### DIFF
--- a/src/app/core/models/user-settings.model.ts
+++ b/src/app/core/models/user-settings.model.ts
@@ -24,7 +24,7 @@ export interface UserSetting {
   infoAboutOfflineSupportMapsRecievedTimestamps?: { [name: string]: number };
   copyright?: string;
   photographer?: string;
-
+  preferredNumberOfRecords?: number;
   /**
    * true = use full/complete snow obs schemas
    * false/undefined = use simple snow obs schema

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -214,6 +214,7 @@ export class SearchCriteriaService {
         )
       ),
       this.userSettingService.language$,
+      this.userSettingService.userSetting$.pipe(map((us) => us.preferredNumberOfRecords)),
       this.userSettingService.currentGeoHazard$.pipe(
         tap((geohazard) => {
           this.currentGeoHazard !== undefined && this.resetSearchCriteria();
@@ -235,9 +236,10 @@ export class SearchCriteriaService {
       // - FromDtObsTime: fromDate URL param
       debounceTime(50),
       map(
-        ([criteria, langKey, geoHazards, fromObsTime, useMapExtent, extent]: [
+        ([criteria, langKey, numOfRecords, geoHazards, fromObsTime, useMapExtent, extent]: [
           SearchCriteriaRequestDto,
           LangKey,
+          number,
           GeoHazard[],
           string,
           boolean,
@@ -249,6 +251,7 @@ export class SearchCriteriaService {
             SelectedGeoHazards: geoHazards,
             FromDtObsTime: convertToIsoDateTime(criteria.FromDtObsTime || fromObsTime),
             Extent: useMapExtent ? extent : null,
+            ...(numOfRecords && { NumberOfRecords: numOfRecords }),
           };
         }
       ),
@@ -381,6 +384,10 @@ export class SearchCriteriaService {
 
   setObserverNickName(nickName: string) {
     this.searchCriteriaChanges.next({ ObserverNickName: nickName });
+  }
+
+  setNumberOfRecords(numberOfRecords: number) {
+    this.searchCriteriaChanges.next({ NumberOfRecords: numberOfRecords });
   }
 
   setCompetence(competenceCriteria: number[]) {

--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -134,7 +134,7 @@ export class PagedSearchResult<TViewModel extends HasRegId> {
       map((pageInfo) => ({
         ...searchCriteria,
         Offset: pageInfo.offset,
-        NumberOfRecords: pageInfo.items,
+        NumberOfRecords: searchCriteria.NumberOfRecords || pageInfo.items,
       })),
       // Search for matching registrations.
       // Use concatMap here and not switchMap as we want to include all pages if increasePage() is called before

--- a/src/app/pages/observation-list/observation-list.page.html
+++ b/src/app/pages/observation-list/observation-list.page.html
@@ -8,11 +8,11 @@
       </ion-item-divider>
       <ion-grid class="filter-panel">
         <ion-row>
-          <ion-col>
+          <ion-col class="display-none-on-small">
             <ion-segment
               [value]="useMapExtentFilter$ | async"
               (click)="toggleFilterByMapView($event)"
-              class="map-extent-filter-toggle segment-button-class"
+              class="segment-button-class"
               mode="ios"
               [disabled]="noMapExtentAvailable$ | async"
             >
@@ -24,15 +24,29 @@
               </ion-segment-button>
             </ion-segment>
           </ion-col>
-          <ion-col>
-            <!--titelen -->
+          <!--<ion-col>
+            titelen
+          </ion-col>-->
+          <ion-col class="display-none-on-small">
+            <div class="select-wrapper select-wrapper-short">
+              <span>{{'OBSERVATION_LIST.NUMBER_OBS_PER_PAGE' | translate}}</span>
+              <ion-select
+                (ionChange)="handleChangeNumberObsPerPage($event)"
+                [value]="numOfRecords"
+                [interface]="popupType"
+              >
+                <ion-select-option *ngFor="let numPerPage of numberObsPerPageOptions" [value]="numPerPage"
+                  >{{numPerPage}}</ion-select-option
+                >
+              </ion-select>
+            </div>
           </ion-col>
+          <!--<ion-col>
+            bilde galleri toggle
+          </ion-col>-->
           <ion-col>
-            <!--bilde galleri toggle-->
-          </ion-col>
-          <ion-col class="order-by-select">
             <ng-container *ngIf="orderBy$ | async as orderBy">
-              <div class="select-wrapper">
+              <div class="select-wrapper select-wrapper-wide">
                 <span>{{'OBSERVATION_LIST.SORT_BY_TEXT' | translate}}</span>
                 <ion-select (ionChange)="handleChangeSorting($event)" [value]="orderBy" [interface]="popupType">
                   <ion-select-option value="DtObsTime">
@@ -67,7 +81,7 @@
       </ion-item-divider>
       <ion-grid class="filter-panel">
         <ion-row>
-          <ion-col>
+          <ion-col class="display-none-on-small">
             <ion-segment
               (ionChange)="toggleFilterByMapView($event)"
               class="segment-button-class"
@@ -75,21 +89,35 @@
               mode="ios"
             >
               <ion-segment-button value="mapBorders">
-                <ion-label>I kartutsnitt</ion-label>
+                <ion-label>{{'OBSERVATION_LIST.TOGGLE_BUTTON_OBSERVATIONS_IN_MAP_VIEW' | translate}}</ion-label>
               </ion-segment-button>
               <ion-segment-button value="all">
-                <ion-label>Alle</ion-label>
+                <ion-label>{{'OBSERVATION_LIST.TOGGLE_BUTTON_OBSERVATIONS_ALL' | translate}}</ion-label>
               </ion-segment-button>
             </ion-segment>
           </ion-col>
-          <ion-col>
-            <!--titelen -->
+          <!--<ion-col>
+           titelen
+          </ion-col> -->
+          <ion-col class="display-none-on-small">
+            <div class="select-wrapper select-wrapper-short">
+              <span>{{'OBSERVATION_LIST.NUMBER_OBS_PER_PAGE' | translate}}</span>
+              <ion-select
+                (ionChange)="handleChangeNumberObsPerPage($event)"
+                [value]="numOfRecords"
+                [interface]="popupType"
+              >
+                <ion-select-option *ngFor="let numPerPage of numberObsPerPageOptions" [value]="numPerPage"
+                  >{{numPerPage}}</ion-select-option
+                >
+              </ion-select>
+            </div>
           </ion-col>
+          <!--<ion-col>
+            bilde galleri toggle
+          </ion-col>-->
           <ion-col>
-            <!--bilde galleri toggle-->
-          </ion-col>
-          <ion-col class="order-by-select">
-            <div class="select-wrapper">
+            <div class="select-wrapper select-wrapper-wide">
               <span>{{'OBSERVATION_LIST.SORT_BY_TEXT' | translate}}</span>
               <ion-select (ionChange)="handleChangeSorting($event)" [interface]="popupType">
                 <ion-select-option value="DtObsTime">

--- a/src/app/pages/observation-list/observation-list.page.scss
+++ b/src/app/pages/observation-list/observation-list.page.scss
@@ -6,11 +6,18 @@
   bottom: 0;
 }
 
+.select-wrapper-wide {
+  min-width: 250px;
+}
+
+.select-wrapper-short {
+  min-width: 50px;
+}
+
 .select-wrapper {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-width: 250px;
 
   span {
     margin-right: 10px;
@@ -41,20 +48,18 @@ ion-grid {
   margin: 0 1rem;
 }
 
-.order-by-select {
-  align-items: flex-end;
-}
-
 ion-row {
   max-width: 960px;
   margin: 0 auto;
+  align-items: center;
 }
 
 ion-col {
   padding: 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-end;
+  flex-basis: 0;
 }
 
 ion-item-divider {
@@ -68,7 +73,7 @@ ion-item-divider {
 }
 
 @media only screen and (max-width: 899px) {
-  .map-extent-filter-toggle {
+  .display-none-on-small {
     display: none;
   }
 }
@@ -82,6 +87,7 @@ ion-item-divider {
 @media only screen and (max-width: 465px) {
   ion-col {
     padding: 5px 0;
+    flex-basis: 100%;
   }
 }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -259,6 +259,7 @@
     "MAX_COUNT_REACHED_TEXT": "We show max {{ maxCount }} observations here. If you didn't find what you looked for you may try to zoom in or narrow the period you want to see observations from.",
     "NO_OBSERVATIONS": "No observations",
     "NO_OBSERVATIONS_TEXT": "There are no observations in the map section, try to change the view or expand the period you want to see observations from.",
+    "NUMBER_OBS_PER_PAGE": "Number per page",
     "SORT_BY_CHANGE_TIME": "Recently updated",
     "SORT_BY_OBS_TIME": "Recently observed",
     "SORT_BY_TEXT": "Order by",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -259,6 +259,7 @@
     "MAX_COUNT_REACHED_TEXT": "Vi viser maks {{ maxCount }} observasjoner her. Hvis du ikke fant det du lette etter, prøv å zoome inn på kartet eller snevre inn perioden du vil se observasjoner fra.",
     "NO_OBSERVATIONS": "Ingen observasjoner",
     "NO_OBSERVATIONS_TEXT": "Det er ingen observasjoner i kartutsnittet, forsøk å endre utsnittet eller utvid perioden du vil se observasjoner fra.",
+    "NUMBER_OBS_PER_PAGE": "Antall per side",
     "SORT_BY_CHANGE_TIME": "Oppdatert tid",
     "SORT_BY_OBS_TIME": "Observert tid",
     "SORT_BY_TEXT": "Sorter på",


### PR DESCRIPTION
Nå kan bruker velge hvor mange observasjoner skal hentes på en 'page' søk på observation-list. Det er fast antall som 10 (default), 50 og 100(MAX_ITEMS i search-registration.service). Hvis det trengs så kan det selvfølgelig justeres. 
La til et nytt property i userSettings: preferredNumberOfRecords. Hvis den er tom så settes propertyet til PAGE_SIZE = 10; 
Det er samme verdi som i search-registration.service. Lurer på om vi kunne kanskje plassere det et sted som brukes av både search-reg-service og obs-list.component men jeg tror ikke det finnes noe sted hvor vi kunne lagre den? 
Hvis bruker endrer antall per side til så vil den lagres i user.settings så at appen/nettsiden husker neste gang. 
Select komponent skal forsvinne på små skjermer (samme som med toggle knapp) siden det kanskje ikke vil brukes på mobil? 