### PR TITLE
RO-2349: sentrert en tom liste på mobil

### DIFF
--- a/src/app/pages/observation-list/observation-list.page.scss
+++ b/src/app/pages/observation-list/observation-list.page.scss
@@ -107,6 +107,7 @@ ion-item-divider {
   }
 }
 
+/*margin auto centers div horizontally within its container*/
 .center {
   width: 300px;
   height: 300px;

--- a/src/app/pages/observation-list/observation-list.page.scss
+++ b/src/app/pages/observation-list/observation-list.page.scss
@@ -110,6 +110,7 @@ ion-item-divider {
 .center {
   width: 300px;
   height: 300px;
+  margin: auto;
   display: inline-block;
   position: relative;
 
@@ -190,4 +191,5 @@ ion-item-divider {
 
 .error {
   flex-direction: column;
+  width: 95%;
 }


### PR DESCRIPTION
Siden vi definerer størrelse på boksen (300px) og ikke bruker flex må vi legge margin auto som vil sentrere diven på siden. 