### PR TITLE
RO-2284: få fikset bredde på tidsrom på web

### DIFF
--- a/src/app/modules/side-menu/components/date-range/date-range.component.html
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.html
@@ -1,13 +1,13 @@
-<ion-accordion-group (ionChange)="toggleAccordion($event)">
+<ion-accordion-group *ngIf="!isNativePlatform; else observationsDaysBackOnly" (ionChange)="toggleAccordion($event)">
   <ion-accordion value="first">
     <ion-item slot="header" color="light">
       <ion-label color="dark" position="stacked">
         {{ "MENU.TIMESPAN" | translate }}
       </ion-label>
       <ng-container *ngIf="useDaysBack$ | async; else showDateRange">
-        <ng-container *ngIf="daysBackSubject | async as daysBack">
+        <ng-container *ngIf="{ daysBack: daysBackSubject | async } as daysBack">
           <ion-text *ngIf="!isOpen" class="ion-align-self-start">
-            <app-check-days-or-weeks-back [daysBack]="daysBack"></app-check-days-or-weeks-back>
+            <app-check-days-or-weeks-back [daysBack]="daysBack.daysBack"></app-check-days-or-weeks-back>
           </ion-text>
         </ng-container>
       </ng-container>
@@ -15,7 +15,7 @@
     <div slot="content">
       <ion-list *ngIf="mode$ | async as mode">
         <ion-radio-group [value]="mode" (ionChange)="changeMode($event)">
-          <ion-item (click)="setUseDaysBack($event)">
+          <ion-item>
             <ion-radio slot="start" value="predefined"></ion-radio>
             <app-observations-days-back (changeDaysBack)="setUseDaysBack($event)"></app-observations-days-back>
           </ion-item>
@@ -64,4 +64,8 @@
       <span>{{ dateRangeText }}</span>
     </ion-text>
   </ng-container>
+</ng-template>
+
+<ng-template #observationsDaysBackOnly>
+  <app-observations-days-back (changeDaysBack)="setUseDaysBack($event)"></app-observations-days-back>
 </ng-template>

--- a/src/app/modules/side-menu/components/date-range/date-range.component.html
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.html
@@ -5,9 +5,11 @@
         {{ "MENU.TIMESPAN" | translate }}
       </ion-label>
       <ng-container *ngIf="useDaysBack$ | async; else showDateRange">
-        <ng-container *ngIf="{ daysBack: daysBackSubject | async } as daysBack">
+        <ng-container>
           <ion-text *ngIf="!isOpen" class="ion-align-self-start">
-            <app-check-days-or-weeks-back [daysBack]="daysBack.daysBack"></app-check-days-or-weeks-back>
+            <app-check-days-or-weeks-back
+              [daysBack]="userSettingService.daysBackForCurrentGeoHazard$ | async"
+            ></app-check-days-or-weeks-back>
           </ion-text>
         </ng-container>
       </ng-container>

--- a/src/app/modules/side-menu/components/date-range/date-range.component.html
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.html
@@ -4,16 +4,20 @@
       <ion-label color="dark" position="stacked">
         {{ "MENU.TIMESPAN" | translate }}
       </ion-label>
-      <ion-text class="ion-align-self-start">
-        <span *ngIf="!isOpen">{{ modeText$ | async }}</span>
-      </ion-text>
+      <ng-container *ngIf="useDaysBack$ | async; else showDateRange">
+        <ng-container *ngIf="daysBackSubject | async as daysBack">
+          <ion-text *ngIf="!isOpen" class="ion-align-self-start">
+            <app-check-days-or-weeks-back [daysBack]="daysBack"></app-check-days-or-weeks-back>
+          </ion-text>
+        </ng-container>
+      </ng-container>
     </ion-item>
     <div slot="content">
       <ion-list *ngIf="mode$ | async as mode">
         <ion-radio-group [value]="mode" (ionChange)="changeMode($event)">
-          <ion-item (click)="setUseDaysBack()">
+          <ion-item (click)="setUseDaysBack($event)">
             <ion-radio slot="start" value="predefined"></ion-radio>
