### PR TITLE
RO-1890: lufttemperatur validering

### DIFF
--- a/src/app/modules/registration/pages/snow/weather/weather.page.html
+++ b/src/app/modules/registration/pages/snow/weather/weather.page.html
@@ -25,8 +25,8 @@
       <app-numeric-input
         [(value)]="draft.registration.WeatherObservation.AirTemperature"
         label="REGISTRATION.SNOW.WEATHER.AIR_TEMPERATURE"
-        [min]="-150"
-        [max]="60"
+        [min]="-50"
+        [max]="50"
         suffix="°C"
         placeholder="REGISTRATION.SNOW.WEATHER.AIR_TEMPERATURE_PLACEHOLDER"
         [decimalPlaces]="2"


### PR DESCRIPTION
På samme måte som vi begrenser brukere til å skrive tall høyere enn 50 på vindhastighet, nå kan brukere skrive ikke tall høyere enn 50 og mindre enn -50 på lufttemperatur