### PR TITLE
RO-2315 Filter på sørpeskred

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -503,13 +503,7 @@ export class SearchCriteriaService {
   }
 
   async removeObservationType(typeToRemove: RegistrationTypeCriteriaDto) {
-    if (
-      typeToRemove.Id === REGISTRATION_TYPE_AVALANCHE_AND_DANGER_SIGN &&
-      typeToRemove.SubTypes.includes(RegistrationTid.AvalancheObs)
-    ) {
-      //removes filter by slush flow if filter by avalanche obs is removed
-      this.searchCriteriaChanges.next({ PropertyFilters: null });
-    }
+    this.removeSlushFlowFilterIfFilterByAvalancheIsRemoved(typeToRemove);
     const { SelectedRegistrationTypes: currentTypesCriteria } = await firstValueFrom(this.searchCriteria$);
     if (currentTypesCriteria) {
       const copyCriteria = [...currentTypesCriteria] as RegistrationTypeCriteriaDto[];
@@ -585,6 +579,15 @@ export class SearchCriteriaService {
    */
   isSlushFlow(criteria: SearchCriteria): boolean {
     return criteria.PropertyFilters?.length === 1 && criteria.PropertyFilters[0] === CRITERIA_SLUSH_FLOW;
+  }
+
+  private removeSlushFlowFilterIfFilterByAvalancheIsRemoved(typeToRemove: RegistrationTypeCriteriaDto) {
+    if (
+      typeToRemove.Id === REGISTRATION_TYPE_AVALANCHE_AND_DANGER_SIGN &&
+      typeToRemove.SubTypes.includes(RegistrationTid.AvalancheObs)
+    ) {
+      this.searchCriteriaChanges.next({ PropertyFilters: null });
+    }
   }
 
   private daysBackToIsoDateTime(daysBack: number): string {

--- a/src/app/modules/common-regobs-api/models.ts
+++ b/src/app/modules/common-regobs-api/models.ts
@@ -80,6 +80,7 @@ export { SearchCriteriaRequestDto } from './models/search-criteria-request-dto';
 export { RegistrationTypeCriteriaDto } from './models/registration-type-criteria-dto';
 export { WithinRadiusCriteriaDto } from './models/within-radius-criteria-dto';
 export { WithinExtentCriteriaDto } from './models/within-extent-criteria-dto';
+export { PropertyFilter } from './models/property-filter';
 export { PositionDto } from './models/position-dto';
 export { SearchCriteriaExclUserRequestDto } from './models/search-criteria-excl-user-request-dto';
 export { SearchCountResponseDto } from './models/search-count-response-dto';

--- a/src/app/modules/common-regobs-api/models/property-filter.ts
+++ b/src/app/modules/common-regobs-api/models/property-filter.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+
+/**
+ * Filter by property value
+ */
+export interface PropertyFilter {
+
+  /**
+   * Property name. Properties in sub schemas must be prefixed with schema name.
+   * Example: AvalancheObs.AvalancheTID
+   * Multiple instance schemas, like DangerSign, are not supported.
+   * If you use unknown/unsupported properties, you will get an HTTP 400.
+   */
+  Name?: string;
+  Operator?: 0;
+
+  /**
+   * Target property value
+   */
+  Value?: string;
+}

--- a/src/app/modules/common-regobs-api/models/search-criteria-excl-user-request-dto.ts
+++ b/src/app/modules/common-regobs-api/models/search-criteria-excl-user-request-dto.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 import { WithinExtentCriteriaDto } from './within-extent-criteria-dto';
+import { PropertyFilter } from './property-filter';
 import { WithinRadiusCriteriaDto } from './within-radius-criteria-dto';
 import { RegistrationTypeCriteriaDto } from './registration-type-criteria-dto';
 
@@ -54,6 +55,12 @@ export interface SearchCriteriaExclUserRequestDto {
    * Field to order by. You may use these fields: DtObsTime, DtRegTime, DtChangeTime. Default is DtObsTime. A few other fields may also work
    */
   OrderBy?: string;
+
+  /**
+   * Find registrations with given property value.
+   * [Obsolete("Experimental feature that may be changed or removed in later versions")]
+   */
+  PropertyFilters?: Array<PropertyFilter>;
   Radius?: WithinRadiusCriteriaDto;
 
   /**

--- a/src/app/modules/common-regobs-api/models/search-criteria-request-dto.ts
+++ b/src/app/modules/common-regobs-api/models/search-criteria-request-dto.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 import { WithinExtentCriteriaDto } from './within-extent-criteria-dto';
+import { PropertyFilter } from './property-filter';
 import { WithinRadiusCriteriaDto } from './within-radius-criteria-dto';
 import { RegistrationTypeCriteriaDto } from './registration-type-criteria-dto';
 
@@ -81,6 +82,12 @@ export interface SearchCriteriaRequestDto {
    * Field to order by. You may use these fields: DtObsTime, DtRegTime, DtChangeTime. Default is DtObsTime. A few other fields may also work
    */
   OrderBy?: string;
+
+  /**
+   * Find registrations with given property value.
+   * [Obsolete("Experimental feature that may be changed or removed in later versions")]
+   */
+  PropertyFilters?: Array<PropertyFilter>;
   Radius?: WithinRadiusCriteriaDto;
 
   /**

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -32,6 +32,7 @@
             <ion-label class="ion-padding-start">{{ type.name }}</ion-label>
           </ion-item>
         </ng-container>
+        <app-slush-flow-filter> </app-slush-flow-filter>
       </ion-list>
     </ion-item>
   </ng-container>

--- a/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.html
+++ b/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.html
@@ -1,0 +1,4 @@
+<ion-item *ngIf="visible$ | async" class="item-height">
+  <ion-checkbox [checked]="value$ | async" (ionChange)="setValue($event)" color="varsom-dark-blue"> </ion-checkbox>
+  <ion-label class="ion-padding-start">{{ caption$ | async }}</ion-label>
+</ion-item>

--- a/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.scss
+++ b/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.scss
@@ -1,0 +1,4 @@
+ion-item {
+  max-height: 40px;
+  display: flex;
+}

--- a/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.ts
+++ b/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.ts
@@ -10,6 +10,7 @@ import { KdvService } from 'src/app/modules/common-registration/registration.ser
 @Component({
   selector: 'app-slush-flow-filter',
   templateUrl: './slush-flow-filter.component.html',
+  styleUrls: ['./slush-flow-filter.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SlushFlowFilterComponent extends NgDestoryBase implements OnInit {

--- a/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.ts
+++ b/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.ts
@@ -1,0 +1,59 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Capacitor } from '@capacitor/core';
+import { map, Observable, takeUntil } from 'rxjs';
+import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
+import { SearchCriteriaService, SLUSH_FLOW_ID } from 'src/app/core/services/search-criteria/search-criteria.service';
+import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
+import { GeoHazard } from 'src/app/modules/common-core/models';
+import { KdvService } from 'src/app/modules/common-registration/registration.services';
+
+@Component({
+  selector: 'app-slush-flow-filter',
+  templateUrl: './slush-flow-filter.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SlushFlowFilterComponent extends NgDestoryBase implements OnInit {
+  visible$: Observable<boolean>;
+  value$: Observable<boolean>;
+  caption$: Observable<string>;
+
+  constructor(
+    private searchCriteriaService: SearchCriteriaService,
+    private userSettingService: UserSettingService,
+    private kdvService: KdvService
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.visible$ = this.userSettingService.currentGeoHazard$.pipe(
+      takeUntil(this.ngDestroy$),
+      map((geoHazard) => {
+        const snow = geoHazard.length === 1 && geoHazard.includes(GeoHazard.Snow);
+        return !Capacitor.isNativePlatform() && snow;
+      })
+    );
+
+    this.caption$ = this.kdvService.getKdvRepositoryByKeyObservable('Snow_AvalancheKDV').pipe(
+      map((avalancheKdvs) => {
+        const slushFlowKdv = avalancheKdvs.find((type) => type.Id === SLUSH_FLOW_ID);
+        if (slushFlowKdv) {
+          return slushFlowKdv.Name;
+        }
+        return "Sørpeskred'"; // fallback name
+      })
+    );
+
+    this.value$ = this.searchCriteriaService.searchCriteria$.pipe(
+      takeUntil(this.ngDestroy$),
+      map((criteria) => {
+        return this.searchCriteriaService.isSlushFlow(criteria);
+      })
+    );
+  }
+
+  setValue(event: CustomEvent) {
+    const checked = event.detail.checked;
+    this.searchCriteriaService.setSlushFlow(checked);
+  }
+}

--- a/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.ts
+++ b/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.ts
@@ -41,7 +41,7 @@ export class SlushFlowFilterComponent extends NgDestoryBase implements OnInit {
         if (slushFlowKdv) {
           return slushFlowKdv.Name;
         }
-        return "Sørpeskred'"; // fallback name
+        return "Slush flow'"; // fallback name
       })
     );
 

--- a/src/app/modules/side-menu/side-menu.module.ts
+++ b/src/app/modules/side-menu/side-menu.module.ts
@@ -16,6 +16,7 @@ import { DateRangeComponent } from './components/date-range/date-range.component
 import { SharedComponentsModule } from '../registration/shared-components.module';
 import { NoLegendComponent } from './components/support-tiles-menu/legends/no-legend.component';
 import { SelectedItemsCounterLabelComponent } from './components/selected-items-counter-label/selected-items-counter-label.component';
+import { SlushFlowFilterComponent } from './components/slush-flow-filter/slush-flow-filter.component';
 
 @NgModule({
   imports: [SharedModule, SharedComponentsModule],
@@ -35,6 +36,7 @@ import { SelectedItemsCounterLabelComponent } from './components/selected-items-
     SteepnessCommonLegendComponent,
     DateRangeComponent,
     NoLegendComponent,
+    SlushFlowFilterComponent,
   ],
   exports: [SideMenuComponent, FilterMenuComponent],
 })


### PR DESCRIPTION
Denne forutsetter at API'et støtter søk på sørpeskred. Jeg har generert nye API-modeller basert på test-API'et. Jeg tror ikke demo- og prod-API støtter sørpeskred ennå.
Filter på sørpeskred støttes kun på web og med naturfare snø og vises som en ekstra sjekkboks i bunnen av observasjonstype-lista.
Jeg har knytta sørpeskred til snøskredhendelse, siden sørpeskred er en type snøskredhendelse. Derfor blir filter på snøskredhendelse satt automatisk om man velger sørpeskred. Dessverre blir det trigget to søk når man gjør dette, men jeg syntes det var litt mye jobb å slå disse to sammen til ett filter.

Husk å sjekke at filteret virker og at filteret blir satt i url. Sjekk også at filteret blir satt automatisk om du legger inn slushFlow=true i url. 

- [x] Jeg trenger hjelp til å fjerne det ekstra mellomrommet eller evt. legge inn en liten horisontal strek for å skille denne sjekkboksen fra de over.