### PR TITLE
RO-2106: fikset tooltips på skjemaer 

### DIFF
--- a/src/app/components/kdv-select/kdv-select.component.html
+++ b/src/app/components/kdv-select/kdv-select.component.html
@@ -1,12 +1,12 @@
 <ion-item [lines]="obsLocMode ? 'none' : undefined">
   <ion-label [color]="labelColor" position="stacked" [ngClass]="{ 'ion-text-uppercase': !obsLocMode }">
-    {{ labelTitle | translate }}
+    {{ label | translate }}
   </ion-label>
   <app-select
     [(selectedValue)]="value"
     [options]="selectOptions"
     [disabled]="disabled"
-    [labelTitle]="labelTitle"
+    [label]="label"
     [showReset]="showResetButton"
     (selectedValueChange)="valueChange.emit($event)"
     [ngClass]="{ 'obs-loc-mode-select': obsLocMode }"

--- a/src/app/components/kdv-select/kdv-select.component.html
+++ b/src/app/components/kdv-select/kdv-select.component.html
@@ -1,12 +1,12 @@
 <ion-item [lines]="obsLocMode ? 'none' : undefined">
   <ion-label [color]="labelColor" position="stacked" [ngClass]="{ 'ion-text-uppercase': !obsLocMode }">
-    {{ title | translate }}
+    {{ labelTitle | translate }}
   </ion-label>
   <app-select
     [(selectedValue)]="value"
     [options]="selectOptions"
     [disabled]="disabled"
-    [title]="title"
+    [labelTitle]="labelTitle"
     [showReset]="showResetButton"
     (selectedValueChange)="valueChange.emit($event)"
     [ngClass]="{ 'obs-loc-mode-select': obsLocMode }"

