### PR TITLE
RO-2340: fjerne tom WaterLvl2 objekt fra api body hvis den ikke trengs

### DIFF
--- a/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
+++ b/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
@@ -21,7 +21,7 @@
       </h2></ion-label
     >
     <ion-text color="medium" class="ion-align-self-start ion-text-wrap"> </ion-text>
-    <ion-icon *ngIf="waterLevel2.Extent" slot="end" color="success" name="checkmark-circle"></ion-icon>
+    <ion-icon *ngIf="waterLevel2?.Extent" slot="end" color="success" name="checkmark-circle"></ion-icon>
     <ion-icon slot="end" class="item-detail-icon" name="chevron-forward"> </ion-icon>
   </ion-item>
 </ion-list>

--- a/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
+++ b/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
@@ -8,11 +8,11 @@
   <app-text-comment
     label="DIALOGS.COMMENT"
     placeholder="REGISTRATION.GENERAL_COMMENT.COMMENT_PLACEHOLDER"
-    [(value)]="generalObservation.ObsComment"
-    (valueChange)="save()"
+    [value]="generalObservation.ObsComment"
+    (valueChange)="saveComment($event)"
   ></app-text-comment>
 
-  <app-add-web-url-item (weburlsChange)="save()" [(weburls)]="generalObservation.Urls"></app-add-web-url-item>
+  <app-add-web-url-item (weburlsChange)="saveUrl($event)" [weburls]="generalObservation.Urls"></app-add-web-url-item>
 
   <ion-item (click)="nav()">
     <ion-label>

--- a/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.ts
+++ b/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.ts
@@ -19,9 +19,6 @@ export class SimpleWaterObsComponent {
   constructor(private draftRepository: DraftRepositoryService, private navController: NavController) {}
 
   get waterLevel2(): Waterlevel2EditModel {
-    if (!this.draft.registration.WaterLevel2) {
-      this.draft.registration.WaterLevel2 = {};
-    }
     return this.draft.registration.WaterLevel2;
   }
 

--- a/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.ts
+++ b/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.ts
@@ -55,7 +55,7 @@ export class SimpleWaterObsComponent {
     if (isEmpty) {
       this.draft.registration.GeneralObservation = null;
     }
-    this.draftRepository.save(this.draft);
+    await this.draftRepository.save(this.draft);
   }
 
   nav() {

--- a/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.ts
+++ b/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.ts
@@ -2,7 +2,9 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { NavController } from '@ionic/angular';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
-import { GeneralObservationEditModel, Waterlevel2EditModel } from 'src/app/modules/common-regobs-api';
+import { isObservationModelEmptyForRegistrationTid } from 'src/app/modules/common-registration/registration.helpers';
+import { RegistrationTid } from 'src/app/modules/common-registration/registration.models';
+import { GeneralObservationEditModel, UrlEditModel, Waterlevel2EditModel } from 'src/app/modules/common-regobs-api';
 
 /**
  * Simplified water registration schema.'
@@ -24,12 +26,35 @@ export class SimpleWaterObsComponent {
 
   get generalObservation(): GeneralObservationEditModel {
     if (!this.draft.registration.GeneralObservation) {
-      this.draft.registration.GeneralObservation = {};
+      return {};
     }
     return this.draft.registration.GeneralObservation;
   }
 
+  async saveComment(value: string) {
+    if (!this.draft.registration.GeneralObservation) {
+      this.draft.registration.GeneralObservation = {};
+    }
+    this.draft.registration.GeneralObservation.Comment = value;
+    await this.save();
+  }
+
+  async saveUrl(value: UrlEditModel[]) {
+    if (!this.draft.registration.GeneralObservation) {
+      this.draft.registration.GeneralObservation = {};
+    }
+    this.draft.registration.GeneralObservation.Urls = value;
+    await this.save();
+  }
+
   async save(): Promise<void> {
+    const isEmpty = isObservationModelEmptyForRegistrationTid(
+      this.draft.registration,
+      RegistrationTid.GeneralObservation
+    );
+    if (isEmpty) {
+      this.draft.registration.GeneralObservation = null;
+    }
     this.draftRepository.save(this.draft);
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,8 +57,8 @@ export const settings: ISettings = {
       apiUrl: {
         PROD: 'https://api.regobs.no/v5',
         DEMO: 'https://demo-api.regobs.no/v5',
-        TEST: 'https://test-api.regobs.no/v5',
-        //TEST: 'http://localhost:40001',
+        //TEST: 'https://test-api.regobs.no/v5',
+        TEST: 'http://localhost:40001',
       },
       serviceUrl: {
         PROD: 'https://api.nve.no/hydrology/regobs/v3.5.0',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,8 +57,8 @@ export const settings: ISettings = {
       apiUrl: {
         PROD: 'https://api.regobs.no/v5',
         DEMO: 'https://demo-api.regobs.no/v5',
-        //TEST: 'https://test-api.regobs.no/v5',
-        TEST: 'http://localhost:40001',
+        TEST: 'https://test-api.regobs.no/v5',
+        //TEST: 'http://localhost:40001',
       },
       serviceUrl: {
         PROD: 'https://api.nve.no/hydrology/regobs/v3.5.0',


### PR DESCRIPTION
Vi sender ikke en tom WaterLvl2 objekt hvis det ikke finnes polygoner i observasjonen. ViewModel fra api sender ikke det heller så vi ikke får misvisende titler på skjemaer på atglance kort 