### PR TITLE
RO-2312: vise at faretegn feltet i skjema er obligatorisk

### DIFF
--- a/src/app/modules/registration/pages/danger-obs/add-or-edit-danger-obs-modal/add-or-edit-danger-obs-modal.page.html
+++ b/src/app/modules/registration/pages/danger-obs/add-or-edit-danger-obs-modal/add-or-edit-danger-obs-modal.page.html
@@ -24,7 +24,7 @@
     </ion-item>
     <app-kdv-select
       (valueChange)="dropdownChanged($event)"
-      title="REGISTRATION.DANGER_OBS.TITLE"
+      title="REGISTRATION.DANGER_OBS.DROPDOWN_TITLE"
       *ngIf="showDangerSignSelect"
       kdvKey="{{ geoHazardName }}_DangerSignKDV"
       [(value)]="dangerSignTid"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -328,6 +328,7 @@
       "COMMENT": "Comment",
       "COMMENT_PLACEHOLDER": "Provide description of the danger sign",
       "DESCRIPTION": "Description",
+      "DROPDOWN_TITLE": "Danger Sign (required)",
       "FOR_MUNICIPAL": "For the municipality",
       "FOR_REGION": "County / Warning region",
       "GENERAL_ON_MOUNTAIN": "Generally in the mountains",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -328,6 +328,7 @@
       "COMMENT": "Kommentar",
       "COMMENT_PLACEHOLDER": "Her kan du gi ytterligere beskrivelse av faretegnet",
       "DESCRIPTION": "Beskrivelse",
+      "DROPDOWN_TITLE": "Faretegn (obligatorisk)",
       "FOR_MUNICIPAL": "For kommunen",
       "FOR_REGION": "Fylket/varslingsregion",
       "GENERAL_ON_MOUNTAIN": "Generelt på fjellet",


### PR DESCRIPTION
Jeg lage en separat tittel på dropdownen med '(obligatorisk)' på slutten. Måtte gjøre det sånn for vanlig TITLE ble brukt mange andre steder hvor vi ikke trenger å vise 'obligatorisk' teskten.