### PR TITLE
RO-2339: Varsle hvis Regobs-API'et er utdatert

### DIFF
--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -14,12 +14,12 @@ import { LoggingService } from 'src/app/modules/shared/services/logging/logging.
 import { RegobsAuthService, TOKEN_RESPONSE_FULL_KEY } from 'src/app/modules/auth/services/regobs-auth.service';
 import { StorageBackend } from '@openid/appauth';
 import { ApiVersionService } from '../services/api-version/api-version.service';
-
-const DEBUG_TAG = 'ApiInterceptor';
+import { Capacitor } from '@capacitor/core';
 
 /**
  * Sender innloggings-token med kall til Regobs API der kallene krever at man er logget inn.
- * Hvis api-kallet feiler pga. innloggingsfeil (HTTP 401), prøver vi å fornye tokenet og kjører kallet en gang til
+ * Hvis api-kallet feiler pga. innloggingsfeil (HTTP 401), prøver vi å fornye tokenet og kjører kallet en gang til.
+ * Sjekker også om vi får sunset-header i repons fra API'et for å varsle om at vi bruker et utdatert API.
  */
 @Injectable()
 export class ApiInterceptor implements HttpInterceptor {
@@ -74,7 +74,7 @@ export class ApiInterceptor implements HttpInterceptor {
         if (httpEvent.type === 0) {
           return; // Skip request
         }
-        if (httpEvent instanceof HttpResponse) {
+        if (Capacitor.isNativePlatform() && httpEvent instanceof HttpResponse) {
           if (httpEvent.headers.has('sunset')) {
             const sunsetDate = httpEvent.headers.get('sunset');
             this.apiVersionService.setSunsetDate(sunsetDate);

--- a/src/app/core/services/api-version/api-version.service.ts
+++ b/src/app/core/services/api-version/api-version.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import { ToastController } from '@ionic/angular';
+import { TranslateService } from '@ngx-translate/core';
+import { filter, firstValueFrom, Subject, take, withLatestFrom } from 'rxjs';
+import { LogLevel } from 'src/app/modules/shared/services/logging/log-level.model';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { UserSettingService } from '../user-setting/user-setting.service';
+
+const DEBUG_TAG = 'ApiVersionService';
+
+/**
+ * Varsler om vi bruker et utdatert Regobs-API
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiVersionService {
+  private sunsetDate = new Subject<string>();
+
+  constructor(
+    private logger: LoggingService,
+    private translateService: TranslateService,
+    private toastService: ToastController,
+    userSettingsService: UserSettingService
+  ) {
+    this.sunsetDate
+      .pipe(
+        filter((sunsetDate) => sunsetDate !== null),
+        withLatestFrom(userSettingsService.language$),
+        take(1)
+      )
+      .subscribe(([sunsetDate]) => {
+        this.logger.log(`Regobs API sunset at ${sunsetDate}`, null, LogLevel.Warning, DEBUG_TAG);
+        this.showWarning(sunsetDate);
+      });
+  }
+
+  setSunsetDate(date: string) {
+    this.sunsetDate.next(date);
+  }
+
+  private async showWarning(sunsetDate: string) {
+    const translations = await firstValueFrom(this.translateService.get(['CLOSE', 'API.SUNSET'], { sunsetDate }));
+    const toast = await this.toastService.create({
+      message: translations['API.SUNSET'],
+      position: 'bottom',
+      cssClass: 'toast',
+      buttons: [
+        {
+          text: translations['CLOSE'],
+          role: 'cancel',
+        },
+      ],
+    });
+    await toast.present();
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -25,6 +25,9 @@
     "UNDO": "Undo",
     "WARNING": "Warning"
   },
+  "API": {
+    "SUNSET": "Please upgrade the app! Your app use an outdated version of the Regobs-API. The API will shut down any time and without further notice after {{ sunsetDate }}, and then you will lose a lot of features."
+  },
   "CLOSE": "Close",
   "COACH_MARKS": {
     "ADD_OBSERVATIONS": "Add your observations",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -25,6 +25,9 @@
     "UNDO": "Angre",
     "WARNING": "Advarsel"
   },
+  "API": {
+    "SUNSET": "Du bør oppgradere appen! Appen din bruker en utdatert versjon av Regobs-API'et som stenges når som helst og uten nærmere varsel etter {{ sunsetDate }}. En rekke funksjoner i appen vil deretter slutte å virke."
+  },
   "CLOSE": "Lukk",
   "COACH_MARKS": {
     "ADD_OBSERVATIONS": "Legg til egne observasjoner",


### PR DESCRIPTION
Denne sjekker om vi får en "sunset-header" fra API'et. Hvis vi får dette gir vi beskjed om at observatør bør oppdatere appen.
Feilmeldinga vises kun en gang per sesjon og vises sånn:

![image](https://user-images.githubusercontent.com/71138449/237029661-4b80b4ae-eae6-4f63-8ca4-45529603b84e.png)

Det er regler for formatering av sunset-headere, men de returneres som string i HTTP. Jeg har ikke giddet å bruke tid på å parse dette i appen, da vi risikerer at vi ikke får opp noen dato i tilfelle API'et ikke bruker standarden når den tid kommer.

Siden API'et ikke sender sunset-header nå, kan du teste om appen fungerer på en av to måter på web.
I begge tilfeller må du fjerne kallet Capacitor.isNativePlatform() i ApiInterceptor, ellers vil den ikke se etter headeren.

1.  Legge til sunset-header i API'et ved å kjøre opp denne PR: 
https://dev.azure.com/NVE-devops/Varsom%20Regobs/_git/regobs/pullrequest/3635
og kjøre appen mot lokalt API som webapp.

2. Ved å endre ApiInterceptor til å sjekke en av headerne vi alltid får fra API'et, f.eks. "date".

Du kan også teste på telefon i kombinasjon med (1) over, men da må du bruke f.eks. ngrok og endre API-url'en i settings.ts i appen. Jeg har testet på denne måten på Android.

PS! Tar gjerne imot forslag til bedre feilmeldingstekst!-)
