### PR TITLE
RO-2279:  Fiks slik at filter på dager tilbake ikke slutter å virke

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -83,17 +83,22 @@ describe('SearchCriteriaService', () => {
 
   it('default days-back filter should work', fakeAsync(async () => {
     jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
+    await userSettingService.saveGeoHazardsAndDaysBack({ daysBack: 1 });
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
     tick(150);
-    //check that criteria contains correct from time. Should be 2 days earlier at midnight
-    expect(criteria.FromDtObsTime).toEqual('2000-12-22T00:00:00.000+01:00');
+    //check that criteria contains correct from time. Should be 1 days earlier at midnight
+    expect(criteria.FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
 
     await service.applyQueryParams();
 
-    //check fromDate parameter in url. Should be 2 days earlier based on local time
+    //check daysBack parameter in url. Should be 1 days earlier based on local time
     const url = new URL(document.location.href);
-    expect(url.searchParams.get('fromDate')).toEqual('2000-12-22');
+    expect(url.searchParams.get('daysBack')).toEqual('1');
+
+    // Check that fromDate and toDate are not in url while daysBack are there
+    expect(url.searchParams.get('fromDate')).toBeNull();
+    expect(url.searchParams.get('toDate')).toBeNull();
   }));
   it('nick name filter should work', fakeAsync(async () => {
     let criteria;

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -285,7 +285,7 @@ export class SearchCriteriaService {
     const orderBy = this.readOrderBy(url.searchParams.get(URL_PARAM_ORDER_BY));
 
     const daysBack = url.searchParams.get(URL_PARAM_DAYSBACK);
-    const daysBackNumeric = this.convertToPositiveInteger(daysBack);
+    const daysBackNumeric = this.convertToInt(daysBack);
 
     let fromObsTime: string;
     let toObsTime: string;
@@ -385,12 +385,12 @@ export class SearchCriteriaService {
     params.apply();
   }
 
-  private convertToPositiveInteger(value: string): number {
+  private convertToInt(value: string): number {
     if (typeof value !== 'string') {
       return null;
     }
     const numericValue = Number(value);
-    if (Number.isInteger(numericValue) && numericValue > 0) {
+    if (Number.isInteger(numericValue)) {
       return numericValue;
     }
     return null;

--- a/src/app/modules/side-menu/components/date-range/date-range.component.html
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.html
@@ -9,8 +9,8 @@
       </ion-text>
     </ion-item>
     <div slot="content">
-      <ion-list>
-        <ion-radio-group [ngModel]="mode.value" (ionChange)="changeMode($event)">
+      <ion-list *ngIf="mode$ | async as mode">
+        <ion-radio-group [value]="mode" (ionChange)="changeMode($event)">
           <ion-item>
             <ion-radio value="predefined" slot="start" (click)="changeDateAndSetMode()"></ion-radio>
             <app-observations-days-back (changeDaysBack)="changeDateAndSetMode($event)"></app-observations-days-back>

--- a/src/app/modules/side-menu/components/date-range/date-range.component.html
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.html
@@ -21,7 +21,7 @@
             <ion-radio slot="start" value="custom"></ion-radio>
           </ion-item>
 
-          <ion-item class="white-background" *ngIf="mode.value === 'custom'">
+          <ion-item class="white-background" *ngIf="mode === 'custom'">
             <ion-label slot="start">{{ "MENU.START_DATE" | translate }}</ion-label>
             <app-datetime-picker
               presentation="date"
@@ -35,7 +35,7 @@
             ></app-datetime-picker>
           </ion-item>
 
-          <ion-item class="white-background" *ngIf="mode.value === 'custom'">
+          <ion-item class="white-background" *ngIf="mode === 'custom'">
             <ion-label slot="start">{{ "MENU.END_DATE" | translate }}</ion-label>
             <app-datetime-picker
               presentation="date"

--- a/src/app/modules/side-menu/components/date-range/date-range.component.html
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.html
@@ -11,23 +11,23 @@
     <div slot="content">
       <ion-list *ngIf="mode$ | async as mode">
         <ion-radio-group [value]="mode" (ionChange)="changeMode($event)">
-          <ion-item>
-            <ion-radio value="predefined" slot="start" (click)="changeDateAndSetMode()"></ion-radio>
-            <app-observations-days-back (changeDaysBack)="changeDateAndSetMode($event)"></app-observations-days-back>
+          <ion-item (click)="setUseDaysBack()">
+            <ion-radio slot="start" value="predefined"></ion-radio>
+            <app-observations-days-back (changeDaysBack)="setUseDaysBack()"></app-observations-days-back>
           </ion-item>
 
           <ion-item>
-            <ion-label>{{ "MENU.CUSTOM_TIMESPAN" | translate }}</ion-label>
             <ion-radio slot="start" value="custom"></ion-radio>
+            <ion-label>{{ "MENU.CUSTOM_TIMESPAN" | translate }}</ion-label>
           </ion-item>
 
           <ion-item class="white-background" *ngIf="mode === 'custom'">
             <ion-label slot="start">{{ "MENU.START_DATE" | translate }}</ion-label>
             <app-datetime-picker
               presentation="date"
-              [(dateTime)]="fromDate"
+              [dateTime]="fromDate$ | async"
               [minDate]="minDate"
-              [maxDate]="toDate || maxDate"
+              [maxDate]="(toDate$ | async) || maxDate"
               (dateTimeChange)="setFromDate($event)"
               dateTimeFormat="dd. MMM yyyy"
               textAlign="right"
@@ -39,8 +39,8 @@
             <ion-label slot="start">{{ "MENU.END_DATE" | translate }}</ion-label>
             <app-datetime-picker
               presentation="date"
-              [(dateTime)]="toDate"
-              [minDate]="fromDate || minDate"
+              [dateTime]="toDate$ | async"
+              [minDate]="(fromDate$ | async) || minDate"
               [maxDate]="maxDate"
               (dateTimeChange)="setToDate($event)"
               dateTimeFormat="dd. MMM yyyy"

--- a/src/app/modules/side-menu/components/date-range/date-range.component.ts
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.ts
@@ -89,8 +89,7 @@ export class DateRangeComponent extends NgDestoryBase implements OnInit {
   }
 
   changeDateAndSetMode(days?: number): void {
-    const mode = days !== undefined ? 'predefined' : 'custom';
-    let date;
+    let date: moment.Moment;
 
     if (days !== undefined) {
       if (days === 0) {
@@ -106,6 +105,7 @@ export class DateRangeComponent extends NgDestoryBase implements OnInit {
         date = moment().subtract(days, 'days');
       }
     }
+    this.searchCriteriaService.setUseDaysBack(true);
     this.searchCriteriaService.setFromDate(date.format('YYYY-MM-DD'), true);
   }
 
@@ -151,9 +151,9 @@ export class DateRangeComponent extends NgDestoryBase implements OnInit {
 
   changeMode($event: CustomEvent<IRadioGroupRadioGroupChangeEventDetail>) {
     if ($event.detail.value === 'predefined') {
-      this.searchCriteriaService.
-    } || $event.detail.value === 'custom') {
-
+      this.searchCriteriaService.setUseDaysBack(true);
+    } else if ($event.detail.value === 'custom') {
+      this.searchCriteriaService.setUseDaysBack(false);
     }
   }
 }

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -2,7 +2,7 @@
   <ion-list-header color="varsom-blue" class="ion-no-margin">
     <ion-label>{{ "OBSERVATION_FILTER.TITLE" | translate }}</ion-label>
   </ion-list-header>
-  <app-observations-days-back *ngIf="isIosOrAndroid"></app-observations-days-back>
+  <app-observations-days-back></app-observations-days-back>
   <app-date-range *ngIf="!isIosOrAndroid"></app-date-range>
   <app-update-observations></app-update-observations>
 

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -2,7 +2,7 @@
   <ion-list-header color="varsom-blue" class="ion-no-margin">
     <ion-label>{{ "OBSERVATION_FILTER.TITLE" | translate }}</ion-label>
   </ion-list-header>
-  <app-observations-days-back></app-observations-days-back>
+  <app-observations-days-back *ngIf="isIosOrAndroid"></app-observations-days-back>
   <app-date-range *ngIf="!isIosOrAndroid"></app-date-range>
   <app-update-observations></app-update-observations>
 

--- a/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.html
+++ b/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.html
@@ -5,8 +5,8 @@
   <ion-select
     cancelText="{{ 'DIALOGS.CANCEL' | translate }}"
     [interface]="popupType"
-    (ionChange)="save()"
-    [(ngModel)]="selectedDaysBack"
+    (ionChange)="save($event)"
+    [value]="userSettingService.daysBackForCurrentGeoHazard$ | async"
   >
     <ion-select-option *ngFor="let item of daysBackOptions" [value]="item.val">
       <app-check-days-or-weeks-back [daysBack]="item.val"></app-check-days-or-weeks-back>

--- a/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.ts
+++ b/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.ts
@@ -4,7 +4,7 @@ import { takeUntil } from 'rxjs/operators';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 import { settings } from '../../../../../settings';
-import { Platform } from '@ionic/angular';
+import { Platform, SelectCustomEvent } from '@ionic/angular';
 import { SelectInterface } from '@ionic/core';
 import { isAndroidOrIos } from '../../../../core/helpers/ionic/platform-helper';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
@@ -15,14 +15,13 @@ import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
   styleUrls: ['./observations-days-back.component.scss'],
 })
 export class ObservationsDaysBackComponent extends NgDestoryBase implements OnInit {
-  selectedDaysBack: number;
   daysBackOptions: { val: number }[];
   subscription: Subscription;
   popupType: SelectInterface;
 
   @Output() changeDaysBack = new EventEmitter<number>();
 
-  constructor(private userSettingService: UserSettingService, private platform: Platform) {
+  constructor(public userSettingService: UserSettingService, private platform: Platform) {
     super();
   }
 
@@ -31,12 +30,6 @@ export class ObservationsDaysBackComponent extends NgDestoryBase implements OnIn
     this.userSettingService.currentGeoHazard$.pipe(takeUntil(this.ngDestroy$)).subscribe((currentGeoHazard) => {
       this.daysBackOptions = this.getDaysBackArray(currentGeoHazard[0]);
     });
-
-    this.userSettingService.daysBackForCurrentGeoHazard$
-      .pipe(takeUntil(this.ngDestroy$))
-      .subscribe((selectedDaysBack) => {
-        this.selectedDaysBack = selectedDaysBack;
-      });
   }
 
   getDaysBackArray(geoHazard: GeoHazard) {
@@ -45,10 +38,11 @@ export class ObservationsDaysBackComponent extends NgDestoryBase implements OnIn
     }));
   }
 
-  async save(): Promise<void> {
-    const daysBack = await this.userSettingService.saveGeoHazardsAndDaysBack({ daysBack: this.selectedDaysBack });
-    if (typeof daysBack === 'number') {
-      this.changeDaysBack.emit(daysBack);
+  async save(event: SelectCustomEvent<number>): Promise<void> {
+    const newDaysBack = event.detail.value;
+    const savedDaysBack = await this.userSettingService.saveGeoHazardsAndDaysBack({ daysBack: newDaysBack });
+    if (typeof savedDaysBack === 'number') {
+      this.changeDaysBack.emit(savedDaysBack);
     }
   }
 }


### PR DESCRIPTION
Sjekk saken i Jira for hva som var feil.
Det var et bra stykke arbeide Jørgen la ned for å finne ut av dette, jeg har bare forsøkt å fullføre det han starta på.

Jeg har også gjort litt om på logikken når man leser url-parametre på web, slik at hvis fromDate eller toDate er i url, brukes datovelger og ikke "x dager tilbake". Dette fordi "x dager tilbake" ikke alltid passer med en evt. from fromDate i url.
Testet på Android og web.
