### PR TITLE
RO-2332: Filter på sørpeskred deaktiverer type-filter

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -221,6 +221,7 @@ export class SearchCriteriaService {
   }
 
   resetEvent: Subject<void> = new Subject();
+
   /**
    * Current filter. Current language and geo hazards are always included
    */
@@ -636,6 +637,7 @@ export class SearchCriteriaService {
 
       // turn on avalancheObs automatically since slush flow is a type of avalancheObs
       this.setObservationType(avalacheObsType);
+      //this.searchCriteriaChanges.next({ SelectedRegistrationTypes: [avalacheObsType] });
     } else {
       this.searchCriteriaChanges.next({ PropertyFilters: null });
 

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -221,7 +221,6 @@ export class SearchCriteriaService {
   }
 
   resetEvent: Subject<void> = new Subject();
-
   /**
    * Current filter. Current language and geo hazards are always included
    */
@@ -637,7 +636,6 @@ export class SearchCriteriaService {
 
       // turn on avalancheObs automatically since slush flow is a type of avalancheObs
       this.setObservationType(avalacheObsType);
-      //this.searchCriteriaChanges.next({ SelectedRegistrationTypes: [avalacheObsType] });
     } else {
       this.searchCriteriaChanges.next({ PropertyFilters: null });
 

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -14,7 +14,9 @@
 
   <ng-container *ngIf="isSupported('observationType')">
     <ion-list-header color="varsom-blue" class="ion-no-margin">
-      <app-selected-items-counter-label [selectedItemsCount]="observationTypesSelectedCount">
+      <app-selected-items-counter-label
+        [selectedItemsCount]="slushFlowFilterIsActive ? 1 : observationTypesSelectedCount"
+      >
         {{ "OBSERVATION_FILTER.OBSERVATION_TYPE_FILTER.TITLE" | translate }}
       </app-selected-items-counter-label>
     </ion-list-header>
@@ -25,10 +27,10 @@
           <ion-item class="item-height">
             <!-- if slush flow filter is set, disable filter by observation type because it cannot be combined -->
             <ion-checkbox
-              [checked]="type.isChecked"
+              [checked]="!slushFlowFilterIsActive && type.isChecked"
               (click)="setNewType($event, type.parentId, type.id)"
               color="varsom-dark-blue"
-              [disabled]="slushFlowFilterIsActive$ | async"
+              [disabled]="slushFlowFilterIsActive"
             >
             </ion-checkbox>
             <ion-label class="ion-padding-start">{{ type.name }}</ion-label>

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -23,10 +23,12 @@
       <ion-list lines="none">
         <ng-container *ngFor="let type of observationTypesOptions">
           <ion-item class="item-height">
+            <!-- if slush flow filter is set, disable filter by observation type because it cannot be combined -->
             <ion-checkbox
               [checked]="type.isChecked"
               (click)="setNewType($event, type.parentId, type.id)"
               color="varsom-dark-blue"
+              [disabled]="slushFlowFilterIsActive$ | async"
             >
             </ion-checkbox>
             <ion-label class="ion-padding-start">{{ type.name }}</ion-label>

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { CheckboxCustomEvent, Platform, SearchbarCustomEvent, SelectCustomEvent } from '@ionic/angular';
 import { SelectInterface } from '@ionic/core';
-import { combineLatest, firstValueFrom, Observable, of } from 'rxjs';
+import { BehaviorSubject, combineLatest, firstValueFrom, Observable, of, Subject } from 'rxjs';
 import { map, shareReplay, switchMap, takeUntil, tap } from 'rxjs/operators';
 import {
   AUTOMATIC_STATIONS,
@@ -126,6 +126,8 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     return avalancheRegionTrackById;
   }
 
+  slushFlowFilterIsActive$ = new BehaviorSubject(false);
+
   constructor(
     private platform: Platform,
     private userSettingService: UserSettingService,
@@ -187,6 +189,7 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
       //set chosen nickname
       this.nickName = criteria.ObserverNickName;
       this.cdr.markForCheck();
+      this.slushFlowFilterIsActive$.next(this.searchCriteriaService.isSlushFlow(criteria));
     });
   }
 

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -126,7 +126,7 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     return avalancheRegionTrackById;
   }
 
-  slushFlowFilterIsActive$ = new BehaviorSubject(false);
+  slushFlowFilterIsActive = false;
 
   constructor(
     private platform: Platform,
@@ -188,8 +188,8 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
       this.setObserverCompetence(criteria.ObserverCompetence as number[]);
       //set chosen nickname
       this.nickName = criteria.ObserverNickName;
+      this.slushFlowFilterIsActive = this.searchCriteriaService.isSlushFlow(criteria);
       this.cdr.markForCheck();
-      this.slushFlowFilterIsActive$.next(this.searchCriteriaService.isSlushFlow(criteria));
     });
   }
 


### PR DESCRIPTION
Hva tenker dere om denne løsninga?
Det er fortsatt forvirrende at det står "3 valgt" e.l. i overskrift til observasjonstype når man setter filter på sørpeskred.

1. Skal vi fortsatt sette filter på skredhendelse automatisk når vi velger sørpeskred?
2. Hvilket antall skal vi vise i overskriften til observasjonstype ?
3. Skal vi flytte sørpeskred-filteret til en egen gruppe eller skille den fra de andre typene med en strek e.l.?