### PR TITLE
RO-2348: nullstille/fjerne genobs hvis den er tom

### DIFF
--- a/src/app/modules/common-registration/helpers/registration.helper.spec.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.spec.ts
@@ -88,13 +88,13 @@ describe('registration.helper', () => {
   });
 
   it('hasAnyDataBesidesPropertyToExclude should return false if there is no other data except the excluded fields', () => {
-    expect(hasAnyDataBesidesPropertyToExclude(viewModel.AvalancheActivityObs[0], 'DtAvalancheTime')).toBeFalse();
+    expect(hasAnyDataBesidesPropertyToExclude(viewModel.AvalancheActivityObs[0], ['DtAvalancheTime'])).toBeFalse();
   });
 
   it('hasAnyDataBesidesPropertyToExclude should return true if there is other data except the excluded fields', () => {
     const copyObject = { ...viewModel.AvalancheActivityObs[0] };
     copyObject.Comment = 'this test is good';
-    expect(hasAnyDataBesidesPropertyToExclude(copyObject, 'DtAvalancheTime')).toBeTrue();
+    expect(hasAnyDataBesidesPropertyToExclude(copyObject, ['DtAvalancheTime'])).toBeTrue();
   });
 
   it('Empty registrationTid should return all attachments', () => {

--- a/src/app/modules/common-registration/helpers/registration.helper.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.ts
@@ -134,14 +134,13 @@ export function isObservationModelEmptyForRegistrationTid(
   If in AvalancheObs data model we want to exclude DtAvalancheTime from 'isEmpty' validation we need to pass that property
   in the function. In that case we set hasAnyDataBesidesPropertyToExclude(AvalancheObs, 'DtAvalancheTime')
 */
-export function hasAnyDataBesidesPropertyToExclude<T>(dataModel: T, propertyToExclude: string) {
+export function hasAnyDataBesidesPropertyToExclude<T>(dataModel: T, propertyToExclude: string[]) {
   // have to remove the property to exclude from the object and then check values on the rest
-  //
   if (dataModel) {
     const dataModelCopy = { ...dataModel };
-    delete dataModelCopy[propertyToExclude];
-    const allValues = Object.values(dataModelCopy);
-    return allValues.some((v) => v);
+    propertyToExclude.forEach((p) => delete dataModelCopy[p]);
+    const isEmtpy = isEmpty(dataModelCopy);
+    return !isEmtpy;
   }
 }
 

--- a/src/app/modules/registration/components/snow/simple-snow-obs/edit-images-bar/edit-images-bar.component.ts
+++ b/src/app/modules/registration/components/snow/simple-snow-obs/edit-images-bar/edit-images-bar.component.ts
@@ -1,37 +1,16 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ModalController } from '@ionic/angular';
 import deepEqual from 'fast-deep-equal';
-import { map, Observable, distinctUntilChanged, combineLatest } from 'rxjs';
-import { attachmentsComparator } from 'src/app/core/helpers/attachment-comparator';
+import { Observable } from 'rxjs';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
 import { DraftRepositoryService } from 'src/app/core/services/draft/draft-repository.service';
-import { getAllAttachmentsFromEditModel } from 'src/app/modules/common-registration/registration.helpers';
-import {
-  ExistingAttachmentType,
-  ExistingOrNewAttachment,
-  NewAttachmentType,
-} from 'src/app/modules/common-registration/registration.models';
+import { ExistingOrNewAttachment } from 'src/app/modules/common-registration/registration.models';
 import { NewAttachmentService } from 'src/app/modules/common-registration/registration.services';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { EditImagesPage } from '../../../edit-images/edit-images.page';
+import { getNewAndExistingAttachmentsForDraft$ } from 'src/app/core/services/add-update-delete-registration/attachmentHelpers';
 
 const DEBUG_TAG = 'EditImagesBarComponent';
-
-/**
- * Compares two versions of a draft and returns true if existing (remote) attachments has changed
- */
-function existingAttachmentsHasNotChanged(
-  previous: RegistrationDraft,
-  current: RegistrationDraft,
-  registrationTid: number
-) {
-  const preExistingAttachments = getAllAttachmentsFromEditModel(previous.registration, registrationTid);
-  const curExistingAttachments = getAllAttachmentsFromEditModel(current.registration, registrationTid);
-
-  // Check if existing attachments has changed
-  const changed = attachmentsComparator(preExistingAttachments, curExistingAttachments, 'AttachmentId');
-  return changed;
-}
 
 /**
  * Show thumbnails of all images for given registration.
@@ -59,7 +38,11 @@ export class EditImagesBarComponent {
   ) {}
 
   ngOnInit() {
-    this.attachments$ = this.getNewAndExistingAttachmentsForDraft$(this.draft.uuid);
+    this.attachments$ = getNewAndExistingAttachmentsForDraft$(
+      this.registrationTid,
+      this.draftRepository.getDraft$(this.draft.uuid),
+      this.newAttachmentService.getAttachments(this.draft.uuid, { registrationTid: this.registrationTid })
+    );
   }
 
   async showEditImagesPage(): Promise<void> {
@@ -89,26 +72,5 @@ export class EditImagesBarComponent {
     } else {
       this.logger.debug('Existing (remote) attachments not changed', DEBUG_TAG);
     }
-  }
-
-  /**
-   * @returns an observable array of both new attachments and already uploaded attachments for given draft uuid
-   */
-  private getNewAndExistingAttachmentsForDraft$(uuid: string): Observable<ExistingOrNewAttachment[]> {
-    const draft$ = this.draftRepository
-      .getDraft$(uuid)
-      .pipe(distinctUntilChanged((prev, curr) => existingAttachmentsHasNotChanged(prev, curr, this.registrationTid)));
-    const newAttachments$ = this.newAttachmentService
-      .getAttachments(uuid, { registrationTid: this.registrationTid })
-      .pipe(distinctUntilChanged((prev, curr) => attachmentsComparator(prev, curr, 'id')));
-    return combineLatest([draft$, newAttachments$]).pipe(
-      map(([draft, newAttachments]) => {
-        const existingAttachments = getAllAttachmentsFromEditModel(draft.registration, this.registrationTid);
-        return [
-          ...existingAttachments.map((attachment) => ({ type: 'existing' as ExistingAttachmentType, attachment })),
-          ...newAttachments.map((attachment) => ({ type: 'new' as NewAttachmentType, attachment })),
-        ];
-      })
-    );
   }
 }

--- a/src/app/modules/registration/pages/general-comment/general-comment.page.ts
+++ b/src/app/modules/registration/pages/general-comment/general-comment.page.ts
@@ -3,7 +3,11 @@ import { RegistrationTid } from 'src/app/modules/common-registration/registratio
 import { BasePage } from '../base.page';
 import { BasePageService } from '../base-page-service';
 import { ActivatedRoute } from '@angular/router';
+import { hasAnyDataBesidesPropertyToExclude } from 'src/app/modules/common-registration/registration.helpers';
 
+// while creating generalObservation api adds two fields GeoHazardTID and GeoHazardName
+// user cannot see those fields therefore while editing generalObservation and removing all the data in the app
+// UI will show that generalObservation is still filled
 @Component({
   selector: 'app-general-comment',
   templateUrl: './general-comment.page.html',
@@ -12,5 +16,29 @@ import { ActivatedRoute } from '@angular/router';
 export class GeneralCommentPage extends BasePage {
   constructor(basePageService: BasePageService, activatedRoute: ActivatedRoute) {
     super(RegistrationTid.GeneralObservation, basePageService, activatedRoute);
+  }
+
+  async isEmpty(): Promise<boolean> {
+    //check if the existing generalObservation has any data besides excluded fields
+    if (this.draft.registration.GeneralObservation.GeoHazardTID) {
+      if (
+        hasAnyDataBesidesPropertyToExclude(this.draft.registration.GeneralObservation, [
+          'GeoHazardTID',
+          'GeoHazardName',
+        ])
+      ) {
+        return false;
+      } else return true;
+    }
+
+    // check if there are any attachments connected to the generalObservation
+    const hasAttachments = await super.hasAttachments(RegistrationTid.GeneralObservation);
+    if (hasAttachments) {
+      return false;
+    }
+
+    // check if a new generalObservation is not emtpy
+    const isGeneralObservationEmpty = await super.isEmpty(RegistrationTid.GeneralObservation);
+    return isGeneralObservationEmpty;
   }
 }

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -177,7 +177,7 @@ export class AvalancheObsPage extends BasePage {
     // we need to ignore the default value of DtAvalancheTime
     if (
       this.avalancheObs.DtAvalancheTime &&
-      (hasAnyDataBesidesPropertyToExclude(this.avalancheObs, 'DtAvalancheTime') ||
+      (hasAnyDataBesidesPropertyToExclude(this.avalancheObs, ['DtAvalancheTime']) ||
         this.dtAvalancheTimeIsDifferentThanObsTime)
     ) {
       return false;

--- a/src/app/modules/registration/pages/water/set-flood-area/set-flood-area.page.ts
+++ b/src/app/modules/registration/pages/water/set-flood-area/set-flood-area.page.ts
@@ -54,9 +54,6 @@ export class SetFloodAreaPage implements OnInit {
       if (!this.draft.registration.WaterLevel2) {
         this.draft.registration.WaterLevel2 = {};
       }
-      if (!this.draft.registration.GeneralObservation) {
-        this.draft.registration.GeneralObservation = {};
-      }
       this.relativeToLatLng = this.draft.registration.ObsLocation
         ? L.latLng(this.draft.registration.ObsLocation.Latitude, this.draft.registration.ObsLocation.Longitude)
         : null;


### PR DESCRIPTION
Det er best å teste PRen med https://dev.azure.com/NVE-devops/Varsom%20Regobs/_git/regobs/pullrequest/3667

Hvis man redigerer en eksisterende generalObservation (eller bilder, obscomment, og url linker i vann obs) og fjerner alt, så burde vi ikke sende et objekt med GeoHazardTID og GeoHazardName eller et tomt objekt men sende null isteden så at den ikke vises på atglance kort. 
I tillegg hvis man fjerner alt i generalobs skjema gjennom redigering burde det vises som et tomt skjema. Det gjelder bare skjemaer som ble lagret i db fra før. 

- [ ] fyll et generalobservation skjema og send til API. Deretter rediger skjemaet og fjern alle synlige feltene (bilder inkludert). Nå burde skjema være tomt på overviewPage. 
- [ ] sjekk at man ikke sender et tomt GeneralObservation objekt til API 
- [ ] hvis du tester PRen med PRen på api Notater burde ikke vises på atglance kort etter du har slettet alt fra genobs skjema