### PR TITLE
Small offline registrations fix

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -40,9 +40,6 @@
   "DATA_LOAD": {
     "DATA": "Loading...",
     "LOADING": "Loading",
-    "NO_FETCHED_OBSERVATIONS": "App didn't fetch observations",
-    "OBSERVATIONS_LAST_UPDATE_OLDER_THAN_TWO_WEEKS": "Observations were last fetched on {{timeSinceLastUpdated}}",
-    "SERVICE_UNAVAILABLE": "You may not have network connection or the app can't contact with Regobs. You can try to update manually by clicking the refresh button in the filter menu.",
     "SPINNER_FETCH_OBSERVATIONS": "Fetching observations"
   },
   "DATE": "Date",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -40,9 +40,6 @@
   "DATA_LOAD": {
     "DATA": "Laster data...",
     "LOADING": "Laster",
-    "NO_FETCHED_OBSERVATIONS": "Appen har ikke fått hentet observasjoner",
-    "OBSERVATIONS_LAST_UPDATE_OLDER_THAN_TWO_WEEKS": "Observasjoner ble sist hentet for {{timeSinceLastUpdated}}",
-    "SERVICE_UNAVAILABLE": "Det kan være du ikke har nett eller at appen ikke får kontakt med Regobs. Du kan prøve å oppdatere manuelt med oppdateringsknappen i filtermenyen",
     "SPINNER_FETCH_OBSERVATIONS": "Henter observasjoner"
   },
   "DATE": "Dato",


### PR DESCRIPTION
Fixes two things:

- Removes the outdated observations toast
- Compares counts and checks for deleted after normal syncing is done, this avoids the app getting into a state where it is in the middle of a sync, but thinks it has to remove registrations because the sync is not finished yet.
