### PR TITLE
RO-2280: Bedre feilhåndtering av offlinekartnedlasting på Android når vi mister nett

### DIFF
--- a/android/app/src/main/java/no/nve/regobs4/DownloadStatus.java
+++ b/android/app/src/main/java/no/nve/regobs4/DownloadStatus.java
@@ -1,0 +1,76 @@
+package no.nve.regobs4;
+
+import android.app.DownloadManager;
+
+public class DownloadStatus {
+  double progress;
+  int status;
+  int reason;
+
+  DownloadStatus(double progress, int status, int reason) {
+    this.progress = progress;
+    this.status = status;
+    this.reason = reason;
+  }
+
+  String getStatusAndReasonAsString() {
+    String statusString = getStatusString();
+    String reasonString = getReasonString();
+    StringBuilder result = new StringBuilder();
+    if (statusString != null) {
+      result.append("Status: " + statusString);
+    }
+    if (reason != 0) {
+      result.append(", reason: " + reasonString);
+    }
+    return result.toString();
+  }
+
+  String getStatusString() {
+    // have tried to harmonize these with ProgressMonitor.Result
+    switch (status) {
+      case DownloadManager.STATUS_FAILED:
+        return "ERROR";
+      case DownloadManager.STATUS_SUCCESSFUL:
+        return "SUCCESS";
+      case DownloadManager.STATUS_PAUSED:
+      case DownloadManager.STATUS_PENDING:
+        return "PENDING";
+      case DownloadManager.STATUS_RUNNING:
+        return "WORK_IN_PROGRESS";
+    }
+    return null;
+  }
+
+  String getReasonString() {
+    switch (reason) {
+      case DownloadManager.ERROR_CANNOT_RESUME:
+        return "CANNOT_RESUME";
+      case DownloadManager.ERROR_DEVICE_NOT_FOUND:
+        return "DEVICE_NOT_FOUND";
+      case DownloadManager.ERROR_FILE_ALREADY_EXISTS:
+        return "FILE_ALREADY_EXISTS";
+      case DownloadManager.ERROR_FILE_ERROR:
+        return "FILE_ERROR";
+      case DownloadManager.ERROR_HTTP_DATA_ERROR:
+        return "HTTP_DATA_ERROR";
+      case DownloadManager.ERROR_INSUFFICIENT_SPACE:
+        return "INSUFFICIENT_SPACE";
+      case DownloadManager.ERROR_TOO_MANY_REDIRECTS:
+        return "TOO_MANY_REDIRECTS";
+      case DownloadManager.ERROR_UNHANDLED_HTTP_CODE:
+        return "UNHANDLED_HTTP_CODE";
+      case DownloadManager.ERROR_UNKNOWN:
+        return "UNKNOWN";
+      case DownloadManager.PAUSED_WAITING_FOR_NETWORK:;
+        return "WAITING_FOR_NETWORK";
+      case DownloadManager.PAUSED_QUEUED_FOR_WIFI:;
+        return "QUEUED_FOR_WIFI";
+      case DownloadManager.PAUSED_WAITING_TO_RETRY:;
+        return "WAITING_TO_RETRY";
+      case DownloadManager.PAUSED_UNKNOWN:
+        return "UNKNOWN";
+    }
+    return "HTTP " + String.valueOf(reason);
+  }
+}

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -294,11 +294,18 @@ export class OfflineMapService {
           done.next();
           done.complete();
           this.onUnzipStepComplete(parts, mapPackage, partNumber);
+        } else if (status.status === 'PENDING') {
+          this.reportThatWeAreWaiting(mapPackage, status.progress, partNumber, parts.length, 'Downloading');
         } else if (status.status === 'ERROR') {
           done.next();
           done.complete();
           const isDownloading = status.task === 'download';
-          this.onUnzipOrDownloadError(mapPackage, null, isDownloading);
+          this.onUnzipOrDownloadError(
+            mapPackage,
+            null,
+            isDownloading,
+            `Status: ${status.status}, reason: ${status.reason}`
+          );
         } else {
           if (part) {
             const partOfStep: 'Downloading' | 'Unzipping' = status.task === 'download' ? 'Downloading' : 'Unzipping';
@@ -378,6 +385,25 @@ export class OfflineMapService {
         }),
       (error) => this.onUnzipOrDownloadError(mapPackage, error, false)
     );
