### PR TITLE
RO-2345: Fiks av at vi ikke fikk se mer enn 100 observasjoner i kartet

### DIFF
--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -334,7 +334,8 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
           return this.rememberExtent(currentBounds);
         }
       }),
-      map(([, current]) => current)
+      map(([, current]) => current),
+      map((criteria) => ({ ...criteria, NumberOfRecords: 100000 }))
     );
     return searchCriteriaWithLargerExtent;
   }


### PR DESCRIPTION
Ber nå om maks 100000 rader i stedet for 100, som er standard. Dette glemte jeg å ta med når jeg skrev om kartsøket.
Test at vi får flere enn 100 observasjoner hvis vi søker f.eks. etter snøobservasjoner 14 dager tilbake i prod.