### PR TITLE
RO-2292: Satt zoom til 6 for offlinekart-oversikten

### DIFF
--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -20,6 +20,7 @@
       [showSupportMaps]="false"
       [autoActivate]="true"
       [geoTag]="'package-map'"
+      [zoom]="6"
     ></app-map>
   </div>
 </ion-content>


### PR DESCRIPTION
Offlinekart-oversikten bruker fortsatt samme kartsenter som hovedkartet, men zoom-nivå vil nå alltid være 6 når du velger "Offlinekart" i menyen.