### PR TITLE
RO-2331: få search modal til å fungere

### DIFF
--- a/src/app/modules/map/components/map-controls/map-controls.component.html
+++ b/src/app/modules/map/components/map-controls/map-controls.component.html
@@ -1,5 +1,5 @@
 <div class="map-controls" [ngClass]="{ fullscreen: (fullscreen$ | async) }">
-  <app-map-search *ngIf="showMapSearch"></app-map-search>
+  <app-map-search></app-map-search>
   <app-fullscreen-toggle *ngIf="showFullscreenToggle"></app-fullscreen-toggle>
   <app-gps-center *ngIf="showGpsCenter"></app-gps-center>
   <app-map-zoom></app-map-zoom>

--- a/src/app/modules/map/components/map-controls/map-controls.component.ts
+++ b/src/app/modules/map/components/map-controls/map-controls.component.ts
@@ -8,7 +8,6 @@ import { Observable } from 'rxjs';
   styleUrls: ['./map-controls.component.scss'],
 })
 export class MapControlsComponent {
-  @Input() showMapSearch = true;
   @Input() showFullscreenToggle = true;
   @Input() showGpsCenter = true;
   fullscreen$: Observable<boolean>;

--- a/src/app/modules/map/components/map-controls/map-search/map-search.component.html
+++ b/src/app/modules/map/components/map-controls/map-search/map-search.component.html
@@ -2,9 +2,4 @@
   <ion-fab-button (click)="openModal()" id="open-modal" color="varsom-dark-blue" class="map-control-fab">
     <ion-icon name="search"></ion-icon>
   </ion-fab-button>
-  <ion-modal [isOpen]="mapSearchOpen" trigger="open-modal">
-    <ng-template>
-      <app-modal-search></app-modal-search>
-    </ng-template>
-  </ion-modal>
 </ion-fab>

--- a/src/app/modules/map/components/map-controls/map-search/map-search.component.ts
+++ b/src/app/modules/map/components/map-controls/map-search/map-search.component.ts
@@ -1,4 +1,6 @@
 import { Component, Input } from '@angular/core';
+import { ModalSearchPage } from '../../../pages/modal-search/modal-search.page';
+import { ModalController } from '@ionic/angular';
 
 @Component({
   selector: 'app-map-search',
@@ -6,9 +8,11 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./map-search.component.scss'],
 })
 export class MapSearchComponent {
-  @Input() mapSearchOpen = false;
-
-  openModal() {
-    this.mapSearchOpen = true;
+  constructor(private modalController: ModalController) {}
+  async openModal(): Promise<void> {
+    const modal = await this.modalController.create({
+      component: ModalSearchPage,
+    });
+    modal.present();
   }
 }

--- a/src/app/modules/map/components/map-controls/map-search/map-search.component.ts
+++ b/src/app/modules/map/components/map-controls/map-search/map-search.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { ModalSearchPage } from '../../../pages/modal-search/modal-search.page';
 import { ModalController } from '@ionic/angular';
 
@@ -9,6 +9,7 @@ import { ModalController } from '@ionic/angular';
 })
 export class MapSearchComponent {
   constructor(private modalController: ModalController) {}
+
   async openModal(): Promise<void> {
     const modal = await this.modalController.create({
       component: ModalSearchPage,

--- a/src/app/modules/map/components/map/map.component.html
+++ b/src/app/modules/map/components/map/map.component.html
@@ -1,9 +1,5 @@
 <div *ngIf="loaded" leaflet [leafletOptions]="options" (leafletMapReady)="onLeafletMapReady($event)"></div>
-<app-map-controls
-  [showMapSearch]="showMapSearch"
-  [showFullscreenToggle]="showFullscreenToggle"
-  [showGpsCenter]="showGpsCenter"
-></app-map-controls>
+<app-map-controls [showFullscreenToggle]="showFullscreenToggle" [showGpsCenter]="showGpsCenter"></app-map-controls>
 
 <div
   #observerTripsContainer


### PR DESCRIPTION
Search modal åpner seg ikke hvis man åpner og lukker den, også prøver å åpne igjen på set-location-map komponent.
Den også sliter hvis man åpner modalen på set-location page der hvor man starter en ny observasjon, går tilbake til hoved kort og prøver å åpne modalen. Da får man to modaler i DOMen hvor en tom en dekker search-modal. Det skyldes at vi ikke handler modalene med modalcontroller der, men bruker ngIfen istedenfor. Det tulla litt med modal identifikasjon i DOMen. 
- [ ] modal skal åpnes og lukkes flere ganger i set-location-map komponent (der hvor man velger lokasjon til en ny obs)
- [ ] modalen skal åpnes bare en gang, med riktig innhold hvis man først åpner modalen i set-location-map og så går man til hovedside og prøver å åpne modalen der. 