### PR TITLE
Fix valgt geohazard under oppstart + fjern tomme søkekriterier

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -177,7 +177,7 @@ describe('SearchCriteriaService', () => {
     const obsType2 = { Id: 40, SubTypes: [26] };
     tick(500);
     await service.removeObservationType(obsType2);
-    expect(criteria.SelectedRegistrationTypes).toEqual(null);
+    expect(criteria.SelectedRegistrationTypes).toEqual(undefined);
     await service.applyQueryParams();
     const url = new URL(document.location.href);
     expect(url.searchParams.get('type')).toEqual(null);


### PR DESCRIPTION
Fikser:

- At ikke snø alltid velges hvis ikke `hazard` er angitt som url-parameter ([RO-2311](https://nveprojects.atlassian.net/browse/RO-2311))
- Fjerner tomme søkekriterier før søkekriterier emites fra search-criteria.service ([RO-2116](https://nveprojects.atlassian.net/browse/RO-2116))
- Rydder litt opp i koden som parser url-parametere

Feilen var at snø var valgt som default hvis ikke noe annet var angitt som url-parameter (se linje 331):

https://github.com/NVE/regObs4/blob/3ae965b53e05d0e065f87e9524ce627558486dbc/src/app/core/services/search-criteria/search-criteria.service.ts#L330-L348
