### PR TITLE
RO-2298: Sikrer at observasjoner vises etter at de er sendt inn

### DIFF
--- a/src/app/pages/my-observations/components/sent-list/sent-list.component.html
+++ b/src/app/pages/my-observations/components/sent-list/sent-list.component.html
@@ -1,5 +1,5 @@
 <!-- A list of observations sent to server -->
-<ng-container *ngIf="myRegistrations; else skeleton">
+<ng-container *ngIf="myRegistrations$ | async as myRegistrations; else skeleton">
   <ion-item-divider no-border>
     <ion-grid class="ion-no-padding ion-no-margin">
       <ion-row>

--- a/src/app/pages/my-observations/my-observations.page.ts
+++ b/src/app/pages/my-observations/my-observations.page.ts
@@ -20,7 +20,6 @@ export class MyObservationsPage {
 
   ionViewDidEnter() {
     this.content.scrollToTop();
-    this.refresh();
   }
 
   refresh(): void {


### PR DESCRIPTION
Har skrevet om visning av innsendte observasjoner en del.
Nå blir søkeresultatet flettet sammen med nylig innsendte observasjoner og evt. slettede observasjoner blir fjernet til slutt.
Dette bør testes grundig.
Sjekk at:

- [ ] observasjoner som er sendt inn automatisk dukker opp under innsendte observasjoner, også på tregt nett
- [ ] observasjoner som er slettet automatisk forsvinner under innsendte observasjoner, også på tregt nett 
- [ ] søket kjøres automatisk når man går inn på sida
- [ ] at man bare søker en gang når man går inn på sida
- [ ] at man bare søker en gang når man sender inn eller sletter observasjoner
- [ ] at de sist innsendte observasjoner er først i lista