### PR TITLE
RO-2295: Fiks av nullstill-filter-knapp

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -273,6 +273,7 @@ export class SearchCriteriaService {
       // ToDtObsTime: null,
     };
     this.setUseDaysBack(true);
+    await this.userSettingService.resetDaysBackForCurrentGeoHazard();
     this.searchCriteriaChanges.next(criteria);
     this.resetEvent.next();
   }

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -295,13 +295,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
       }
     }
     if (daysBack != null) {
-      for (const geoHazard of userSetting.currentGeoHazard) {
-        const existingValue = userSetting.observationDaysBack.find((x) => x.geoHazard === geoHazard);
-        if (existingValue.daysBack !== daysBack) {
-          existingValue.daysBack = daysBack;
-          changed = true;
-        }
-      }
+      changed = this.setDaysBackForCurrentGeoHazard(daysBack, userSetting);
     }
     if (changed) {
       this.saveUserSettings(userSetting);
@@ -309,5 +303,31 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
     } else {
       return new Promise((resolve) => resolve(false));
     }
+  }
+
+  /**
+   * Reset daysBack to default for current geo hazard
+   */
+  async resetDaysBackForCurrentGeoHazard(): Promise<void> {
+    const currentGeoHazards = await firstValueFrom(this.currentGeoHazard$);
+    const defaultDaysBackForCurrentGeoHazard = DEFAULT_USER_SETTINGS(null).observationDaysBack.find(
+      (x) => x.geoHazard === currentGeoHazards[0]
+    );
+    const userSettings = await firstValueFrom(this.userSetting$);
+    if (this.setDaysBackForCurrentGeoHazard(defaultDaysBackForCurrentGeoHazard.daysBack, userSettings)) {
+      this.saveUserSettings(userSettings);
+    }
+  }
+
+  private setDaysBackForCurrentGeoHazard(daysBack: number, userSettings: UserSetting): boolean {
+    let changed = false;
+    for (const geoHazard of userSettings.currentGeoHazard) {
+      const existingValue = userSettings.observationDaysBack.find((x) => x.geoHazard === geoHazard);
+      if (existingValue.daysBack !== daysBack) {
+        existingValue.daysBack = daysBack;
+        changed = true;
+      }
+    }
+    return changed;
   }
 }

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -5,6 +5,12 @@
   <app-observations-days-back *ngIf="isIosOrAndroid"></app-observations-days-back>
   <app-date-range *ngIf="!isIosOrAndroid"></app-date-range>
   <app-update-observations></app-update-observations>
+  <ion-item>
+    <ion-button (click)="onResetFilters()" class="resetFiltersButton" type="button" fill="clear">
+      <ion-icon src="./assets/icon/reset-button.svg"> </ion-icon>
+      {{ "OBSERVATION_FILTER.RESET_FILTER_BUTTON_TITLE" | translate }}
+    </ion-button>
+  </ion-item>
 
   <ng-container *ngIf="isSupported('observationType')">
     <ion-list-header color="varsom-blue" class="ion-no-margin">
@@ -81,11 +87,4 @@
       </ion-searchbar>
     </ion-item>
   </ng-container>
-
-  <ion-item>
-    <ion-button (click)="onResetFilters()" class="resetFiltersButton" type="button" fill="clear">
-      <ion-icon src="./assets/icon/reset-button.svg"> </ion-icon>
-      {{ "OBSERVATION_FILTER.RESET_FILTER_BUTTON_TITLE" | translate }}
-    </ion-button>
-  </ion-item>
 </ion-list>

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -250,7 +250,7 @@
     "OBSERVATION_TYPE_FILTER": {
       "TITLE": "Observasjonstype"
     },
-    "RESET_FILTER_BUTTON_TITLE": "Tilbakestill filtre",
+    "RESET_FILTER_BUTTON_TITLE": "Tilbakestill alle filtre",
     "TITLE": "Observasjonsfilter"
   },
   "OBSERVATION_LIST": {


### PR DESCRIPTION
Nå nullstiller vi også tidsrom-filteret til standard for gjeldende naturfare.
Nullstill-knappen er også flyttet og teksten på knappen er litt endret.
Test også at appen husker antall dager tilbake vi har valgt, siden jeg har endret koden for dette.