-            <app-observations-days-back (changeDaysBack)="setUseDaysBack()"></app-observations-days-back>
+            <app-observations-days-back (changeDaysBack)="setUseDaysBack($event)"></app-observations-days-back>
           </ion-item>
 
           <ion-item>
@@ -53,3 +57,11 @@
     </div>
   </ion-accordion>
 </ion-accordion-group>
+
+<ng-template #showDateRange>
+  <ng-container *ngIf="dateRangeText$ | async as dateRangeText">
+    <ion-text *ngIf="!isOpen" class="ion-align-self-start">
+      <span>{{ dateRangeText }}</span>
+    </ion-text>
+  </ng-container>
+</ng-template>

--- a/src/app/modules/side-menu/components/date-range/date-range.component.spec.ts
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.spec.ts
@@ -23,7 +23,7 @@ describe('DateRangeComponent', () => {
       mapService as unknown as MapService,
       new TestLoggingService()
     );
-    component = new DateRangeComponent(searchCriteriaService, userSettingService, null);
+    component = new DateRangeComponent(searchCriteriaService, userSettingService);
   }));
 
   it('should create', () => {

--- a/src/app/modules/side-menu/components/date-range/date-range.component.ts
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.ts
@@ -1,21 +1,18 @@
 import { Component, OnInit } from '@angular/core';
 import { SearchCriteriaService } from '../../../../core/services/search-criteria/search-criteria.service';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
-import { BehaviorSubject, map, Observable, takeUntil, combineLatest, concatMap, switchMap, startWith } from 'rxjs';
+import { map, Observable, combineLatest, firstValueFrom, Subject } from 'rxjs';
 import { NgDestoryBase } from '../../../../core/helpers/observable-helper';
 import moment from 'moment';
 import { IonAccordionGroup } from '@ionic/angular';
-import { TranslateService } from '@ngx-translate/core';
-import { getLangKeyString } from '../../../common-core/helpers';
 import { RadioGroupChangeEventDetail as IRadioGroupRadioGroupChangeEventDetail } from '@ionic/core/dist/types/components/radio-group/radio-group-interface';
-import { LangKey } from 'src/app/modules/common-core/models';
 
 @Component({
   selector: 'app-date-range',
   templateUrl: './date-range.component.html',
   styleUrls: ['./date-range.component.scss'],
 })
-export class DateRangeComponent extends NgDestoryBase {
+export class DateRangeComponent extends NgDestoryBase implements OnInit {
   minDate = new Date('2010-01-01T00:00:00').toISOString();
   maxDate = new Date().toISOString();
   isOpen = false;
@@ -24,13 +21,12 @@ export class DateRangeComponent extends NgDestoryBase {
   modeText$: Observable<string>;
   fromDate$: Observable<string>;
   toDate$: Observable<string>;
+  useDaysBack$: Observable<boolean>;
   readableDays$: Observable<string>;
+  dateRangeText$: Observable<string>;
+  daysBackSubject = new Subject<number>();
 
-  constructor(
-    private searchCriteriaService: SearchCriteriaService,
-    private userSettingService: UserSettingService,
-    private translateService: TranslateService
-  ) {
+  constructor(private searchCriteriaService: SearchCriteriaService, private userSettingService: UserSettingService) {
     super();
     this.mode$ = this.searchCriteriaService.useDaysBack$.pipe(
       map((useDaysBack) => (useDaysBack ? 'predefined' : 'custom'))
@@ -40,18 +36,15 @@ export class DateRangeComponent extends NgDestoryBase {
 
     this.toDate$ = this.searchCriteriaService.searchCriteria$.pipe(map((criteria) => criteria.ToDtObsTime));
 
-    const daysBackText$ = this.userSettingService.daysBackForCurrentGeoHazard$.pipe(
-      concatMap((days) => this.getReadableDays(days)),
-      map((x) => x[Object.keys(x)[0]])
-    );
+    this.useDaysBack$ = this.searchCriteriaService.useDaysBack$;
 
-    const dateRangeText$ = combineLatest([this.userSettingService.language$, this.fromDate$, this.toDate$]).pipe(
-      map(([lang, fromDate, toDate]) => generateDateRange(lang, fromDate, toDate))
+    this.dateRangeText$ = combineLatest([this.fromDate$, this.toDate$]).pipe(
+      map(([fromDate, toDate]) => generateDateRange(fromDate, toDate))
     );
-
-    this.modeText$ = this.searchCriteriaService.useDaysBack$.pipe(
-      switchMap((useDaysBack) => (useDaysBack ? daysBackText$ : dateRangeText$))
-    );
+  }
+  async ngOnInit() {
+    const daysBackFromUserSettings = await firstValueFrom(this.userSettingService.daysBackForCurrentGeoHazard$);
+    this.daysBackSubject.next(daysBackFromUserSettings);
   }
 
   /**
@@ -85,25 +78,9 @@ export class DateRangeComponent extends NgDestoryBase {
     this.searchCriteriaService.setToDate(date);
   }
 
-  setUseDaysBack(): void {
+  setUseDaysBack(date: number): void {
+    this.daysBackSubject.next(date);
     this.searchCriteriaService.setUseDaysBack(true);
-  }
-
-  private getReadableDays(day: number): Observable<string> {
-    if (day === 0) return this.translateService.get(['MENU.DATE_RANGE.TODAY']);
-    if (day === 1) return this.translateService.get(['MENU.DATE_RANGE.YESTERDAY']);
-    if (day > 1 && day < 7) {
-      return this.translateService.get(['MENU.DATE_RANGE.LAST_X_DAYS'], { days: day });
-    }
-    if (day >= 7 && day < 14) {
-      return this.translateService.get(['MENU.DATE_RANGE.LAST_WEEK']);
-    }
-    if (day >= 14 && day < 28) {
-      return this.translateService.get(['MENU.DATE_RANGE.LAST_X_WEEKS'], { weeks: day / 7 });
-    }
-    if (day >= 28) {
-      return this.translateService.get(['MENU.DATE_RANGE.LAST_X_MONTHS'], { months: day / 30 });
-    }
   }
 
   changeMode($event: CustomEvent<IRadioGroupRadioGroupChangeEventDetail>) {
@@ -115,25 +92,16 @@ export class DateRangeComponent extends NgDestoryBase {
   }
 }
 
-export function generateDateRange(language: LangKey, fromDate?: string, toDate?: string) {
+export function generateDateRange(fromDate?: string, toDate?: string) {
   let dateRange = '';
-  const lang = getLangKeyString(language);
   if (fromDate) {
-    dateRange = new Date(fromDate).toLocaleDateString(lang, {
-      day: '2-digit',
-      month: '2-digit',
-      year: '2-digit',
-    });
+    dateRange = moment(fromDate).format('DD/MM/YY');
   }
   if (toDate) {
     if (fromDate) {
       dateRange += ' - ';
     }
-    dateRange += new Date(toDate).toLocaleDateString(lang, {
-      day: '2-digit',
-      month: '2-digit',
-      year: '2-digit',
-    });
+    dateRange += moment(toDate).format('DD/MM/YY');
   }
   return dateRange;
 }

--- a/src/app/modules/side-menu/components/date-range/date-range.component.ts
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.ts
@@ -1,22 +1,23 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { SearchCriteriaService } from '../../../../core/services/search-criteria/search-criteria.service';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
-import { map, Observable, combineLatest, firstValueFrom, Subject } from 'rxjs';
+import { map, Observable, combineLatest, Subject } from 'rxjs';
 import { NgDestoryBase } from '../../../../core/helpers/observable-helper';
 import moment from 'moment';
 import { IonAccordionGroup } from '@ionic/angular';
 import { RadioGroupChangeEventDetail as IRadioGroupRadioGroupChangeEventDetail } from '@ionic/core/dist/types/components/radio-group/radio-group-interface';
+import { Capacitor } from '@capacitor/core';
 
 @Component({
   selector: 'app-date-range',
   templateUrl: './date-range.component.html',
   styleUrls: ['./date-range.component.scss'],
 })
-export class DateRangeComponent extends NgDestoryBase implements OnInit {
+export class DateRangeComponent extends NgDestoryBase {
   minDate = new Date('2010-01-01T00:00:00').toISOString();
   maxDate = new Date().toISOString();
   isOpen = false;
-
+  isNativePlatform: boolean;
   mode$: Observable<'predefined' | 'custom'>;
   modeText$: Observable<string>;
   fromDate$: Observable<string>;
@@ -31,7 +32,7 @@ export class DateRangeComponent extends NgDestoryBase implements OnInit {
     this.mode$ = this.searchCriteriaService.useDaysBack$.pipe(
       map((useDaysBack) => (useDaysBack ? 'predefined' : 'custom'))
     );
-
+    this.isNativePlatform = Capacitor.isNativePlatform();
     this.fromDate$ = this.searchCriteriaService.searchCriteria$.pipe(map((criteria) => criteria.FromDtObsTime));
 
     this.toDate$ = this.searchCriteriaService.searchCriteria$.pipe(map((criteria) => criteria.ToDtObsTime));
@@ -41,10 +42,8 @@ export class DateRangeComponent extends NgDestoryBase implements OnInit {
     this.dateRangeText$ = combineLatest([this.fromDate$, this.toDate$]).pipe(
       map(([fromDate, toDate]) => generateDateRange(fromDate, toDate))
     );
-  }
-  async ngOnInit() {
-    const daysBackFromUserSettings = await firstValueFrom(this.userSettingService.daysBackForCurrentGeoHazard$);
-    this.daysBackSubject.next(daysBackFromUserSettings);
+
+    this.userSettingService.daysBackForCurrentGeoHazard$.subscribe((v) => this.daysBackSubject.next(v));
   }
 
   /**

--- a/src/app/modules/side-menu/components/date-range/date-range.component.ts
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.ts
@@ -94,13 +94,13 @@ export class DateRangeComponent extends NgDestoryBase {
 export function generateDateRange(fromDate?: string, toDate?: string) {
   let dateRange = '';
   if (fromDate) {
-    dateRange = moment(fromDate).format('DD/MM/YY');
+    dateRange = moment(fromDate).format('DD.MM.yyyy');
   }
   if (toDate) {
     if (fromDate) {
       dateRange += ' - ';
     }
-    dateRange += moment(toDate).format('DD/MM/YY');
+    dateRange += moment(toDate).format('DD.MM.yyyy');
   }
   return dateRange;
 }

--- a/src/app/modules/side-menu/components/date-range/date-range.component.ts
+++ b/src/app/modules/side-menu/components/date-range/date-range.component.ts
@@ -25,9 +25,8 @@ export class DateRangeComponent extends NgDestoryBase {
   useDaysBack$: Observable<boolean>;
   readableDays$: Observable<string>;
   dateRangeText$: Observable<string>;
-  daysBackSubject = new Subject<number>();
 
-  constructor(private searchCriteriaService: SearchCriteriaService, private userSettingService: UserSettingService) {
+  constructor(private searchCriteriaService: SearchCriteriaService, public userSettingService: UserSettingService) {
     super();
     this.mode$ = this.searchCriteriaService.useDaysBack$.pipe(
       map((useDaysBack) => (useDaysBack ? 'predefined' : 'custom'))
@@ -42,8 +41,6 @@ export class DateRangeComponent extends NgDestoryBase {
     this.dateRangeText$ = combineLatest([this.fromDate$, this.toDate$]).pipe(
       map(([fromDate, toDate]) => generateDateRange(fromDate, toDate))
     );
-
-    this.userSettingService.daysBackForCurrentGeoHazard$.subscribe((v) => this.daysBackSubject.next(v));
   }
 
   /**
@@ -77,8 +74,8 @@ export class DateRangeComponent extends NgDestoryBase {
     this.searchCriteriaService.setToDate(date);
   }
 
-  setUseDaysBack(date: number): void {
-    this.daysBackSubject.next(date);
+  setUseDaysBack(daysBack: number): void {
+    this.userSettingService.saveGeoHazardsAndDaysBack({ daysBack });
     this.searchCriteriaService.setUseDaysBack(true);
   }
 

--- a/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.html
+++ b/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="this.isNativePlatform; else selectTimeSpan">
+<ng-container *ngIf="isNativePlatform; else selectTimeSpan">
   <ion-item slot="header">
     <ion-label color="dark" position="stacked">
       {{ "MENU.TIMESPAN" | translate }}

--- a/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.html
+++ b/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.html
@@ -1,7 +1,13 @@
-<ion-item slot="header">
-  <ion-label color="dark" position="stacked">
-    {{ "MENU.TIMESPAN" | translate }}
-  </ion-label>
+<ng-container *ngIf="this.isNativePlatform; else selectTimeSpan">
+  <ion-item slot="header">
+    <ion-label color="dark" position="stacked">
+      {{ "MENU.TIMESPAN" | translate }}
+    </ion-label>
+    <ng-component *ngTemplateOutlet="selectTimeSpan"></ng-component>
+  </ion-item>
+</ng-container>
+
+<ng-template #selectTimeSpan>
   <ion-select
     cancelText="{{ 'DIALOGS.CANCEL' | translate }}"
     [interface]="popupType"
@@ -12,4 +18,4 @@
       <app-check-days-or-weeks-back [daysBack]="item.val"></app-check-days-or-weeks-back>
     </ion-select-option>
   </ion-select>
-</ion-item>
+</ng-template>

--- a/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.scss
+++ b/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.scss
@@ -8,6 +8,7 @@ ion-item {
 ion-select {
   width: 100%;
   max-width: 100%;
+  padding: 0;
 }
 
 ion-radio {

--- a/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.scss
+++ b/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.scss
@@ -8,10 +8,15 @@ ion-item {
 ion-select {
   width: 100%;
   max-width: 100%;
-  padding: 0;
 }
 
 ion-radio {
   margin-right: 20px;
   margin-left: 4px;
+}
+
+@media only screen and (min-width: 465px) {
+  ion-select {
+    padding: 0;
+  }
 }

--- a/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.ts
+++ b/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.ts
@@ -4,10 +4,9 @@ import { takeUntil } from 'rxjs/operators';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 import { settings } from '../../../../../settings';
-import { Platform } from '@ionic/angular';
 import { SelectInterface } from '@ionic/core';
-import { isAndroidOrIos } from '../../../../core/helpers/ionic/platform-helper';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
+import { Capacitor } from '@capacitor/core';
 
 @Component({
   selector: 'app-observations-days-back',
@@ -19,15 +18,17 @@ export class ObservationsDaysBackComponent extends NgDestoryBase implements OnIn
   daysBackOptions: { val: number }[];
   subscription: Subscription;
   popupType: SelectInterface;
+  isNativePlatform: boolean;
 
   @Output() changeDaysBack = new EventEmitter<number>();
 
-  constructor(private userSettingService: UserSettingService, private platform: Platform) {
+  constructor(private userSettingService: UserSettingService) {
     super();
   }
 
   ngOnInit(): void {
-    this.popupType = isAndroidOrIos(this.platform) ? 'action-sheet' : 'popover';
+    this.isNativePlatform = Capacitor.isNativePlatform();
+    this.popupType = this.isNativePlatform ? 'action-sheet' : 'popover';
     this.userSettingService.currentGeoHazard$.pipe(takeUntil(this.ngDestroy$)).subscribe((currentGeoHazard) => {
       this.daysBackOptions = this.getDaysBackArray(currentGeoHazard[0]);
     });

--- a/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.ts
+++ b/src/app/modules/side-menu/components/observations-days-back/observations-days-back.component.ts
@@ -22,7 +22,7 @@ export class ObservationsDaysBackComponent extends NgDestoryBase implements OnIn
 
   @Output() changeDaysBack = new EventEmitter<number>();
 
-  constructor(private userSettingService: UserSettingService) {
+  constructor(public userSettingService: UserSettingService) {
     super();
   }
 


### PR DESCRIPTION
I date-range sjekker  html templaten om vi er native eller ikke og så enten renderes akkordion eller bare select komponent med bestemte alternativer 
Det er ganske mange ngIfer i  html templaten. tenkte også å ta ut showDateRange ng-templaten så det ser ryddigere ut. 
Jeg måtte returnere daysBackSubject i html templaten som et objekt - hvis dagen verdi var 0 (kun dagens obs) templaten trodde verdi var falsy og viste ikke check-days-or-weeks-back (derfor bare kun dagens funka ikke).

I komponenten har jeg slettet metoder som viser dagene på en annen måte enn dropdownet. Fikk ganske mindre kode til slutt. 