+  }
+
+  private async reportThatWeAreWaiting(
+    mapPackage: OfflineMapPackage,
+    progress: number,
+    partNumber: number,
+    totalParts: number,
+    taskType: 'Downloading' | 'Unzipping'
+  ): Promise<void> {
+    this.onProgress(mapPackage, {
+      step: ProgressStep.download,
+      percentage: this.calculateTotalProgress(progress, partNumber, totalParts, taskType),
+      description: await firstValueFrom(
+        this.translateService.get('OFFLINE_MAP.STATUS.WAITING_FOR_NETWORK', {
+          n: partNumber + 1,
+          totalParts,
+        })
+      ),
+    });
   }
 
   private async reportProgress(
@@ -730,8 +756,13 @@ export class OfflineMapService {
     this.downloadAndUnzipProgress.next([...unzipProgress, metadata]);
   }
 
-  private async onUnzipOrDownloadError(metadata: OfflineMapPackage, error: Error, isDownloading: boolean) {
-    this.loggingService.error(error, DEBUG_TAG, `Error downloading map ${metadata.name}`);
+  private async onUnzipOrDownloadError(
+    metadata: OfflineMapPackage,
+    error: Error,
+    isDownloading: boolean,
+    description?: string
+  ) {
+    this.loggingService.error(error, DEBUG_TAG, `Error downloading map ${metadata.name}: ${description}`);
     metadata.error = error || new Error('Unknown error');
     const errorMessageKey = isDownloading ? 'OFFLINE_MAP.STATUS.DOWNLOAD_ERROR' : 'OFFLINE_MAP.STATUS.UNZIP_ERROR';
     metadata.progress.description = await firstValueFrom(this.translateService.get(errorMessageKey));

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -762,7 +762,11 @@ export class OfflineMapService {
     isDownloading: boolean,
     description?: string
   ) {
-    this.loggingService.error(error, DEBUG_TAG, `Error downloading map ${metadata.name}: ${description}`);
+    let message = `Error downloading map ${metadata.name}`;
+    if (description) {
+      message = `${message}: ${description}`;
+    }
+    this.loggingService.error(error, DEBUG_TAG, message, metadata);
     metadata.error = error || new Error('Unknown error');
     const errorMessageKey = isDownloading ? 'OFFLINE_MAP.STATUS.DOWNLOAD_ERROR' : 'OFFLINE_MAP.STATUS.UNZIP_ERROR';
     metadata.progress.description = await firstValueFrom(this.translateService.get(errorMessageKey));

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -290,7 +290,8 @@
       "DOWNLOADING_PART_X_OF_Y": "Downloading part {{n}} of {{totalParts}}",
       "DOWNLOAD_ERROR": "Download error",
       "UNZIP_ERROR": "Unzip error",
-      "UNZIP_PART_X_OF_Y": "Unzipping part {{n}} of {{totalParts}}"
+      "UNZIP_PART_X_OF_Y": "Unzipping part {{n}} of {{totalParts}}",
+      "WAITING_FOR_NETWORK": "Waiting for network"
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Could not save map package to disk. Please try again",
     "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Could not save map package to disk. Are you sure there is enough disk space?"

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -290,7 +290,8 @@
       "DOWNLOADING_PART_X_OF_Y": "Laster ned {{n}} av {{totalParts}}",
       "DOWNLOAD_ERROR": "Nedlasting feilet",
       "UNZIP_ERROR": "Utpakking feilet",
-      "UNZIP_PART_X_OF_Y": "Pakker ut {{n}} av {{totalParts}}"
+      "UNZIP_PART_X_OF_Y": "Pakker ut {{n}} av {{totalParts}}",
+      "WAITING_FOR_NETWORK": "Venter på nettverk"
     },
     "UNZIP_ERROR_MESSAGE_GENERIC": "Klarte ikke lagre kartpakke på disk. Vennligst prøv igjen!",
     "UNZIP_ERROR_MESSAGE_NO_SPACE_LEFT": "Klarte ikke lagre kartpakke på disk. Er du sikker på at det er nok plass tilgjengelig?"

--- a/src/download-and-unzip-plugin.ts
+++ b/src/download-and-unzip-plugin.ts
@@ -4,8 +4,11 @@ export interface JobStatus {
   /** Between 0 and 1. 0 is not started, 1 is done. */
   progress: number;
 
-  /** May be: SUCCESS, WORK_IN_PROGRESS, ERROR, UNKNOWN  */
+  /** May be: SUCCESS, WORK_IN_PROGRESS, PENDING, ERROR, UNKNOWN  */
   status: string;
+
+  /** You might get a reason here if status is PENDING OR ERROR */
+  reason: string;
 
   /** Ongoing (last started) task type */
   task: 'download' | 'unzip';


### PR DESCRIPTION
Pluginen kræsjet når den prøvde å rapportere framdrift etter at vi fikk tilbake nett igjen.
Årsaken var at vi prøvde å dele på filstørrelsen, og den var 0. Android sin DownloadManager nullstiller filstørrelsen om nedlasting feiler og henter ikke denne på nytt.
Har også utvidet statusrapportering for nedlasting sånn at vi nå viser om vi ikke har nett og du vil se bedre feilmeldinger i loggen.

Prøv å teste:

- å starte nedlasting uten nett
- å fjerne nett på flere mulige måter under nedlasting og deretter få tlf. på nett igjen

Det er ikke alltid tlf. greier å fortsette nedlasting om du mister nett, men da skal du få tydelig beskjed.
