### PR TITLE
RO-2205: riktig tilbake navigering etter man logger seg på i login sida

### DIFF
--- a/src/app/modules/login/pages/user-information/user-information.html
+++ b/src/app/modules/login/pages/user-information/user-information.html
@@ -160,7 +160,7 @@
   </ion-grid>
 </ion-content>
 <ng-template #login>
-  <ion-button class="logout-button" expand="block" type="submit" color="varsom-orange" (click)="signIn()">
+  <ion-button class="login-button" expand="block" type="submit" color="varsom-orange" (click)="signIn()">
     {{ 'LOGIN.LOGIN' | translate }}
   </ion-button>
 </ng-template>

--- a/src/app/modules/login/pages/user-information/user-information.html
+++ b/src/app/modules/login/pages/user-information/user-information.html
@@ -1,7 +1,7 @@
 <ion-header *ngIf="loggedInUser$ | async as loggedInUser">
   <ion-toolbar appHeaderColor mode="ios">
     <ion-buttons slot="start">
-      <ion-back-button text="" defaultHref="/"></ion-back-button>
+      <a role="button" (click)="navigateBack()"> <ion-back-button text="" defaultHref="/"></ion-back-button></a>
     </ion-buttons>
     <ion-title>
       {{ loggedInUser.isLoggedIn ? ('MY_PROFILE.TITLE' | translate) : ('LOGIN.TITLE' | translate) }}
@@ -59,7 +59,7 @@
       </div>
     </ion-row>
 
-    <!-- TODO: edit functionality in api v5. 
+    <!-- TODO: edit functionality in api v5.
        <ion-row>
       <ion-col>
         <h2>{{'MY_PROFILE.NICKNAME' | translate}}</h2>
@@ -122,11 +122,11 @@
       </ion-col>
     </ion-row>
     <ion-row class="ion-padding-top">
-       Generere GeoHazard listen ved å hente de ut 
+       Generere GeoHazard listen ved å hente de ut
       <ion-col size="3" size-xs="5" size-sm="3" size-md="2">
         <p class="no-margin" *ngFor="let geoHazard of geoHazards">{{geoHazard.GeoHazardName | translate}}</p>
       </ion-col>
-       Hente ut kompetansen riktig ved å koble opp mot API 
+       Hente ut kompetansen riktig ved å koble opp mot API
       <ion-col class="star-container" size="auto" size-xs="7" size-sm="9" size-md="10" pullMd="1" pullSm="2" pullXs="1">
         <app-competence class="stars" *ngFor="let geoHazard of geoHazards" [competenceLevel]="getCompetenceFromGeoHazard(geoHazard.GeoHazardTID)"></app-competence>
       </ion-col>

--- a/src/app/modules/login/pages/user-information/user-information.scss
+++ b/src/app/modules/login/pages/user-information/user-information.scss
@@ -61,6 +61,10 @@ ion-col {
   text-decoration: underline;
 }
 
+.login-button {
+  margin: auto;
+}
+
 .max-div-height {
   max-height: 40px;
 }

--- a/src/app/modules/login/pages/user-information/user-information.ts
+++ b/src/app/modules/login/pages/user-information/user-information.ts
@@ -12,6 +12,7 @@ import { StarRatingHelper } from '../../../../components/competence/star-helper'
 import { AccountService, MyPageData, ObserverGroupDto } from 'src/app/modules/common-regobs-api';
 import { ModalController } from '@ionic/angular';
 import { EditPictureInfoModalComponent } from '../../../edit-picture-info-modal/edit-picture-info-modal.component';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-user-information',
@@ -67,7 +68,8 @@ export class UserInformation implements OnInit {
     private externalLinkService: ExternalLinkService,
     private userGroupService: UserGroupService,
     private accountApiService: AccountService,
-    public modalController: ModalController
+    public modalController: ModalController,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -91,6 +93,11 @@ export class UserInformation implements OnInit {
           : this.loggedInUser$.pipe(map((LoggedInUser) => LoggedInUser.email))
       )
     );
+  }
+
+  navigateBack() {
+    const prevUrl = localStorage.getItem('prevUrl') || '/';
+    this.router.navigate([prevUrl]);
   }
 
   signIn(): Promise<void> {

--- a/src/app/modules/side-menu/components/user-login/user-login.component.html
+++ b/src/app/modules/side-menu/components/user-login/user-login.component.html
@@ -6,7 +6,7 @@
     </ion-label>
   </ion-item>
   <ng-container *ngIf="loggedInUser.isLoggedIn">
-    <ion-item routerLink="/login" routerDirection="forward" detail="true">
+    <ion-item (click)="storeCurLocation()" routerLink="/login" routerDirection="forward" detail="true">
       <ion-icon slot="start" name="person-circle" color="varsom-blue"></ion-icon>
       <ion-label class="menu-label">
         {{ loggedInUser.email }}

--- a/src/app/modules/side-menu/components/user-login/user-login.component.ts
+++ b/src/app/modules/side-menu/components/user-login/user-login.component.ts
@@ -3,6 +3,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { RegobsAuthService } from '../../../auth/services/regobs-auth.service';
 import { LoggedInUser } from '../../../login/models/logged-in-user.model';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-user-login',
@@ -14,7 +15,7 @@ export class UserLoginComponent implements OnInit, OnDestroy {
   private ngDestroy$ = new Subject<void>();
   isLoggingIn = false;
 
-  constructor(private regobsauthService: RegobsAuthService, private ngZone: NgZone) {}
+  constructor(private regobsauthService: RegobsAuthService, private router: Router, private ngZone: NgZone) {}
 
   ngOnInit(): void {
     this.regobsauthService.loggedInUser$.pipe(takeUntil(this.ngDestroy$)).subscribe((val) => {
@@ -31,6 +32,14 @@ export class UserLoginComponent implements OnInit, OnDestroy {
 
   login(): void {
     this.regobsauthService.signIn();
+  }
+
+  storeCurLocation() {
+    // we need to store curLocation in case user logs out and login on the /login page
+    // then we navigate based on prevUrl in localStorage otherwise back button will navigate to
+    // authcalback site and hang the app
+    const curLocation = this.router.url;
+    localStorage.setItem('prevUrl', curLocation);
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Etter man har logget seg på på /login siden tilbake knapp navigerer til authcallback side siden det står i nettleseren stacken (og ion-back-button henter data derfra). Nettleseren gir ikke tilgang til flere enn bare den siste siden man besøkte derfor kan vi ikke får takket i urlen som ble aktivt før man åpnet login side.
Lagring urlene i appen sitt state vil ikke hjelpe for appen starter på nytt etter pålogging. Derfor tenkte jeg å lagre prevUrl i localStorage når man klikker på  'min side' i side meny. Måtte wrappe 'ion-button' med 'a' tag for å overskrive ion-back-button sitt funksjonalitet fordi å programmere selve ion-back-button er litt tungt.  Det er en litt hackete løsning men det funker. 

Test med å logge seg ut på min side. Logg deg på på min side og trykk på chevron-knappen (<) øverst til venstre. Man burde bli navigert til den siste siden man besøkte i appen.