--- a/src/app/components/kdv-select/kdv-select.component.ts
+++ b/src/app/components/kdv-select/kdv-select.component.ts
@@ -11,7 +11,7 @@ import { KdvKey } from 'src/app/modules/common-registration/registration.models'
   styleUrls: ['./kdv-select.component.scss'],
 })
 export class KdvSelectComponent implements OnInit, OnDestroy {
-  @Input() title: string;
+  @Input() labelTitle: string;
   @Input() kdvKey: KdvKey;
   @Input() value: number;
   @Output() valueChange = new EventEmitter();
@@ -22,7 +22,7 @@ export class KdvSelectComponent implements OnInit, OnDestroy {
   @Input() useDescription: boolean;
   @Input() filter: (number) => boolean;
   @Input() getIconFunc: (kdvElement: KdvElement) => string;
-  @Input() obsLocMode: boolean = false;
+  @Input() obsLocMode = false;
   private kdvelements: KdvElement[] = [];
 
   private subscription: Subscription;

--- a/src/app/components/kdv-select/kdv-select.component.ts
+++ b/src/app/components/kdv-select/kdv-select.component.ts
@@ -11,7 +11,7 @@ import { KdvKey } from 'src/app/modules/common-registration/registration.models'
   styleUrls: ['./kdv-select.component.scss'],
 })
 export class KdvSelectComponent implements OnInit, OnDestroy {
-  @Input() labelTitle: string;
+  @Input() label: string;
   @Input() kdvKey: KdvKey;
   @Input() value: number;
   @Output() valueChange = new EventEmitter();

--- a/src/app/modules/registration/components/damage-obs/damage-obs.component.html
+++ b/src/app/modules/registration/components/damage-obs/damage-obs.component.html
@@ -32,7 +32,7 @@
   >
   </app-edit-images>
   <app-text-comment
-    labelTitle="REGISTRATION.WATER.DAMAGE.COMMENT"
+    label="REGISTRATION.WATER.DAMAGE.COMMENT"
     [(value)]="damageObs.Comment"
     placeholder="REGISTRATION.WATER.DAMAGE.COMMENT_PLACEHOLDER"
   ></app-text-comment>

--- a/src/app/modules/registration/components/damage-obs/damage-obs.component.html
+++ b/src/app/modules/registration/components/damage-obs/damage-obs.component.html
@@ -32,7 +32,7 @@
   >
   </app-edit-images>
   <app-text-comment
-    title="REGISTRATION.WATER.DAMAGE.COMMENT"
+    labelTitle="REGISTRATION.WATER.DAMAGE.COMMENT"
     [(value)]="damageObs.Comment"
     placeholder="REGISTRATION.WATER.DAMAGE.COMMENT_PLACEHOLDER"
   ></app-text-comment>

--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -14,7 +14,7 @@
     </ion-fab>
     <app-text-comment
       [(value)]="attachment.Comment"
-      title="{{ pictureCommentText | translate }}"
+      labelTitle="{{ pictureCommentText | translate }}"
       rows="2"
       placeholder="{{ pictureCommentPlaceholder | translate }}"
     ></app-text-comment>
@@ -33,7 +33,7 @@
     <app-text-comment
       [value]="attachment.Comment"
       (valueChange)="setNewAttachmentComment(attachment, $event)"
-      title="{{ pictureCommentText | translate }}"
+      labelTitle="{{ pictureCommentText | translate }}"
       rows="2"
       placeholder="{{ pictureCommentPlaceholder | translate }}"
     ></app-text-comment>

--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -14,7 +14,7 @@
     </ion-fab>
     <app-text-comment
       [(value)]="attachment.Comment"
-      labelTitle="{{ pictureCommentText | translate }}"
+      label="{{ pictureCommentText | translate }}"
       rows="2"
       placeholder="{{ pictureCommentPlaceholder | translate }}"
     ></app-text-comment>
@@ -33,7 +33,7 @@
     <app-text-comment
       [value]="attachment.Comment"
       (valueChange)="setNewAttachmentComment(attachment, $event)"
-      labelTitle="{{ pictureCommentText | translate }}"
+      label="{{ pictureCommentText | translate }}"
       rows="2"
       placeholder="{{ pictureCommentPlaceholder | translate }}"
     ></app-text-comment>

--- a/src/app/modules/registration/components/kdv-icon-select/kdv-icon-select.component.html
+++ b/src/app/modules/registration/components/kdv-icon-select/kdv-icon-select.component.html
@@ -2,7 +2,7 @@
   <!-- Header -->
   <ion-item class="header">
     <div class="header-content">
-      <ion-label>{{ title | translate }}</ion-label>
+      <ion-label>{{ label | translate }}</ion-label>
 
       <div *ngIf="multiSelect" class="n-selected">
         {{ "REGISTRATION.SELECTION_COUNT" | translate: { count: count() } }}

--- a/src/app/modules/registration/components/kdv-icon-select/kdv-icon-select.component.ts
+++ b/src/app/modules/registration/components/kdv-icon-select/kdv-icon-select.component.ts
@@ -22,7 +22,7 @@ const DEBUG_TAG = 'KdvIconSelectComponent';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class KdvIconSelectComponent {
-  @Input() title: string;
+  @Input() label: string;
   @Input() kdvKey: KdvKey;
 
   /**

--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.html
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.html
@@ -7,13 +7,13 @@
   (keyup.enter)="openPicker()"
 >
   <ion-label
-    *ngIf="title"
+    *ngIf="labelTitle"
     [color]="color"
     position="stacked"
     class="no-white-space-wrap"
     [ngClass]="{ 'ion-text-uppercase': !simpleObsMode, 'simple-mode-title': simpleObsMode }"
   >
-    {{ title | translate }} {{ isValid == false ? "(" + (errorMessage | translate) + ")" : null }}
+    {{ labelTitle | translate }} {{ isValid == false ? "(" + (errorMessage | translate) + ")" : null }}
   </ion-label>
   <ion-text
     [ngClass]="{ 'ion-align-self-start': true, 'simple-mode-sub': simpleObsMode }"

--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.html
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.html
@@ -7,13 +7,13 @@
   (keyup.enter)="openPicker()"
 >
   <ion-label
-    *ngIf="labelTitle"
+    *ngIf="label"
     [color]="color"
     position="stacked"
     class="no-white-space-wrap"
     [ngClass]="{ 'ion-text-uppercase': !simpleObsMode, 'simple-mode-title': simpleObsMode }"
   >
-    {{ labelTitle | translate }} {{ isValid == false ? "(" + (errorMessage | translate) + ")" : null }}
+    {{ label | translate }} {{ isValid == false ? "(" + (errorMessage | translate) + ")" : null }}
   </ion-label>
   <ion-text
     [ngClass]="{ 'ion-align-self-start': true, 'simple-mode-sub': simpleObsMode }"

--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.ts
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.ts
@@ -17,7 +17,7 @@ export class NumericInputComponent {
   @Input() isValid = true;
   @Input() errorMessage?: string;
   @Output() valueChange = new EventEmitter();
-  @Input() labelTitle: string;
+  @Input() label: string;
   @Input() placeholder: string;
   @Input() convertRatio: number;
   @Input() readonly = false;
@@ -49,7 +49,7 @@ export class NumericInputComponent {
           max: this.max,
           suffix: this.suffix,
           decimalSeparator: this.decimalSeparator,
-          title: this.labelTitle,
+          title: this.label,
         },
       });
       modal.present();

--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.ts
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.ts
@@ -17,7 +17,7 @@ export class NumericInputComponent {
   @Input() isValid = true;
   @Input() errorMessage?: string;
   @Output() valueChange = new EventEmitter();
-  @Input() title: string;
+  @Input() labelTitle: string;
   @Input() placeholder: string;
   @Input() convertRatio: number;
   @Input() readonly = false;
@@ -49,7 +49,7 @@ export class NumericInputComponent {
           max: this.max,
           suffix: this.suffix,
           decimalSeparator: this.decimalSeparator,
-          title: this.title,
+          title: this.labelTitle,
         },
       });
       modal.present();

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
@@ -128,7 +128,7 @@
           <div *ngIf="isDesktop" class="flex-row">
             <app-kdv-select
               class="flex-grow selectors"
-              labelTitle="REGISTRATION.OBS_LOCATION.SOURCE"
+              label="REGISTRATION.OBS_LOCATION.SOURCE"
               kdvKey="SourceKDV"
               labelColor="rgb(68, 68, 68)"
               obsLocMode="true"

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
@@ -128,7 +128,7 @@
           <div *ngIf="isDesktop" class="flex-row">
             <app-kdv-select
               class="flex-grow selectors"
-              title="REGISTRATION.OBS_LOCATION.SOURCE"
+              labelTitle="REGISTRATION.OBS_LOCATION.SOURCE"
               kdvKey="SourceKDV"
               labelColor="rgb(68, 68, 68)"
               obsLocMode="true"

--- a/src/app/modules/registration/components/snow/compression-test-list/compression-test-modal/compression-test-modal.page.html
+++ b/src/app/modules/registration/components/snow/compression-test-list/compression-test-modal/compression-test-modal.page.html
@@ -20,7 +20,7 @@
       </ion-toggle>
     </ion-item>
     <app-kdv-select
-      title="REGISTRATION.SNOW.COMPRESSION_TEST.TEST_TYPE"
+      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.TEST_TYPE"
       kdvKey="Snow_PropagationKDV"
       [(value)]="compressionTest.PropagationTID"
       (valueChange)="checkTestType()"
@@ -36,13 +36,13 @@
       <app-select
         [(selectedValue)]="compressionTest.TapsFracture"
         [options]="tapsArray"
-        title="REGISTRATION.SNOW.COMPRESSION_TEST.TAPS_FRACTURE"
+        labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.TAPS_FRACTURE"
       ></app-select>
     </ion-item>
     <app-numeric-input
       *ngIf="!isCTNorECTXorRB7() && !isNull()"
       [(value)]="compressionTest.FractureDepth"
-      title="REGISTRATION.SNOW.COMPRESSION_TEST.DISTANCE_FROM_TOP"
+      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.DISTANCE_FROM_TOP"
       [min]="0"
       [max]="999"
       [decimalPlaces]="0"
@@ -52,7 +52,7 @@
     <app-numeric-input
       *ngIf="isPST()"
       [(value)]="compressionTest.PstX"
-      title="REGISTRATION.SNOW.COMPRESSION_TEST.X_DISTANCE"
+      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.X_DISTANCE"
       [min]="0"
       [max]="999"
       [decimalPlaces]="0"
@@ -62,7 +62,7 @@
     <app-numeric-input
       *ngIf="isPST()"
       [(value)]="compressionTest.PstY"
-      title="REGISTRATION.SNOW.COMPRESSION_TEST.Y_DISTANCE"
+      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.Y_DISTANCE"
       [min]="0"
       [max]="999"
       [decimalPlaces]="0"
@@ -72,7 +72,7 @@
     <app-numeric-input
       *ngIf="rbReleaseVisible()"
       [(value)]="compressionTest.RbRelease"
-      title="REGISTRATION.SNOW.COMPRESSION_TEST.RB_RELEASE"
+      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.RB_RELEASE"
       [min]="0"
       [max]="100"
       [decimalPlaces]="0"
@@ -81,17 +81,18 @@
     </app-numeric-input>
     <app-kdv-select
       *ngIf="testFractureVisible()"
-      title="REGISTRATION.SNOW.COMPRESSION_TEST.FRACTURE_TYPE"
+      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.FRACTURE_TYPE"
       kdvKey="Snow_ComprTestFractureKDV"
       [(value)]="compressionTest.ComprTestFractureTID"
     ></app-kdv-select>
     <app-kdv-select
       *ngIf="!isLBT() && !isNull()"
-      title="REGISTRATION.SNOW.COMPRESSION_TEST.STABILITY_EVAL"
+      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.STABILITY_EVAL"
       kdvKey="Snow_StabilityEvalKDV"
       [(value)]="compressionTest.StabilityEvalTID"
     ></app-kdv-select>
-    <app-text-comment title="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="compressionTest.Comment"> </app-text-comment>
+    <app-text-comment labelTitle="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="compressionTest.Comment">
+    </app-text-comment>
   </ion-list>
   <app-modal-save-or-delete-buttons
     [saveDisabled]="!isValid"

--- a/src/app/modules/registration/components/snow/compression-test-list/compression-test-modal/compression-test-modal.page.html
+++ b/src/app/modules/registration/components/snow/compression-test-list/compression-test-modal/compression-test-modal.page.html
@@ -20,7 +20,7 @@
       </ion-toggle>
     </ion-item>
     <app-kdv-select
-      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.TEST_TYPE"
+      label="REGISTRATION.SNOW.COMPRESSION_TEST.TEST_TYPE"
       kdvKey="Snow_PropagationKDV"
       [(value)]="compressionTest.PropagationTID"
       (valueChange)="checkTestType()"
@@ -36,13 +36,13 @@
       <app-select
         [(selectedValue)]="compressionTest.TapsFracture"
         [options]="tapsArray"
-        labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.TAPS_FRACTURE"
+        label="REGISTRATION.SNOW.COMPRESSION_TEST.TAPS_FRACTURE"
       ></app-select>
     </ion-item>
     <app-numeric-input
       *ngIf="!isCTNorECTXorRB7() && !isNull()"
       [(value)]="compressionTest.FractureDepth"
-      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.DISTANCE_FROM_TOP"
+      label="REGISTRATION.SNOW.COMPRESSION_TEST.DISTANCE_FROM_TOP"
       [min]="0"
       [max]="999"
       [decimalPlaces]="0"
@@ -52,7 +52,7 @@
     <app-numeric-input
       *ngIf="isPST()"
       [(value)]="compressionTest.PstX"
-      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.X_DISTANCE"
+      label="REGISTRATION.SNOW.COMPRESSION_TEST.X_DISTANCE"
       [min]="0"
       [max]="999"
       [decimalPlaces]="0"
@@ -62,7 +62,7 @@
     <app-numeric-input
       *ngIf="isPST()"
       [(value)]="compressionTest.PstY"
-      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.Y_DISTANCE"
+      label="REGISTRATION.SNOW.COMPRESSION_TEST.Y_DISTANCE"
       [min]="0"
       [max]="999"
       [decimalPlaces]="0"
@@ -72,7 +72,7 @@
     <app-numeric-input
       *ngIf="rbReleaseVisible()"
       [(value)]="compressionTest.RbRelease"
-      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.RB_RELEASE"
+      label="REGISTRATION.SNOW.COMPRESSION_TEST.RB_RELEASE"
       [min]="0"
       [max]="100"
       [decimalPlaces]="0"
@@ -81,18 +81,17 @@
     </app-numeric-input>
     <app-kdv-select
       *ngIf="testFractureVisible()"
-      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.FRACTURE_TYPE"
+      label="REGISTRATION.SNOW.COMPRESSION_TEST.FRACTURE_TYPE"
       kdvKey="Snow_ComprTestFractureKDV"
       [(value)]="compressionTest.ComprTestFractureTID"
     ></app-kdv-select>
     <app-kdv-select
       *ngIf="!isLBT() && !isNull()"
-      labelTitle="REGISTRATION.SNOW.COMPRESSION_TEST.STABILITY_EVAL"
+      label="REGISTRATION.SNOW.COMPRESSION_TEST.STABILITY_EVAL"
       kdvKey="Snow_StabilityEvalKDV"
       [(value)]="compressionTest.StabilityEvalTID"
     ></app-kdv-select>
-    <app-text-comment labelTitle="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="compressionTest.Comment">
-    </app-text-comment>
+    <app-text-comment label="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="compressionTest.Comment"> </app-text-comment>
   </ion-list>
   <app-modal-save-or-delete-buttons
     [saveDisabled]="!isValid"

--- a/src/app/modules/registration/components/snow/simple-snow-obs/simple-snow-obs.component.html
+++ b/src/app/modules/registration/components/snow/simple-snow-obs/simple-snow-obs.component.html
@@ -1,6 +1,6 @@
 <ion-list lines="full">
   <app-kdv-icon-select
-    title="REGISTRATION.SNOW.SNOW_SURFACE.SKI_CONDITIONS"
+    label="REGISTRATION.SNOW.SNOW_SURFACE.SKI_CONDITIONS"
     kdvKey="Snow_SkiConditionsKDV"
     [(value)]="snowSurfaceObservation.SkiConditionsTID"
     (valueChange)="save()"
@@ -9,7 +9,7 @@
   </app-kdv-icon-select>
 
   <app-kdv-icon-select
-    title="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_SURFACE"
+    label="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_SURFACE"
     kdvKey="Snow_SnowSurfaceKDV"
     [(value)]="snowSurfaceObservation.SnowSurfaceTID"
     (valueChange)="save()"
@@ -23,7 +23,7 @@
   ></app-edit-images-bar>
 
   <app-kdv-icon-select
-    title="REGISTRATION.DANGER_OBS.TITLE"
+    label="REGISTRATION.DANGER_OBS.TITLE"
     kdvKey="Snow_DangerSignKDV"
     [(value)]="dangerSignTIDs"
     (valueChange)="save()"
@@ -41,7 +41,7 @@
   <div class="inline numeric-side-by-side">
     <app-numeric-input
       [(value)]="snowSurfaceObservation.NewSnowDepth24"
-      labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_DEPTH"
+      label="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_DEPTH"
       [min]="0"
       [max]="999"
       [decimalPlaces]="0"
@@ -54,7 +54,7 @@
 
     <app-numeric-input
       [(value)]="snowSurfaceObservation.SnowDepth"
-      labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DEPTH"
+      label="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DEPTH"
       [min]="0"
       [max]="9999"
       [decimalPlaces]="0"

--- a/src/app/modules/registration/components/snow/simple-snow-obs/simple-snow-obs.component.html
+++ b/src/app/modules/registration/components/snow/simple-snow-obs/simple-snow-obs.component.html
@@ -41,7 +41,7 @@
   <div class="inline numeric-side-by-side">
     <app-numeric-input
       [(value)]="snowSurfaceObservation.NewSnowDepth24"
-      title="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_DEPTH"
+      labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_DEPTH"
       [min]="0"
       [max]="999"
       [decimalPlaces]="0"
@@ -54,7 +54,7 @@
 
     <app-numeric-input
       [(value)]="snowSurfaceObservation.SnowDepth"
-      title="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DEPTH"
+      labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DEPTH"
       [min]="0"
       [max]="9999"
       [decimalPlaces]="0"

--- a/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-layer-modal/snow-density-layer-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-layer-modal/snow-density-layer-modal.page.html
@@ -15,7 +15,7 @@
       <ng-container *ngIf="useCylinder else noCylinder">
         <app-numeric-input
           [(value)]="layer.Thickness"
-          title="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.HEIGHT"
+          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.HEIGHT"
           [max]="999"
           [min]="0"
           suffix="cm"
@@ -26,7 +26,7 @@
         </app-numeric-input>
         <app-numeric-input
           [(value)]="layer.Weight"
-          title="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.WEIGHT"
+          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.WEIGHT"
           [max]="9999"
           [min]="0"
           [convertRatio]="1000"
@@ -91,7 +91,7 @@
 <ng-template #noCylinder>
   <app-numeric-input
     [(value)]="layer.Thickness"
-    title="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.HEIGHT"
+    labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.HEIGHT"
     [max]="999"
     [min]="0"
     suffix="cm"
@@ -102,7 +102,7 @@
   </app-numeric-input>
   <app-numeric-input
     [(value)]="layer.Density"
-    title="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.DENSITY"
+    labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.DENSITY"
     [max]="9999"
     [min]="0"
     suffix="kg/m³"

--- a/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-layer-modal/snow-density-layer-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-layer-modal/snow-density-layer-modal.page.html
@@ -15,7 +15,7 @@
       <ng-container *ngIf="useCylinder else noCylinder">
         <app-numeric-input
           [(value)]="layer.Thickness"
-          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.HEIGHT"
+          label="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.HEIGHT"
           [max]="999"
           [min]="0"
           suffix="cm"
@@ -26,7 +26,7 @@
         </app-numeric-input>
         <app-numeric-input
           [(value)]="layer.Weight"
-          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.WEIGHT"
+          label="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.WEIGHT"
           [max]="9999"
           [min]="0"
           [convertRatio]="1000"
@@ -91,7 +91,7 @@
 <ng-template #noCylinder>
   <app-numeric-input
     [(value)]="layer.Thickness"
-    labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.HEIGHT"
+    label="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.HEIGHT"
     [max]="999"
     [min]="0"
     suffix="cm"
@@ -102,7 +102,7 @@
   </app-numeric-input>
   <app-numeric-input
     [(value)]="layer.Density"
-    labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.DENSITY"
+    label="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.DENSITY"
     [max]="9999"
     [min]="0"
     suffix="kg/m³"

--- a/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-modal/snow-density-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-modal/snow-density-modal.page.html
@@ -22,7 +22,7 @@
         </ion-list-header>
         <app-numeric-input
           [(value)]="profile.CylinderDiameter"
-          title="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.CYLINDER_DIAMETER"
+          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.CYLINDER_DIAMETER"
           [max]="999"
           [min]="0"
           suffix="cm"
@@ -33,7 +33,7 @@
         <app-numeric-input
           [(value)]="profile.TareWeight"
           (valueChange)="recalculateLayersAndSave()"
-          title="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.TARE_WEIGHT"
+          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.TARE_WEIGHT"
           [max]="999"
           [min]="0"
           suffix="g"

--- a/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-modal/snow-density-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-modal/snow-density-modal.page.html
@@ -22,7 +22,7 @@
         </ion-list-header>
         <app-numeric-input
           [(value)]="profile.CylinderDiameter"
-          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.CYLINDER_DIAMETER"
+          label="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.CYLINDER_DIAMETER"
           [max]="999"
           [min]="0"
           suffix="cm"
@@ -33,7 +33,7 @@
         <app-numeric-input
           [(value)]="profile.TareWeight"
           (valueChange)="recalculateLayersAndSave()"
-          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.TARE_WEIGHT"
+          label="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.TARE_WEIGHT"
           [max]="999"
           [min]="0"
           suffix="g"

--- a/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp-layer-modal/snow-temp-layer-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp-layer-modal/snow-temp-layer-modal.page.html
@@ -14,7 +14,7 @@
       </ion-list-header>
       <app-numeric-input
         [(value)]="layer.Depth"
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.DEPTH"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.DEPTH"
         [max]="999"
         [min]="0"
         suffix="cm"
@@ -23,7 +23,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="layer.SnowTemp"
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.TEMPERATURE"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.TEMPERATURE"
         [max]="0"
         [min]="-70"
         suffix="°C"

--- a/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp-layer-modal/snow-temp-layer-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp-layer-modal/snow-temp-layer-modal.page.html
@@ -14,7 +14,7 @@
       </ion-list-header>
       <app-numeric-input
         [(value)]="layer.Depth"
-        title="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.DEPTH"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.DEPTH"
         [max]="999"
         [min]="0"
         suffix="cm"
@@ -23,7 +23,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="layer.SnowTemp"
-        title="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.TEMPERATURE"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.TEMPERATURE"
         [max]="0"
         [min]="-70"
         suffix="°C"

--- a/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-layer-modal/strat-profile-layer-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-layer-modal/strat-profile-layer-modal.page.html
@@ -14,7 +14,7 @@
       </ion-list-header>
       <app-numeric-input
         [(value)]="layer.Thickness"
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.THICKNESS"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.THICKNESS"
         [min]="0"
         suffix="cm"
         [decimalPlaces]="2"
@@ -22,13 +22,13 @@
       >
       </app-numeric-input>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.HARDNESS"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.HARDNESS"
         kdvKey="Snow_HardnessKDV"
         [(value)]="layer.HardnessTID"
         [filter]="hardnessFilter"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.GRAIN_FORM"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.GRAIN_FORM"
         kdvKey="Snow_GrainFormKDV"
         [(value)]="layer.GrainFormPrimaryTID"
         [filter]="grainFormFilter"
@@ -42,12 +42,12 @@
         <app-select
           [(selectedValue)]="layer.GrainSizeAvg"
           [options]="grainSizeOptions"
-          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.SIZE"
+          label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.SIZE"
         >
         </app-select>
       </ion-item>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.WETNESS"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.WETNESS"
         kdvKey="Snow_WetnessKDV"
         [(value)]="layer.WetnessTID"
         [filter]="wetnessFilter"
@@ -65,13 +65,13 @@
     </ion-button>
     <ion-list lines="full" *ngIf="showMore">
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.HARDNESS_BOTTOM"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.HARDNESS_BOTTOM"
         kdvKey="Snow_HardnessKDV"
         [(value)]="layer.HardnessBottomTID"
       >
       </app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.GRAIN_FROM_SECONDARY"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.GRAIN_FROM_SECONDARY"
         kdvKey="Snow_GrainFormKDV"
         [(value)]="layer.GrainFormSecondaryTID"
         [getIconFunc]="getIconFunc"
@@ -84,17 +84,17 @@
         <app-select
           [(selectedValue)]="layer.GrainSizeAvgMax"
           [options]="grainSizeOptions"
-          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.MAX_GRAIN_SIZE"
+          label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.MAX_GRAIN_SIZE"
         >
         </app-select>
       </ion-item>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.CRITICAL_LAYER"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.CRITICAL_LAYER"
         kdvKey="Snow_CriticalLayerKDV"
         [(value)]="layer.CriticalLayerTID"
       >
       </app-kdv-select>
-      <app-text-comment labelTitle="DIALOGS.COMMENT" [(value)]="layer.Comment"></app-text-comment>
+      <app-text-comment label="DIALOGS.COMMENT" [(value)]="layer.Comment"></app-text-comment>
     </ion-list>
     <ion-grid class="ion-no-padding">
       <ion-row>

--- a/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-layer-modal/strat-profile-layer-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-layer-modal/strat-profile-layer-modal.page.html
@@ -14,7 +14,7 @@
       </ion-list-header>
       <app-numeric-input
         [(value)]="layer.Thickness"
-        title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.THICKNESS"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.THICKNESS"
         [min]="0"
         suffix="cm"
         [decimalPlaces]="2"
@@ -22,13 +22,13 @@
       >
       </app-numeric-input>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.HARDNESS"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.HARDNESS"
         kdvKey="Snow_HardnessKDV"
         [(value)]="layer.HardnessTID"
         [filter]="hardnessFilter"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.GRAIN_FORM"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.GRAIN_FORM"
         kdvKey="Snow_GrainFormKDV"
         [(value)]="layer.GrainFormPrimaryTID"
         [filter]="grainFormFilter"
@@ -42,12 +42,12 @@
         <app-select
           [(selectedValue)]="layer.GrainSizeAvg"
           [options]="grainSizeOptions"
-          title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.SIZE"
+          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.SIZE"
         >
         </app-select>
       </ion-item>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.WETNESS"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.WETNESS"
         kdvKey="Snow_WetnessKDV"
         [(value)]="layer.WetnessTID"
         [filter]="wetnessFilter"
@@ -65,13 +65,13 @@
     </ion-button>
     <ion-list lines="full" *ngIf="showMore">
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.HARDNESS_BOTTOM"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.HARDNESS_BOTTOM"
         kdvKey="Snow_HardnessKDV"
         [(value)]="layer.HardnessBottomTID"
       >
       </app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.GRAIN_FROM_SECONDARY"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.GRAIN_FROM_SECONDARY"
         kdvKey="Snow_GrainFormKDV"
         [(value)]="layer.GrainFormSecondaryTID"
         [getIconFunc]="getIconFunc"
@@ -84,17 +84,17 @@
         <app-select
           [(selectedValue)]="layer.GrainSizeAvgMax"
           [options]="grainSizeOptions"
-          title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.MAX_GRAIN_SIZE"
+          labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.MAX_GRAIN_SIZE"
         >
         </app-select>
       </ion-item>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.CRITICAL_LAYER"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.CRITICAL_LAYER"
         kdvKey="Snow_CriticalLayerKDV"
         [(value)]="layer.CriticalLayerTID"
       >
       </app-kdv-select>
-      <app-text-comment title="DIALOGS.COMMENT" [(value)]="layer.Comment"></app-text-comment>
+      <app-text-comment labelTitle="DIALOGS.COMMENT" [(value)]="layer.Comment"></app-text-comment>
     </ion-list>
     <ion-grid class="ion-no-padding">
       <ion-row>

--- a/src/app/modules/registration/components/text-comment/text-comment.component.html
+++ b/src/app/modules/registration/components/text-comment/text-comment.component.html
@@ -1,6 +1,6 @@
 <ion-item detail="false">
   <ion-label color="medium" position="stacked" class="ion-text-uppercase">
-    {{ labelTitle | translate }}
+    {{ label | translate }}
   </ion-label>
 
   <ion-textarea

--- a/src/app/modules/registration/components/text-comment/text-comment.component.html
+++ b/src/app/modules/registration/components/text-comment/text-comment.component.html
@@ -1,6 +1,6 @@
 <ion-item detail="false">
   <ion-label color="medium" position="stacked" class="ion-text-uppercase">
-    {{ title | translate }}
+    {{ labelTitle | translate }}
   </ion-label>
 
   <ion-textarea

--- a/src/app/modules/registration/components/text-comment/text-comment.component.ts
+++ b/src/app/modules/registration/components/text-comment/text-comment.component.ts
@@ -6,7 +6,7 @@ import { Component, Input, EventEmitter, Output } from '@angular/core';
   styleUrls: ['./text-comment.component.scss'],
 })
 export class TextCommentComponent {
-  @Input() labelTitle: string;
+  @Input() label: string;
   @Input() placeholder: string;
   @Input() value: string;
   @Output() valueChange = new EventEmitter();

--- a/src/app/modules/registration/components/text-comment/text-comment.component.ts
+++ b/src/app/modules/registration/components/text-comment/text-comment.component.ts
@@ -6,7 +6,7 @@ import { Component, Input, EventEmitter, Output } from '@angular/core';
   styleUrls: ['./text-comment.component.scss'],
 })
 export class TextCommentComponent {
-  @Input() title: string;
+  @Input() labelTitle: string;
   @Input() placeholder: string;
   @Input() value: string;
   @Output() valueChange = new EventEmitter();

--- a/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
+++ b/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
@@ -5,7 +5,7 @@
     modalTitlePostfix="GEO_HAZARDS.WATER"
   ></app-edit-images-bar>
   <app-text-comment
-    title="DIALOGS.COMMENT"
+    labelTitle="DIALOGS.COMMENT"
     placeholder="REGISTRATION.GENERAL_COMMENT.COMMENT_PLACEHOLDER"
     [(value)]="draft.registration.GeneralObservation.ObsComment"
     (valueChange)="save()"

--- a/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
+++ b/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
@@ -5,7 +5,7 @@
     modalTitlePostfix="GEO_HAZARDS.WATER"
   ></app-edit-images-bar>
   <app-text-comment
-    labelTitle="DIALOGS.COMMENT"
+    label="DIALOGS.COMMENT"
     placeholder="REGISTRATION.GENERAL_COMMENT.COMMENT_PLACEHOLDER"
     [(value)]="draft.registration.GeneralObservation.ObsComment"
     (valueChange)="save()"

--- a/src/app/modules/registration/pages/add-web-url-modal/add-web-url-modal.page.html
+++ b/src/app/modules/registration/pages/add-web-url-modal/add-web-url-modal.page.html
@@ -14,7 +14,7 @@
     </ion-list-header>
     <app-text-comment
       [(value)]="urlToSave.UrlDescription"
-      labelTitle="REGISTRATION.GENERAL_COMMENT.COMMENT_TITLE"
+      label="REGISTRATION.GENERAL_COMMENT.COMMENT_TITLE"
       rows="2"
     ></app-text-comment>
     <ion-item>

--- a/src/app/modules/registration/pages/add-web-url-modal/add-web-url-modal.page.html
+++ b/src/app/modules/registration/pages/add-web-url-modal/add-web-url-modal.page.html
@@ -14,7 +14,7 @@
     </ion-list-header>
     <app-text-comment
       [(value)]="urlToSave.UrlDescription"
-      title="REGISTRATION.GENERAL_COMMENT.COMMENT_TITLE"
+      labelTitle="REGISTRATION.GENERAL_COMMENT.COMMENT_TITLE"
       rows="2"
     ></app-text-comment>
     <ion-item>

--- a/src/app/modules/registration/pages/danger-obs/add-or-edit-danger-obs-modal/add-or-edit-danger-obs-modal.page.html
+++ b/src/app/modules/registration/pages/danger-obs/add-or-edit-danger-obs-modal/add-or-edit-danger-obs-modal.page.html
@@ -24,7 +24,7 @@
     </ion-item>
     <app-kdv-select
       (valueChange)="dropdownChanged($event)"
-      labelTitle="REGISTRATION.DANGER_OBS.DROPDOWN_TITLE"
+      label="REGISTRATION.DANGER_OBS.DROPDOWN_TITLE"
       *ngIf="showDangerSignSelect"
       kdvKey="{{ geoHazardName }}_DangerSignKDV"
       [(value)]="dangerSignTid"
@@ -34,15 +34,11 @@
       <ion-label color="medium" position="stacked" class="ion-text-uppercase"
         >{{'REGISTRATION.DANGER_OBS.AREA' | translate}}
       </ion-label>
-      <app-select
-        labelTitle="REGISTRATION.DANGER_OBS.AREA"
-        [(selectedValue)]="tmpArea"
-        [options]="areaArr"
-      ></app-select>
+      <app-select label="REGISTRATION.DANGER_OBS.AREA" [(selectedValue)]="tmpArea" [options]="areaArr"></app-select>
     </ion-item>
     <app-text-comment
       [(value)]="comment"
-      labelTitle="REGISTRATION.DANGER_OBS.COMMENT"
+      label="REGISTRATION.DANGER_OBS.COMMENT"
       rows="2"
       placeholder="REGISTRATION.DANGER_OBS.COMMENT_PLACEHOLDER"
     ></app-text-comment>

--- a/src/app/modules/registration/pages/danger-obs/add-or-edit-danger-obs-modal/add-or-edit-danger-obs-modal.page.html
+++ b/src/app/modules/registration/pages/danger-obs/add-or-edit-danger-obs-modal/add-or-edit-danger-obs-modal.page.html
@@ -24,7 +24,7 @@
     </ion-item>
     <app-kdv-select
       (valueChange)="dropdownChanged($event)"
-      title="REGISTRATION.DANGER_OBS.DROPDOWN_TITLE"
+      labelTitle="REGISTRATION.DANGER_OBS.DROPDOWN_TITLE"
       *ngIf="showDangerSignSelect"
       kdvKey="{{ geoHazardName }}_DangerSignKDV"
       [(value)]="dangerSignTid"
@@ -34,11 +34,15 @@
       <ion-label color="medium" position="stacked" class="ion-text-uppercase"
         >{{'REGISTRATION.DANGER_OBS.AREA' | translate}}
       </ion-label>
-      <app-select title="REGISTRATION.DANGER_OBS.AREA" [(selectedValue)]="tmpArea" [options]="areaArr"></app-select>
+      <app-select
+        labelTitle="REGISTRATION.DANGER_OBS.AREA"
+        [(selectedValue)]="tmpArea"
+        [options]="areaArr"
+      ></app-select>
     </ion-item>
     <app-text-comment
       [(value)]="comment"
-      title="REGISTRATION.DANGER_OBS.COMMENT"
+      labelTitle="REGISTRATION.DANGER_OBS.COMMENT"
       rows="2"
       placeholder="REGISTRATION.DANGER_OBS.COMMENT_PLACEHOLDER"
     ></app-text-comment>

--- a/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.html
+++ b/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.html
@@ -92,30 +92,30 @@
         </ion-label>
       </ion-item>
       <app-kdv-select
-        title="REGISTRATION.DIRT.LAND_SLIDE_OBS.LANDSLIDE_TYPE"
+        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.LANDSLIDE_TYPE"
         kdvKey="Dirt_LandSlideKDV"
         [(value)]="draft.registration.LandSlideObs.LandSlideTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.DIRT.LAND_SLIDE_OBS.DESTRUCTIVE_SIZE"
+        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.DESTRUCTIVE_SIZE"
         kdvKey="Dirt_LandSlideSizeKDV"
         [(value)]="draft.registration.LandSlideObs.LandSlideSizeTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.DIRT.LAND_SLIDE_OBS.AVAL_TRIGGER"
+        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.AVAL_TRIGGER"
         kdvKey="Dirt_LandSlideTriggerKDV"
         [(value)]="draft.registration.LandSlideObs.LandSlideTriggerTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.DIRT.LAND_SLIDE_OBS.DIRT_ACTIVITY_INFLUENCED"
+        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.DIRT_ACTIVITY_INFLUENCED"
         kdvKey="Dirt_ActivityInfluencedKDV"
         [(value)]="draft.registration.LandSlideObs.ActivityInfluencedTID"
       >
       </app-kdv-select>
-      <!--  <app-kdv-select title='REGISTRATION.DIRT.LAND_SLIDE_OBS.DAMAGE_EXTENT' kdvKey='DamageExtentKDV'
+      <!--  <app-kdv-select labelTitle='REGISTRATION.DIRT.LAND_SLIDE_OBS.DAMAGE_EXTENT' kdvKey='DamageExtentKDV'
                             [(value)]='draft.registration.LandSlideObs.DamageExtentTID'></app-kdv-select>-->
       <app-kdv-select
-        title="REGISTRATION.DIRT.LAND_SLIDE_OBS.DIRT_FORECAST_ACCURATE"
+        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.DIRT_FORECAST_ACCURATE"
         kdvKey="ForecastAccurateKDV"
         [(value)]="draft.registration.LandSlideObs.ForecastAccurateTID"
       ></app-kdv-select>

--- a/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.html
+++ b/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.html
@@ -92,30 +92,30 @@
         </ion-label>
       </ion-item>
       <app-kdv-select
-        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.LANDSLIDE_TYPE"
+        label="REGISTRATION.DIRT.LAND_SLIDE_OBS.LANDSLIDE_TYPE"
         kdvKey="Dirt_LandSlideKDV"
         [(value)]="draft.registration.LandSlideObs.LandSlideTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.DESTRUCTIVE_SIZE"
+        label="REGISTRATION.DIRT.LAND_SLIDE_OBS.DESTRUCTIVE_SIZE"
         kdvKey="Dirt_LandSlideSizeKDV"
         [(value)]="draft.registration.LandSlideObs.LandSlideSizeTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.AVAL_TRIGGER"
+        label="REGISTRATION.DIRT.LAND_SLIDE_OBS.AVAL_TRIGGER"
         kdvKey="Dirt_LandSlideTriggerKDV"
         [(value)]="draft.registration.LandSlideObs.LandSlideTriggerTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.DIRT_ACTIVITY_INFLUENCED"
+        label="REGISTRATION.DIRT.LAND_SLIDE_OBS.DIRT_ACTIVITY_INFLUENCED"
         kdvKey="Dirt_ActivityInfluencedKDV"
         [(value)]="draft.registration.LandSlideObs.ActivityInfluencedTID"
       >
       </app-kdv-select>
-      <!--  <app-kdv-select labelTitle='REGISTRATION.DIRT.LAND_SLIDE_OBS.DAMAGE_EXTENT' kdvKey='DamageExtentKDV'
+      <!--  <app-kdv-select label='REGISTRATION.DIRT.LAND_SLIDE_OBS.DAMAGE_EXTENT' kdvKey='DamageExtentKDV'
                             [(value)]='draft.registration.LandSlideObs.DamageExtentTID'></app-kdv-select>-->
       <app-kdv-select
-        labelTitle="REGISTRATION.DIRT.LAND_SLIDE_OBS.DIRT_FORECAST_ACCURATE"
+        label="REGISTRATION.DIRT.LAND_SLIDE_OBS.DIRT_FORECAST_ACCURATE"
         kdvKey="ForecastAccurateKDV"
         [(value)]="draft.registration.LandSlideObs.ForecastAccurateTID"
       ></app-kdv-select>

--- a/src/app/modules/registration/pages/general-comment/general-comment.page.html
+++ b/src/app/modules/registration/pages/general-comment/general-comment.page.html
@@ -19,7 +19,7 @@
       </ion-list-header>
       <app-text-comment
         [(value)]="draft.registration.GeneralObservation.ObsComment"
-        labelTitle="{{'REGISTRATION.GENERAL_COMMENT.COMMENT_TITLE' | translate }}"
+        label="{{'REGISTRATION.GENERAL_COMMENT.COMMENT_TITLE' | translate }}"
         placeholder="{{'REGISTRATION.GENERAL_COMMENT.COMMENT_PLACEHOLDER' | translate }}"
       ></app-text-comment>
       <ion-list-header class="ion-text-uppercase">

--- a/src/app/modules/registration/pages/general-comment/general-comment.page.html
+++ b/src/app/modules/registration/pages/general-comment/general-comment.page.html
@@ -19,7 +19,7 @@
       </ion-list-header>
       <app-text-comment
         [(value)]="draft.registration.GeneralObservation.ObsComment"
-        title="{{'REGISTRATION.GENERAL_COMMENT.COMMENT_TITLE' | translate }}"
+        labelTitle="{{'REGISTRATION.GENERAL_COMMENT.COMMENT_TITLE' | translate }}"
         placeholder="{{'REGISTRATION.GENERAL_COMMENT.COMMENT_PLACEHOLDER' | translate }}"
       ></app-text-comment>
       <ion-list-header class="ion-text-uppercase">

--- a/src/app/modules/registration/pages/ice/ice-cover/ice-cover.page.html
+++ b/src/app/modules/registration/pages/ice/ice-cover/ice-cover.page.html
@@ -15,22 +15,22 @@
   >
     <ion-list lines="full">
       <app-kdv-select
-        title="REGISTRATION.ICE.ICE_COVER.ICE_COVER"
+        labelTitle="REGISTRATION.ICE.ICE_COVER.ICE_COVER"
         kdvKey="Ice_IceCoverKDV"
         [(value)]="draft.registration.IceCoverObs.IceCoverTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.ICE.ICE_COVER.ICE_COVER_BEFORE"
+        labelTitle="REGISTRATION.ICE.ICE_COVER.ICE_COVER_BEFORE"
         kdvKey="Ice_IceCoverBeforeKDV"
         [(value)]="draft.registration.IceCoverObs.IceCoverBeforeTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.ICE.ICE_COVER.ICE_CAPACITY"
+        labelTitle="REGISTRATION.ICE.ICE_COVER.ICE_CAPACITY"
         kdvKey="Ice_IceCapacityKDV"
         [(value)]="draft.registration.IceCoverObs.IceCapacityTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.ICE.ICE_COVER.ICE_SKATEABILITY"
+        labelTitle="REGISTRATION.ICE.ICE_COVER.ICE_SKATEABILITY"
         kdvKey="Ice_IceSkateabilityKDV"
         [(value)]="draft.registration.IceCoverObs.IceSkateabilityTID"
       ></app-kdv-select>

--- a/src/app/modules/registration/pages/ice/ice-cover/ice-cover.page.html
+++ b/src/app/modules/registration/pages/ice/ice-cover/ice-cover.page.html
@@ -15,22 +15,22 @@
   >
     <ion-list lines="full">
       <app-kdv-select
-        labelTitle="REGISTRATION.ICE.ICE_COVER.ICE_COVER"
+        label="REGISTRATION.ICE.ICE_COVER.ICE_COVER"
         kdvKey="Ice_IceCoverKDV"
         [(value)]="draft.registration.IceCoverObs.IceCoverTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.ICE.ICE_COVER.ICE_COVER_BEFORE"
+        label="REGISTRATION.ICE.ICE_COVER.ICE_COVER_BEFORE"
         kdvKey="Ice_IceCoverBeforeKDV"
         [(value)]="draft.registration.IceCoverObs.IceCoverBeforeTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.ICE.ICE_COVER.ICE_CAPACITY"
+        label="REGISTRATION.ICE.ICE_COVER.ICE_CAPACITY"
         kdvKey="Ice_IceCapacityKDV"
         [(value)]="draft.registration.IceCoverObs.IceCapacityTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.ICE.ICE_COVER.ICE_SKATEABILITY"
+        label="REGISTRATION.ICE.ICE_COVER.ICE_SKATEABILITY"
         kdvKey="Ice_IceSkateabilityKDV"
         [(value)]="draft.registration.IceCoverObs.IceSkateabilityTID"
       ></app-kdv-select>

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.html
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.html
@@ -13,13 +13,13 @@
       <ion-label> {{'REGISTRATION.ICE.ICE_THICKNESS.ADD_ICE_LAYER_TITLE' | translate}} </ion-label>
     </ion-list-header>
     <app-kdv-select
-      labelTitle="{{'REGISTRATION.ICE.ICE_THICKNESS.ICE_TYPE' | translate}}"
+      label="{{'REGISTRATION.ICE.ICE_THICKNESS.ICE_TYPE' | translate}}"
       kdvKey="Ice_IceLayerKDV"
       [(value)]="layerCopy.IceLayerTID"
     ></app-kdv-select>
     <app-numeric-input
       [(value)]="layerCopy.IceLayerThickness"
-      labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_LAYER_THICKNESS"
+      label="REGISTRATION.ICE.ICE_THICKNESS.ICE_LAYER_THICKNESS"
       [min]="0"
       [max]="999"
       [decimalPlaces]="2"

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.html
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.html
@@ -13,13 +13,13 @@
       <ion-label> {{'REGISTRATION.ICE.ICE_THICKNESS.ADD_ICE_LAYER_TITLE' | translate}} </ion-label>
     </ion-list-header>
     <app-kdv-select
-      title="{{'REGISTRATION.ICE.ICE_THICKNESS.ICE_TYPE' | translate}}"
+      labelTitle="{{'REGISTRATION.ICE.ICE_THICKNESS.ICE_TYPE' | translate}}"
       kdvKey="Ice_IceLayerKDV"
       [(value)]="layerCopy.IceLayerTID"
     ></app-kdv-select>
     <app-numeric-input
       [(value)]="layerCopy.IceLayerThickness"
-      title="REGISTRATION.ICE.ICE_THICKNESS.ICE_LAYER_THICKNESS"
+      labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_LAYER_THICKNESS"
       [min]="0"
       [max]="999"
       [decimalPlaces]="2"

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.html
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.html
@@ -16,7 +16,7 @@
     <ion-list lines="full" reorder="true">
       <app-numeric-input
         [(value)]="iceThickness.SnowDepth"
-        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.DRY_SNOW_BEFORE_DRILL"
+        label="REGISTRATION.ICE.ICE_THICKNESS.DRY_SNOW_BEFORE_DRILL"
         [min]="0"
         [max]="999"
         [decimalPlaces]="2"
@@ -26,7 +26,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="iceThickness.SlushSnow"
-        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.SLUSH_SNOW_BEFORE_DRILL"
+        label="REGISTRATION.ICE.ICE_THICKNESS.SLUSH_SNOW_BEFORE_DRILL"
         [min]="0"
         [max]="999"
         [decimalPlaces]="2"
@@ -56,7 +56,7 @@
       <app-numeric-input
         [readonly]="true"
         [(value)]="iceThickness.IceThicknessSum"
-        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_THICKNESS_SUM"
+        label="REGISTRATION.ICE.ICE_THICKNESS.ICE_THICKNESS_SUM"
         [min]="0"
         [max]="999"
         [decimalPlaces]="2"
@@ -69,7 +69,7 @@
         *ngIf="isWaterBefore"
         [color]="!waterHeightBefore ? 'danger' : 'medium'"
         [(value)]="waterHeightBefore"
-        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_INPUT"
+        label="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_INPUT"
         [min]="0.01"
         [max]="999"
         [decimalPlaces]="2"
@@ -84,7 +84,7 @@
         *ngIf="isWaterAfter === true"
         [color]="!waterHeightAfter ? 'danger' : 'medium'"
         [(value)]="waterHeightAfter"
-        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_INPUT"
+        label="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_INPUT"
         [min]="0.01"
         [max]="999"
         [decimalPlaces]="2"
@@ -97,7 +97,7 @@
         *ngIf="isWaterAfter === false"
         [color]="waterDepthAfter === undefined ? 'danger' : 'medium'"
         [(value)]="waterDepthAfter"
-        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_AFTER_NO"
+        label="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_AFTER_NO"
         [min]="0"
         [max]="999"
         [decimalPlaces]="2"

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.html
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.html
@@ -16,7 +16,7 @@
     <ion-list lines="full" reorder="true">
       <app-numeric-input
         [(value)]="iceThickness.SnowDepth"
-        title="REGISTRATION.ICE.ICE_THICKNESS.DRY_SNOW_BEFORE_DRILL"
+        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.DRY_SNOW_BEFORE_DRILL"
         [min]="0"
         [max]="999"
         [decimalPlaces]="2"
@@ -26,7 +26,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="iceThickness.SlushSnow"
-        title="REGISTRATION.ICE.ICE_THICKNESS.SLUSH_SNOW_BEFORE_DRILL"
+        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.SLUSH_SNOW_BEFORE_DRILL"
         [min]="0"
         [max]="999"
         [decimalPlaces]="2"
@@ -56,7 +56,7 @@
       <app-numeric-input
         [readonly]="true"
         [(value)]="iceThickness.IceThicknessSum"
-        title="REGISTRATION.ICE.ICE_THICKNESS.ICE_THICKNESS_SUM"
+        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_THICKNESS_SUM"
         [min]="0"
         [max]="999"
         [decimalPlaces]="2"
@@ -69,7 +69,7 @@
         *ngIf="isWaterBefore"
         [color]="!waterHeightBefore ? 'danger' : 'medium'"
         [(value)]="waterHeightBefore"
-        title="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_INPUT"
+        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_INPUT"
         [min]="0.01"
         [max]="999"
         [decimalPlaces]="2"
@@ -84,7 +84,7 @@
         *ngIf="isWaterAfter === true"
         [color]="!waterHeightAfter ? 'danger' : 'medium'"
         [(value)]="waterHeightAfter"
-        title="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_INPUT"
+        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_INPUT"
         [min]="0.01"
         [max]="999"
         [decimalPlaces]="2"
@@ -97,7 +97,7 @@
         *ngIf="isWaterAfter === false"
         [color]="waterDepthAfter === undefined ? 'danger' : 'medium'"
         [(value)]="waterDepthAfter"
-        title="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_AFTER_NO"
+        labelTitle="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_AFTER_NO"
         [min]="0"
         [max]="999"
         [decimalPlaces]="2"

--- a/src/app/modules/registration/pages/incident/incident.page.html
+++ b/src/app/modules/registration/pages/incident/incident.page.html
@@ -15,19 +15,19 @@
   >
     <ion-list>
       <app-kdv-select
-        title="REGISTRATION.INCIDENT.ACTIVITY"
+        labelTitle="REGISTRATION.INCIDENT.ACTIVITY"
         kdvKey="Ice_ActivityInfluencedKDV"
         [(value)]="incident.ActivityInfluencedTID"
       ></app-kdv-select>
       <app-numeric-input
-        title="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM"
+        labelTitle="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM"
         [min]="0"
         [(value)]="incident.InvolvedNum"
         (valueChange)="groupValidate()"
       >
       </app-numeric-input>
       <app-numeric-input
-        title="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM"
+        labelTitle="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM"
         [color]="!isCasualtiesValid ? 'danger' : 'medium'"
         [min]="0"
         [isValid]="isCasualtiesValid"
@@ -36,7 +36,7 @@
         (valueChange)="groupValidate()"
       ></app-numeric-input>
       <app-numeric-input
-        title="REGISTRATION.INCIDENT.DEAD_NUM"
+        labelTitle="REGISTRATION.INCIDENT.DEAD_NUM"
         [color]="!isDeadValid ? 'danger' : 'medium'"
         [min]="0"
         [isValid]="isDeadValid"
@@ -45,16 +45,16 @@
         (valueChange)="groupValidate()"
       ></app-numeric-input>
       <app-kdv-select
-        title="REGISTRATION.INCIDENT.RESCUE_TID"
+        labelTitle="REGISTRATION.INCIDENT.RESCUE_TID"
         kdvKey="RescueKDV"
         [(value)]="incident.RescueTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.ICE.INCIDENT.SAFETY_GEAR_TID"
+        labelTitle="REGISTRATION.ICE.INCIDENT.SAFETY_GEAR_TID"
         kdvKey="Ice_SafetyGearKDV"
         [(value)]="incident.SafetyGearTID"
       ></app-kdv-select>
-      <app-text-comment title="REGISTRATION.INCIDENT.COMMENT" [(value)]="incident.Comment"></app-text-comment>
+      <app-text-comment labelTitle="REGISTRATION.INCIDENT.COMMENT" [(value)]="incident.Comment"></app-text-comment>
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ 'REGISTRATION.ADD_WEB_URL.TITLE' | translate}} </ion-label>
       </ion-list-header>

--- a/src/app/modules/registration/pages/incident/incident.page.html
+++ b/src/app/modules/registration/pages/incident/incident.page.html
@@ -15,19 +15,19 @@
   >
     <ion-list>
       <app-kdv-select
-        labelTitle="REGISTRATION.INCIDENT.ACTIVITY"
+        label="REGISTRATION.INCIDENT.ACTIVITY"
         kdvKey="Ice_ActivityInfluencedKDV"
         [(value)]="incident.ActivityInfluencedTID"
       ></app-kdv-select>
       <app-numeric-input
-        labelTitle="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM"
+        label="REGISTRATION.ICE.INCIDENT.INVOLVED_NUM"
         [min]="0"
         [(value)]="incident.InvolvedNum"
         (valueChange)="groupValidate()"
       >
       </app-numeric-input>
       <app-numeric-input
-        labelTitle="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM"
+        label="REGISTRATION.ICE.INCIDENT.CASUALTIES_NUM"
         [color]="!isCasualtiesValid ? 'danger' : 'medium'"
         [min]="0"
         [isValid]="isCasualtiesValid"
@@ -36,7 +36,7 @@
         (valueChange)="groupValidate()"
       ></app-numeric-input>
       <app-numeric-input
-        labelTitle="REGISTRATION.INCIDENT.DEAD_NUM"
+        label="REGISTRATION.INCIDENT.DEAD_NUM"
         [color]="!isDeadValid ? 'danger' : 'medium'"
         [min]="0"
         [isValid]="isDeadValid"
@@ -45,16 +45,16 @@
         (valueChange)="groupValidate()"
       ></app-numeric-input>
       <app-kdv-select
-        labelTitle="REGISTRATION.INCIDENT.RESCUE_TID"
+        label="REGISTRATION.INCIDENT.RESCUE_TID"
         kdvKey="RescueKDV"
         [(value)]="incident.RescueTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.ICE.INCIDENT.SAFETY_GEAR_TID"
+        label="REGISTRATION.ICE.INCIDENT.SAFETY_GEAR_TID"
         kdvKey="Ice_SafetyGearKDV"
         [(value)]="incident.SafetyGearTID"
       ></app-kdv-select>
-      <app-text-comment labelTitle="REGISTRATION.INCIDENT.COMMENT" [(value)]="incident.Comment"></app-text-comment>
+      <app-text-comment label="REGISTRATION.INCIDENT.COMMENT" [(value)]="incident.Comment"></app-text-comment>
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ 'REGISTRATION.ADD_WEB_URL.TITLE' | translate}} </ion-label>
       </ion-list-header>

--- a/src/app/modules/registration/pages/snow/avalanche-activity/avalanche-activity-modal/avalanche-activity-modal.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-activity/avalanche-activity-modal/avalanche-activity-modal.page.html
@@ -43,27 +43,27 @@
     </ion-item>
     <ng-container *ngIf="!noAvalancheActivity">
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_ACTIVITY.HOW_MANY_AVALANCHES"
+        label="REGISTRATION.SNOW.AVALANCHE_ACTIVITY.HOW_MANY_AVALANCHES"
         kdvKey="Snow_EstimatedNumKDV"
         [(value)]="avalancheActivityCopy.EstimatedNumTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE"
+        label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE"
         kdvKey="Snow_AvalancheExtKDV"
         [(value)]="avalancheActivityCopy.AvalancheExtTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TRIGGER"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TRIGGER"
         kdvKey="Snow_AvalTriggerSimpleKDV"
         [(value)]="avalancheActivityCopy.AvalTriggerSimpleTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE"
         kdvKey="Snow_DestructiveSizeKDV"
         [(value)]="avalancheActivityCopy.DestructiveSizeTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION"
+        label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION"
         kdvKey="Snow_AvalPropagationKDV"
         [(value)]="avalancheActivityCopy.AvalPropagationTID"
       ></app-kdv-select>
@@ -74,7 +74,7 @@
       ></app-exposed-height>
       <app-valid-exposition [(validExposition)]="avalancheActivityCopy.ValidExposition"></app-valid-exposition>
     </ng-container>
-    <app-text-comment labelTitle="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheActivityCopy.Comment">
+    <app-text-comment label="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheActivityCopy.Comment">
     </app-text-comment>
   </ion-list>
   <app-modal-save-or-delete-buttons (saveClicked)="ok()" (deleteClicked)="delete()" [showDelete]="!isNew">

--- a/src/app/modules/registration/pages/snow/avalanche-activity/avalanche-activity-modal/avalanche-activity-modal.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-activity/avalanche-activity-modal/avalanche-activity-modal.page.html
@@ -43,27 +43,27 @@
     </ion-item>
     <ng-container *ngIf="!noAvalancheActivity">
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_ACTIVITY.HOW_MANY_AVALANCHES"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_ACTIVITY.HOW_MANY_AVALANCHES"
         kdvKey="Snow_EstimatedNumKDV"
         [(value)]="avalancheActivityCopy.EstimatedNumTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE"
         kdvKey="Snow_AvalancheExtKDV"
         [(value)]="avalancheActivityCopy.AvalancheExtTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TRIGGER"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TRIGGER"
         kdvKey="Snow_AvalTriggerSimpleKDV"
         [(value)]="avalancheActivityCopy.AvalTriggerSimpleTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE"
         kdvKey="Snow_DestructiveSizeKDV"
         [(value)]="avalancheActivityCopy.DestructiveSizeTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION"
         kdvKey="Snow_AvalPropagationKDV"
         [(value)]="avalancheActivityCopy.AvalPropagationTID"
       ></app-kdv-select>
@@ -74,7 +74,7 @@
       ></app-exposed-height>
       <app-valid-exposition [(validExposition)]="avalancheActivityCopy.ValidExposition"></app-valid-exposition>
     </ng-container>
-    <app-text-comment title="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheActivityCopy.Comment">
+    <app-text-comment labelTitle="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheActivityCopy.Comment">
     </app-text-comment>
   </ion-list>
   <app-modal-save-or-delete-buttons (saveClicked)="ok()" (deleteClicked)="delete()" [showDelete]="!isNew">

--- a/src/app/modules/registration/pages/snow/avalanche-evaluation/avalanche-evaluation.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-evaluation/avalanche-evaluation.page.html
@@ -18,28 +18,28 @@
         <ion-label> {{ 'REGISTRATION.SNOW.AVALANCHE_EVALUATION.TITLE' | translate }} </ion-label>
       </ion-list-header>
       <app-text-comment
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.EVALUATION"
+        label="REGISTRATION.SNOW.AVALANCHE_EVALUATION.EVALUATION"
         rows="3"
         [(value)]="draft.registration.AvalancheEvaluation3.AvalancheEvaluation"
       ></app-text-comment>
       <app-text-comment
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.AVALANCHE_DEVELOPMENT"
+        label="REGISTRATION.SNOW.AVALANCHE_EVALUATION.AVALANCHE_DEVELOPMENT"
         rows="3"
         [(value)]="draft.registration.AvalancheEvaluation3.AvalancheDevelopment"
       ></app-text-comment>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.AVALANCHE_DANGER"
+        label="REGISTRATION.SNOW.AVALANCHE_EVALUATION.AVALANCHE_DANGER"
         kdvKey="Snow_AvalancheDangerKDV"
         [showZeroValues]="true"
         [(value)]="draft.registration.AvalancheEvaluation3.AvalancheDangerTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.FORECAST_CORRECT"
+        label="REGISTRATION.SNOW.AVALANCHE_EVALUATION.FORECAST_CORRECT"
         kdvKey="Snow_ForecastCorrectKDV"
         [(value)]="draft.registration.AvalancheEvaluation3.ForecastCorrectTID"
       ></app-kdv-select>
       <app-text-comment
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.COMMENT"
+        label="REGISTRATION.SNOW.AVALANCHE_EVALUATION.COMMENT"
         [(value)]="draft.registration.AvalancheEvaluation3.ForecastComment"
       ></app-text-comment>
       <ion-list-header class="ion-text-uppercase">

--- a/src/app/modules/registration/pages/snow/avalanche-evaluation/avalanche-evaluation.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-evaluation/avalanche-evaluation.page.html
@@ -18,28 +18,28 @@
         <ion-label> {{ 'REGISTRATION.SNOW.AVALANCHE_EVALUATION.TITLE' | translate }} </ion-label>
       </ion-list-header>
       <app-text-comment
-        title="REGISTRATION.SNOW.AVALANCHE_EVALUATION.EVALUATION"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.EVALUATION"
         rows="3"
         [(value)]="draft.registration.AvalancheEvaluation3.AvalancheEvaluation"
       ></app-text-comment>
       <app-text-comment
-        title="REGISTRATION.SNOW.AVALANCHE_EVALUATION.AVALANCHE_DEVELOPMENT"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.AVALANCHE_DEVELOPMENT"
         rows="3"
         [(value)]="draft.registration.AvalancheEvaluation3.AvalancheDevelopment"
       ></app-text-comment>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_EVALUATION.AVALANCHE_DANGER"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.AVALANCHE_DANGER"
         kdvKey="Snow_AvalancheDangerKDV"
         [showZeroValues]="true"
         [(value)]="draft.registration.AvalancheEvaluation3.AvalancheDangerTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_EVALUATION.FORECAST_CORRECT"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.FORECAST_CORRECT"
         kdvKey="Snow_ForecastCorrectKDV"
         [(value)]="draft.registration.AvalancheEvaluation3.ForecastCorrectTID"
       ></app-kdv-select>
       <app-text-comment
-        title="REGISTRATION.SNOW.AVALANCHE_EVALUATION.COMMENT"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_EVALUATION.COMMENT"
         [(value)]="draft.registration.AvalancheEvaluation3.ForecastComment"
       ></app-text-comment>
       <ion-list-header class="ion-text-uppercase">

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -76,23 +76,23 @@
           >{{ 'REGISTRATION.SNOW.AVALANCHE_OBS.VALID_EXPOSITION' | translate}}</ion-label
         >
         <app-select
-          labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.VALID_EXPOSITION"
+          label="REGISTRATION.SNOW.AVALANCHE_OBS.VALID_EXPOSITION"
           [(selectedValue)]="avalancheObs.ValidExposition"
           [options]="expoArray"
         ></app-select>
       </ion-item>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE"
         kdvKey="Snow_DestructiveSizeKDV"
         [(value)]="avalancheObs.DestructiveSizeTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TYPE"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TYPE"
         kdvKey="Snow_AvalancheKDV"
         [(value)]="avalancheObs.AvalancheTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TRIGGER"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TRIGGER"
         kdvKey="Snow_AvalancheTriggerKDV"
         [(value)]="avalancheObs.AvalancheTriggerTID"
       ></app-kdv-select>
@@ -103,18 +103,18 @@
         <ion-toggle [(ngModel)]="avalancheObs.RemotelyTriggered"></ion-toggle>
       </ion-item>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.TERRAIN_START_ZONE"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.TERRAIN_START_ZONE"
         kdvKey="Snow_TerrainStartZoneKDV"
         [(value)]="avalancheObs.TerrainStartZoneTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.AVAL_CAUSE"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.AVAL_CAUSE"
         kdvKey="Snow_AvalCauseKDV"
         [(value)]="avalancheObs.AvalCauseTID"
       ></app-kdv-select>
       <app-numeric-input
         [(value)]="avalancheObs.FractureHeight"
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.FRACTURE_HEIGTH"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.FRACTURE_HEIGTH"
         [min]="0"
         [max]="9999"
         suffix="cm"
@@ -123,7 +123,7 @@
       </app-numeric-input>
       <app-numeric-input
         [(value)]="avalancheObs.FractureWidth"
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.FRACTURE_WIDTH"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.FRACTURE_WIDTH"
         [min]="0"
         [max]="99999"
         suffix="m"
@@ -131,13 +131,12 @@
       >
       </app-numeric-input>
       <app-text-comment
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.TRAJECTORY_NAME"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.TRAJECTORY_NAME"
         [max]="100"
         [rows]="2"
         [(value)]="avalancheObs.Trajectory"
       ></app-text-comment>
-      <app-text-comment labelTitle="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheObs.Comment">
-      </app-text-comment>
+      <app-text-comment label="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheObs.Comment"> </app-text-comment>
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ 'REGISTRATION.ADD_IMAGES' | translate}} </ion-label>
       </ion-list-header>
@@ -153,12 +152,12 @@
         <ion-label> {{ 'REGISTRATION.SNOW.AVALANCHE_OBS.INCIDENT_DESCRIPTION' | translate}} </ion-label>
       </ion-list-header>
       <app-kdv-select
-        labelTitle="REGISTRATION.INCIDENT.ACTIVITY"
+        label="REGISTRATION.INCIDENT.ACTIVITY"
         kdvKey="Snow_ActivityInfluencedKDV"
         [(value)]="incident.ActivityInfluencedTID"
       ></app-kdv-select>
       <app-numeric-input
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
         [color]="!isInvolvedValid ? 'danger' : 'medium'"
         [min]="0"
         [(value)]="incident.InvolvedNum"
@@ -166,7 +165,7 @@
       >
       </app-numeric-input>
       <app-numeric-input
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
         [color]="!isCasualtiesValid ? 'danger' : 'medium'"
         [isValid]="isCasualtiesValid"
         errorMessage="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM_ERROR_MESSAGE"
@@ -176,7 +175,7 @@
       >
       </app-numeric-input>
       <app-numeric-input
-        labelTitle="REGISTRATION.INCIDENT.DEAD_NUM"
+        label="REGISTRATION.INCIDENT.DEAD_NUM"
         [color]="!isDeadValid ? 'danger' : 'medium'"
         [isValid]="isDeadValid"
         [errorMessage]="!isErrorMessageHarmAndDead ? 'REGISTRATION.SNOW.AVALANCHE_OBS.DEAD_NUM_ERROR_MESSAGE' : 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE'"
@@ -186,7 +185,7 @@
       >
       </app-numeric-input>
       <app-numeric-input
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
         [errorMessage]="!isErrorMessageHarmAndDead ? 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM_ERROR_MESSAGE' : 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE'"
         [isValid]="isHarmedValid"
         [color]="!isHarmedValid ? 'danger' : 'medium'"
@@ -202,7 +201,7 @@
         <ion-toggle [(ngModel)]="incident.TrafficObstructed"></ion-toggle>
       </ion-item>
       <app-numeric-input
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.EVACUATED_NUM"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.EVACUATED_NUM"
         [(value)]="incident.EvacuatedNum"
         [min]="0"
       ></app-numeric-input>
@@ -213,14 +212,14 @@
         <ion-toggle [(ngModel)]="incident.MaterialDamages"></ion-toggle>
       </ion-item>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.SLOPE_ACTIVITY_TID"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.SLOPE_ACTIVITY_TID"
         kdvKey="Snow_SlopeActivityKDV"
         [(value)]="incident.SlopeActivityTID"
       ></app-kdv-select>
-      <app-kdv-select labelTitle="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV" [(value)]="incident.RescueTID">
+      <app-kdv-select label="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV" [(value)]="incident.RescueTID">
       </app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.SAFETY_GEAR_TID"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.SAFETY_GEAR_TID"
         kdvKey="Snow_SafetyGearKDV"
         [(value)]="incident.SafetyGearTID"
       ></app-kdv-select>
@@ -230,11 +229,11 @@
         [(value)]="incident.LocalTouristTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.LOCAL_KNOWLEDGE_TID"
+        label="REGISTRATION.SNOW.AVALANCHE_OBS.LOCAL_KNOWLEDGE_TID"
         kdvKey="LocalKnowledgeKDV"
         [(value)]="incident.LocalKnowledgeTID"
       ></app-kdv-select>
-      <app-text-comment labelTitle="REGISTRATION.INCIDENT.COMMENT" [(value)]="incident.Comment"> </app-text-comment>
+      <app-text-comment label="REGISTRATION.INCIDENT.COMMENT" [(value)]="incident.Comment"> </app-text-comment>
       <ion-item-divider>
         <ion-label class="ion-text-wrap"> {{'REGISTRATION.INCIDENT.COMMENT_PLACEHOLDER' | translate }} </ion-label>
       </ion-item-divider>

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -76,23 +76,23 @@
           >{{ 'REGISTRATION.SNOW.AVALANCHE_OBS.VALID_EXPOSITION' | translate}}</ion-label
         >
         <app-select
-          title="REGISTRATION.SNOW.AVALANCHE_OBS.VALID_EXPOSITION"
+          labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.VALID_EXPOSITION"
           [(selectedValue)]="avalancheObs.ValidExposition"
           [options]="expoArray"
         ></app-select>
       </ion-item>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE"
         kdvKey="Snow_DestructiveSizeKDV"
         [(value)]="avalancheObs.DestructiveSizeTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TYPE"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TYPE"
         kdvKey="Snow_AvalancheKDV"
         [(value)]="avalancheObs.AvalancheTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TRIGGER"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_TRIGGER"
         kdvKey="Snow_AvalancheTriggerKDV"
         [(value)]="avalancheObs.AvalancheTriggerTID"
       ></app-kdv-select>
@@ -103,18 +103,18 @@
         <ion-toggle [(ngModel)]="avalancheObs.RemotelyTriggered"></ion-toggle>
       </ion-item>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.TERRAIN_START_ZONE"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.TERRAIN_START_ZONE"
         kdvKey="Snow_TerrainStartZoneKDV"
         [(value)]="avalancheObs.TerrainStartZoneTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.AVAL_CAUSE"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.AVAL_CAUSE"
         kdvKey="Snow_AvalCauseKDV"
         [(value)]="avalancheObs.AvalCauseTID"
       ></app-kdv-select>
       <app-numeric-input
         [(value)]="avalancheObs.FractureHeight"
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.FRACTURE_HEIGTH"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.FRACTURE_HEIGTH"
         [min]="0"
         [max]="9999"
         suffix="cm"
@@ -123,7 +123,7 @@
       </app-numeric-input>
       <app-numeric-input
         [(value)]="avalancheObs.FractureWidth"
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.FRACTURE_WIDTH"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.FRACTURE_WIDTH"
         [min]="0"
         [max]="99999"
         suffix="m"
@@ -131,12 +131,13 @@
       >
       </app-numeric-input>
       <app-text-comment
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.TRAJECTORY_NAME"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.TRAJECTORY_NAME"
         [max]="100"
         [rows]="2"
         [(value)]="avalancheObs.Trajectory"
       ></app-text-comment>
-      <app-text-comment title="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheObs.Comment"> </app-text-comment>
+      <app-text-comment labelTitle="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheObs.Comment">
+      </app-text-comment>
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ 'REGISTRATION.ADD_IMAGES' | translate}} </ion-label>
       </ion-list-header>
@@ -152,12 +153,12 @@
         <ion-label> {{ 'REGISTRATION.SNOW.AVALANCHE_OBS.INCIDENT_DESCRIPTION' | translate}} </ion-label>
       </ion-list-header>
       <app-kdv-select
-        title="REGISTRATION.INCIDENT.ACTIVITY"
+        labelTitle="REGISTRATION.INCIDENT.ACTIVITY"
         kdvKey="Snow_ActivityInfluencedKDV"
         [(value)]="incident.ActivityInfluencedTID"
       ></app-kdv-select>
       <app-numeric-input
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.INVOLVED_NUM"
         [color]="!isInvolvedValid ? 'danger' : 'medium'"
         [min]="0"
         [(value)]="incident.InvolvedNum"
@@ -165,7 +166,7 @@
       >
       </app-numeric-input>
       <app-numeric-input
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM"
         [color]="!isCasualtiesValid ? 'danger' : 'medium'"
         [isValid]="isCasualtiesValid"
         errorMessage="REGISTRATION.SNOW.AVALANCHE_OBS.CASUALTIES_NUM_ERROR_MESSAGE"
@@ -175,7 +176,7 @@
       >
       </app-numeric-input>
       <app-numeric-input
-        title="REGISTRATION.INCIDENT.DEAD_NUM"
+        labelTitle="REGISTRATION.INCIDENT.DEAD_NUM"
         [color]="!isDeadValid ? 'danger' : 'medium'"
         [isValid]="isDeadValid"
         [errorMessage]="!isErrorMessageHarmAndDead ? 'REGISTRATION.SNOW.AVALANCHE_OBS.DEAD_NUM_ERROR_MESSAGE' : 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE'"
@@ -185,7 +186,7 @@
       >
       </app-numeric-input>
       <app-numeric-input
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM"
         [errorMessage]="!isErrorMessageHarmAndDead ? 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_NUM_ERROR_MESSAGE' : 'REGISTRATION.SNOW.AVALANCHE_OBS.HARMED_DEAD_HIGHER_THAN_CASUALTIES_NUM_ERROR_MESSAGE'"
         [isValid]="isHarmedValid"
         [color]="!isHarmedValid ? 'danger' : 'medium'"
@@ -201,7 +202,7 @@
         <ion-toggle [(ngModel)]="incident.TrafficObstructed"></ion-toggle>
       </ion-item>
       <app-numeric-input
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.EVACUATED_NUM"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.EVACUATED_NUM"
         [(value)]="incident.EvacuatedNum"
         [min]="0"
       ></app-numeric-input>
@@ -212,14 +213,14 @@
         <ion-toggle [(ngModel)]="incident.MaterialDamages"></ion-toggle>
       </ion-item>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.SLOPE_ACTIVITY_TID"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.SLOPE_ACTIVITY_TID"
         kdvKey="Snow_SlopeActivityKDV"
         [(value)]="incident.SlopeActivityTID"
       ></app-kdv-select>
-      <app-kdv-select title="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV" [(value)]="incident.RescueTID">
+      <app-kdv-select labelTitle="REGISTRATION.INCIDENT.RESCUE_TID" kdvKey="RescueKDV" [(value)]="incident.RescueTID">
       </app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.SAFETY_GEAR_TID"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.SAFETY_GEAR_TID"
         kdvKey="Snow_SafetyGearKDV"
         [(value)]="incident.SafetyGearTID"
       ></app-kdv-select>
@@ -229,11 +230,11 @@
         [(value)]="incident.LocalTouristTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_OBS.LOCAL_KNOWLEDGE_TID"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_OBS.LOCAL_KNOWLEDGE_TID"
         kdvKey="LocalKnowledgeKDV"
         [(value)]="incident.LocalKnowledgeTID"
       ></app-kdv-select>
-      <app-text-comment title="REGISTRATION.INCIDENT.COMMENT" [(value)]="incident.Comment"> </app-text-comment>
+      <app-text-comment labelTitle="REGISTRATION.INCIDENT.COMMENT" [(value)]="incident.Comment"> </app-text-comment>
       <ion-item-divider>
         <ion-label class="ion-text-wrap"> {{'REGISTRATION.INCIDENT.COMMENT_PLACEHOLDER' | translate }} </ion-label>
       </ion-item-divider>

--- a/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.html
@@ -18,12 +18,12 @@
     </ion-item>
     <ng-container *ngIf="!noWeakLayers">
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER"
+        label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER"
         kdvKey="Snow_AvalCauseKDV"
         [(value)]="avalancheEvalProblemCopy.AvalCauseTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER_DEPTH"
+        label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER_DEPTH"
         kdvKey="Snow_AvalCauseDepthKDV"
         [(value)]="avalancheEvalProblemCopy.AvalCauseDepthTID"
       ></app-kdv-select>
@@ -36,13 +36,13 @@
       <ion-label> {{ 'REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_PROBABILITY' | translate}} </ion-label>
     </ion-list-header>
     <app-kdv-select
-      labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE"
+      label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE"
       kdvKey="Snow_AvalancheExtKDV"
       [(value)]="avalancheEvalProblemCopy.AvalancheExtTID"
       [filter]="avalancheExtKdvFilter"
     ></app-kdv-select>
     <app-kdv-select
-      labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TRIGGER_PROBABILITY"
+      label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TRIGGER_PROBABILITY"
       kdvKey="Snow_AvalTriggerSimpleKDV"
       [(value)]="avalancheEvalProblemCopy.AvalTriggerSimpleTID"
     ></app-kdv-select>
@@ -55,7 +55,7 @@
       <ion-label> {{ 'REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION' | translate}} </ion-label>
     </ion-list-header>
     <app-kdv-select
-      labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION"
+      label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION"
       kdvKey="Snow_AvalPropagationKDV"
       [(value)]="avalancheEvalProblemCopy.AvalPropagationTID"
     ></app-kdv-select>
@@ -65,7 +65,7 @@
       [(exposedHight2)]="avalancheEvalProblemCopy.ExposedHeight2"
     ></app-exposed-height>
     <app-valid-exposition [(validExposition)]="avalancheEvalProblemCopy.ValidExposition"></app-valid-exposition>
-    <app-text-comment labelTitle="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheEvalProblemCopy.Comment">
+    <app-text-comment label="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheEvalProblemCopy.Comment">
     </app-text-comment>
   </ion-list>
   <app-modal-save-or-delete-buttons (saveClicked)="ok()" (deleteClicked)="delete()" [showDelete]="!isNew">

--- a/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.html
@@ -18,12 +18,12 @@
     </ion-item>
     <ng-container *ngIf="!noWeakLayers">
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER"
         kdvKey="Snow_AvalCauseKDV"
         [(value)]="avalancheEvalProblemCopy.AvalCauseTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER_DEPTH"
+        labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER_DEPTH"
         kdvKey="Snow_AvalCauseDepthKDV"
         [(value)]="avalancheEvalProblemCopy.AvalCauseDepthTID"
       ></app-kdv-select>
@@ -36,13 +36,13 @@
       <ion-label> {{ 'REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_PROBABILITY' | translate}} </ion-label>
     </ion-list-header>
     <app-kdv-select
-      title="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE"
+      labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE"
       kdvKey="Snow_AvalancheExtKDV"
       [(value)]="avalancheEvalProblemCopy.AvalancheExtTID"
       [filter]="avalancheExtKdvFilter"
     ></app-kdv-select>
     <app-kdv-select
-      title="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TRIGGER_PROBABILITY"
+      labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TRIGGER_PROBABILITY"
       kdvKey="Snow_AvalTriggerSimpleKDV"
       [(value)]="avalancheEvalProblemCopy.AvalTriggerSimpleTID"
     ></app-kdv-select>
@@ -55,7 +55,7 @@
       <ion-label> {{ 'REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION' | translate}} </ion-label>
     </ion-list-header>
     <app-kdv-select
-      title="REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION"
+      labelTitle="REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION"
       kdvKey="Snow_AvalPropagationKDV"
       [(value)]="avalancheEvalProblemCopy.AvalPropagationTID"
     ></app-kdv-select>
@@ -65,7 +65,7 @@
       [(exposedHight2)]="avalancheEvalProblemCopy.ExposedHeight2"
     ></app-exposed-height>
     <app-valid-exposition [(validExposition)]="avalancheEvalProblemCopy.ValidExposition"></app-valid-exposition>
-    <app-text-comment title="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheEvalProblemCopy.Comment">
+    <app-text-comment labelTitle="REGISTRATION.DANGER_OBS.COMMENT" [(value)]="avalancheEvalProblemCopy.Comment">
     </app-text-comment>
   </ion-list>
   <app-modal-save-or-delete-buttons (saveClicked)="ok()" (deleteClicked)="delete()" [showDelete]="!isNew">

--- a/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.html
+++ b/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.html
@@ -35,14 +35,14 @@
       </ion-item>
       <app-numeric-input
         [(value)]="snowProfile.SlopeAngle"
-        title="REGISTRATION.SNOW.SNOW_PROFILE.SLOPE_ANGLE"
+        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SLOPE_ANGLE"
         [min]="0"
         [max]="59"
         suffix="°"
         placeholder="REGISTRATION.SNOW.SNOW_PROFILE.SLOPE_ANGLE_PLACEHOLDER"
         [decimalPlaces]="0"
       ></app-numeric-input>
-      <app-text-comment title="DIALOGS.COMMENT" [(value)]="snowProfile.Comment"> </app-text-comment>
+      <app-text-comment labelTitle="DIALOGS.COMMENT" [(value)]="snowProfile.Comment"> </app-text-comment>
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{'REGISTRATION.SNOW.SNOW_PROFILE.SUBFORMS' | translate}} </ion-label>
       </ion-list-header>

--- a/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.html
+++ b/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.html
@@ -35,14 +35,14 @@
       </ion-item>
       <app-numeric-input
         [(value)]="snowProfile.SlopeAngle"
-        labelTitle="REGISTRATION.SNOW.SNOW_PROFILE.SLOPE_ANGLE"
+        label="REGISTRATION.SNOW.SNOW_PROFILE.SLOPE_ANGLE"
         [min]="0"
         [max]="59"
         suffix="°"
         placeholder="REGISTRATION.SNOW.SNOW_PROFILE.SLOPE_ANGLE_PLACEHOLDER"
         [decimalPlaces]="0"
       ></app-numeric-input>
-      <app-text-comment labelTitle="DIALOGS.COMMENT" [(value)]="snowProfile.Comment"> </app-text-comment>
+      <app-text-comment label="DIALOGS.COMMENT" [(value)]="snowProfile.Comment"> </app-text-comment>
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{'REGISTRATION.SNOW.SNOW_PROFILE.SUBFORMS' | translate}} </ion-label>
       </ion-list-header>

--- a/src/app/modules/registration/pages/snow/snow-surface/snow-surface.page.html
+++ b/src/app/modules/registration/pages/snow/snow-surface/snow-surface.page.html
@@ -19,23 +19,23 @@
         <ion-label> {{ 'REGISTRATION.SNOW.SNOW_SURFACE.TITLE' | translate}} </ion-label>
       </ion-list-header>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DRIFT"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DRIFT"
         kdvKey="Snow_SnowDriftKDV"
         [(value)]="draft.registration.SnowSurfaceObservation.SnowDriftTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_SURFACE"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_SURFACE"
         kdvKey="Snow_SnowSurfaceKDV"
         [(value)]="draft.registration.SnowSurfaceObservation.SnowSurfaceTID"
       ></app-kdv-select>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_SURFACE.SURFACE_WATER_CONTENT_REG"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SURFACE_WATER_CONTENT_REG"
         kdvKey="Snow_SurfaceWaterContentKDV"
         [(value)]="draft.registration.SnowSurfaceObservation.SurfaceWaterContentTID"
       ></app-kdv-select>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.NewSnowDepth24"
-        title="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_DEPTH"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_DEPTH"
         [min]="0"
         [max]="999"
         [decimalPlaces]="0"
@@ -44,7 +44,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.NewSnowLine"
-        title="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_LINE"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_LINE"
         [min]="0"
         [max]="8848"
         [decimalPlaces]="0"
@@ -52,7 +52,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.SnowDepth"
-        title="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DEPTH"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DEPTH"
         [min]="0"
         [max]="9999"
         [decimalPlaces]="0"
@@ -61,7 +61,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.SnowLine"
-        title="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_LINE"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_LINE"
         [min]="0"
         [max]="8848"
         [decimalPlaces]="0"
@@ -69,7 +69,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.HeightLimitLayeredSnow"
-        title="REGISTRATION.SNOW.SNOW_SURFACE.HEIGHT_LIMIT_LAYERED_SNOW"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.HEIGHT_LIMIT_LAYERED_SNOW"
         [min]="0"
         [max]="8848"
         [decimalPlaces]="0"
@@ -77,7 +77,7 @@
         placeholder="REGISTRATION.SNOW.SNOW_SURFACE.HIGHT_LIMIT_LAYERED_SNOW_PLACEHOLDER"
       ></app-numeric-input>
       <app-kdv-select
-        title="REGISTRATION.SNOW.SNOW_SURFACE.SKI_CONDITIONS"
+        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SKI_CONDITIONS"
         kdvKey="Snow_SkiConditionsKDV"
         [(value)]="draft.registration.SnowSurfaceObservation.SkiConditionsTID"
       ></app-kdv-select>
@@ -86,7 +86,7 @@
         <ion-label> {{ 'REGISTRATION.SNOW.SNOW_SURFACE.COMMENT_HEADER' | translate}} </ion-label>
       </ion-list-header>
       <app-text-comment
-        title="REGISTRATION.DANGER_OBS.COMMENT"
+        labelTitle="REGISTRATION.DANGER_OBS.COMMENT"
         [(value)]="draft.registration.SnowSurfaceObservation.Comment"
       ></app-text-comment>
       <ion-item-divider>

--- a/src/app/modules/registration/pages/snow/snow-surface/snow-surface.page.html
+++ b/src/app/modules/registration/pages/snow/snow-surface/snow-surface.page.html
@@ -19,23 +19,23 @@
         <ion-label> {{ 'REGISTRATION.SNOW.SNOW_SURFACE.TITLE' | translate}} </ion-label>
       </ion-list-header>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DRIFT"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DRIFT"
         kdvKey="Snow_SnowDriftKDV"
         [(value)]="draft.registration.SnowSurfaceObservation.SnowDriftTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_SURFACE"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_SURFACE"
         kdvKey="Snow_SnowSurfaceKDV"
         [(value)]="draft.registration.SnowSurfaceObservation.SnowSurfaceTID"
       ></app-kdv-select>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SURFACE_WATER_CONTENT_REG"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.SURFACE_WATER_CONTENT_REG"
         kdvKey="Snow_SurfaceWaterContentKDV"
         [(value)]="draft.registration.SnowSurfaceObservation.SurfaceWaterContentTID"
       ></app-kdv-select>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.NewSnowDepth24"
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_DEPTH"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_DEPTH"
         [min]="0"
         [max]="999"
         [decimalPlaces]="0"
@@ -44,7 +44,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.NewSnowLine"
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_LINE"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.NEW_SNOW_LINE"
         [min]="0"
         [max]="8848"
         [decimalPlaces]="0"
@@ -52,7 +52,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.SnowDepth"
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DEPTH"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_DEPTH"
         [min]="0"
         [max]="9999"
         [decimalPlaces]="0"
@@ -61,7 +61,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.SnowLine"
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_LINE"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.SNOW_LINE"
         [min]="0"
         [max]="8848"
         [decimalPlaces]="0"
@@ -69,7 +69,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.SnowSurfaceObservation.HeightLimitLayeredSnow"
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.HEIGHT_LIMIT_LAYERED_SNOW"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.HEIGHT_LIMIT_LAYERED_SNOW"
         [min]="0"
         [max]="8848"
         [decimalPlaces]="0"
@@ -77,7 +77,7 @@
         placeholder="REGISTRATION.SNOW.SNOW_SURFACE.HIGHT_LIMIT_LAYERED_SNOW_PLACEHOLDER"
       ></app-numeric-input>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.SNOW_SURFACE.SKI_CONDITIONS"
+        label="REGISTRATION.SNOW.SNOW_SURFACE.SKI_CONDITIONS"
         kdvKey="Snow_SkiConditionsKDV"
         [(value)]="draft.registration.SnowSurfaceObservation.SkiConditionsTID"
       ></app-kdv-select>
@@ -86,7 +86,7 @@
         <ion-label> {{ 'REGISTRATION.SNOW.SNOW_SURFACE.COMMENT_HEADER' | translate}} </ion-label>
       </ion-list-header>
       <app-text-comment
-        labelTitle="REGISTRATION.DANGER_OBS.COMMENT"
+        label="REGISTRATION.DANGER_OBS.COMMENT"
         [(value)]="draft.registration.SnowSurfaceObservation.Comment"
       ></app-text-comment>
       <ion-item-divider>

--- a/src/app/modules/registration/pages/snow/weather/weather.page.html
+++ b/src/app/modules/registration/pages/snow/weather/weather.page.html
@@ -18,13 +18,13 @@
         <ion-label> {{ 'REGISTRATION.SNOW.WEATHER.TITLE' | translate}} </ion-label>
       </ion-list-header>
       <app-kdv-select
-        labelTitle="REGISTRATION.SNOW.WEATHER.PRECIPITATION"
+        label="REGISTRATION.SNOW.WEATHER.PRECIPITATION"
         kdvKey="Snow_PrecipitationKDV"
         [(value)]="draft.registration.WeatherObservation.PrecipitationTID"
       ></app-kdv-select>
       <app-numeric-input
         [(value)]="draft.registration.WeatherObservation.AirTemperature"
-        labelTitle="REGISTRATION.SNOW.WEATHER.AIR_TEMPERATURE"
+        label="REGISTRATION.SNOW.WEATHER.AIR_TEMPERATURE"
         [min]="-150"
         [max]="60"
         suffix="°C"
@@ -33,7 +33,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.WeatherObservation.WindSpeed"
-        labelTitle="REGISTRATION.SNOW.WEATHER.WIND_SPEED"
+        label="REGISTRATION.SNOW.WEATHER.WIND_SPEED"
         [min]="0"
         [max]="50"
         suffix="m/s"
@@ -42,7 +42,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.WeatherObservation.CloudCover"
-        labelTitle="REGISTRATION.SNOW.WEATHER.CLOUD_COVER"
+        label="REGISTRATION.SNOW.WEATHER.CLOUD_COVER"
         [min]="0"
         [max]="100"
         suffix="%"
@@ -56,14 +56,14 @@
         <app-select
           [(selectedValue)]="draft.registration.WeatherObservation.WindDirection"
           [options]="windDirectionOptions"
-          labelTitle="REGISTRATION.SNOW.WEATHER.WIND_DIRECTION"
+          label="REGISTRATION.SNOW.WEATHER.WIND_DIRECTION"
         ></app-select>
       </ion-item>
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ 'REGISTRATION.SNOW.WEATHER.COMMENT_HEADER' | translate}} </ion-label>
       </ion-list-header>
       <app-text-comment
-        labelTitle="REGISTRATION.DANGER_OBS.COMMENT"
+        label="REGISTRATION.DANGER_OBS.COMMENT"
         [(value)]="draft.registration.WeatherObservation.Comment"
       ></app-text-comment>
       <ion-item-divider>

--- a/src/app/modules/registration/pages/snow/weather/weather.page.html
+++ b/src/app/modules/registration/pages/snow/weather/weather.page.html
@@ -18,13 +18,13 @@
         <ion-label> {{ 'REGISTRATION.SNOW.WEATHER.TITLE' | translate}} </ion-label>
       </ion-list-header>
       <app-kdv-select
-        title="REGISTRATION.SNOW.WEATHER.PRECIPITATION"
+        labelTitle="REGISTRATION.SNOW.WEATHER.PRECIPITATION"
         kdvKey="Snow_PrecipitationKDV"
         [(value)]="draft.registration.WeatherObservation.PrecipitationTID"
       ></app-kdv-select>
       <app-numeric-input
         [(value)]="draft.registration.WeatherObservation.AirTemperature"
-        title="REGISTRATION.SNOW.WEATHER.AIR_TEMPERATURE"
+        labelTitle="REGISTRATION.SNOW.WEATHER.AIR_TEMPERATURE"
         [min]="-150"
         [max]="60"
         suffix="°C"
@@ -33,7 +33,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.WeatherObservation.WindSpeed"
-        title="REGISTRATION.SNOW.WEATHER.WIND_SPEED"
+        labelTitle="REGISTRATION.SNOW.WEATHER.WIND_SPEED"
         [min]="0"
         [max]="50"
         suffix="m/s"
@@ -42,7 +42,7 @@
       ></app-numeric-input>
       <app-numeric-input
         [(value)]="draft.registration.WeatherObservation.CloudCover"
-        title="REGISTRATION.SNOW.WEATHER.CLOUD_COVER"
+        labelTitle="REGISTRATION.SNOW.WEATHER.CLOUD_COVER"
         [min]="0"
         [max]="100"
         suffix="%"
@@ -56,14 +56,14 @@
         <app-select
           [(selectedValue)]="draft.registration.WeatherObservation.WindDirection"
           [options]="windDirectionOptions"
-          title="REGISTRATION.SNOW.WEATHER.WIND_DIRECTION"
+          labelTitle="REGISTRATION.SNOW.WEATHER.WIND_DIRECTION"
         ></app-select>
       </ion-item>
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ 'REGISTRATION.SNOW.WEATHER.COMMENT_HEADER' | translate}} </ion-label>
       </ion-list-header>
       <app-text-comment
-        title="REGISTRATION.DANGER_OBS.COMMENT"
+        labelTitle="REGISTRATION.DANGER_OBS.COMMENT"
         [(value)]="draft.registration.WeatherObservation.Comment"
       ></app-text-comment>
       <ion-item-divider>

--- a/src/app/modules/shared/components/input/select/select.component.ts
+++ b/src/app/modules/shared/components/input/select/select.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, EventEmitter, Output, OnInit } from '@angular/core';
+import { Component, Input, EventEmitter, Output, OnInit, HostBinding } from '@angular/core';
 import { ActionSheetController } from '@ionic/angular';
 import { ActionSheetButton } from '@ionic/core';
 import { SelectOption } from './select-option.model';
@@ -16,7 +16,7 @@ const TRANSLATION_KEY_RESET = 'DIALOGS.RESET';
   styleUrls: ['./select.component.scss'],
 })
 export class SelectComponent implements OnInit {
-  @Input() title: string;
+  @Input() labelTitle: string;
   @Input() subTitle: string;
   @Input() selectedValue: number | string;
   @Output() selectedValueChange = new EventEmitter();
@@ -87,8 +87,8 @@ export class SelectComponent implements OnInit {
 
   async getTitleTranslations() {
     let titleTextTranslated: string;
-    if (this.title) {
-      titleTextTranslated = await firstValueFrom(this.translateService.get(this.title));
+    if (this.labelTitle) {
+      titleTextTranslated = await firstValueFrom(this.translateService.get(this.labelTitle));
     }
     let subTitleTextTranslated: string;
     if (this.subTitle) {

--- a/src/app/modules/shared/components/input/select/select.component.ts
+++ b/src/app/modules/shared/components/input/select/select.component.ts
@@ -16,7 +16,7 @@ const TRANSLATION_KEY_RESET = 'DIALOGS.RESET';
   styleUrls: ['./select.component.scss'],
 })
 export class SelectComponent implements OnInit {
-  @Input() labelTitle: string;
+  @Input() label: string;
   @Input() subTitle: string;
   @Input() selectedValue: number | string;
   @Output() selectedValueChange = new EventEmitter();
@@ -87,8 +87,8 @@ export class SelectComponent implements OnInit {
 
   async getTitleTranslations() {
     let titleTextTranslated: string;
-    if (this.labelTitle) {
-      titleTextTranslated = await firstValueFrom(this.translateService.get(this.labelTitle));
+    if (this.label) {
+      titleTextTranslated = await firstValueFrom(this.translateService.get(this.label));
     }
     let subTitleTextTranslated: string;
     if (this.subTitle) {

--- a/src/app/pages/legacy-trip/legacy-trip.page.html
+++ b/src/app/pages/legacy-trip/legacy-trip.page.html
@@ -14,7 +14,7 @@
           <app-kdv-select
             [labelColor]="(hasClicked && tripDto.TripTypeID === undefined) ? 'danger' : 'medium'"
             [disabled]="isRunning || isLoading"
-            title="TRIP.TRIP_TYPE"
+            labelTitle="TRIP.TRIP_TYPE"
             kdvKey="TripTypeKDV"
             [(value)]="tripDto.TripTypeID"
           ></app-kdv-select>
@@ -30,10 +30,14 @@
               [disabled]="isRunning || isLoading"
               [(selectedValue)]="tripDto.ObservationExpectedMinutes"
               [options]="minutes"
-              title="TRIP.TRIP_END_DESCRIPTION"
+              labelTitle="TRIP.TRIP_END_DESCRIPTION"
             ></app-select>
           </ion-item>
-          <app-text-comment title="DIALOGS.COMMENT" [disabled]="isRunning || isLoading" [(value)]="tripDto.Comment">
+          <app-text-comment
+            labelTitle="DIALOGS.COMMENT"
+            [disabled]="isRunning || isLoading"
+            [(value)]="tripDto.Comment"
+          >
           </app-text-comment>
           <ion-item-divider>
             <ion-label class="ion-text-wrap"> {{'TRIP.COMMENT_DESCRIPTION' | translate}} </ion-label>

--- a/src/app/pages/legacy-trip/legacy-trip.page.html
+++ b/src/app/pages/legacy-trip/legacy-trip.page.html
@@ -14,7 +14,7 @@
           <app-kdv-select
             [labelColor]="(hasClicked && tripDto.TripTypeID === undefined) ? 'danger' : 'medium'"
             [disabled]="isRunning || isLoading"
-            labelTitle="TRIP.TRIP_TYPE"
+            label="TRIP.TRIP_TYPE"
             kdvKey="TripTypeKDV"
             [(value)]="tripDto.TripTypeID"
           ></app-kdv-select>
@@ -30,14 +30,10 @@
               [disabled]="isRunning || isLoading"
               [(selectedValue)]="tripDto.ObservationExpectedMinutes"
               [options]="minutes"
-              labelTitle="TRIP.TRIP_END_DESCRIPTION"
+              label="TRIP.TRIP_END_DESCRIPTION"
             ></app-select>
           </ion-item>
-          <app-text-comment
-            labelTitle="DIALOGS.COMMENT"
-            [disabled]="isRunning || isLoading"
-            [(value)]="tripDto.Comment"
-          >
+          <app-text-comment label="DIALOGS.COMMENT" [disabled]="isRunning || isLoading" [(value)]="tripDto.Comment">
           </app-text-comment>
           <ion-item-divider>
             <ion-label class="ion-text-wrap"> {{'TRIP.COMMENT_DESCRIPTION' | translate}} </ion-label>


### PR DESCRIPTION
'Title' er et reservert ord som html bruker til å vise et tolltip på label tag. For å slå den av på komponentene (siden de viste akkurat samme verdi som selve label) måtte alle 'title' propertiene bli endret til et annet ord (valgt label istedenfor) som ikke forvirrer html sin funksjonalitet