### PR TITLE
RO-2103: Finner ikke snappepunkt hvis tlf har vært offline

### DIFF
--- a/src/app/core/services/location/location.service.ts
+++ b/src/app/core/services/location/location.service.ts
@@ -1,14 +1,21 @@
 import { Injectable } from '@angular/core';
 import { LocationService as RegobsApiLocationService } from 'src/app/modules/common-regobs-api/services';
 import { GeoHazard } from 'src/app/modules/common-core/models';
-import { switchMap } from 'rxjs/operators';
+import { catchError, switchMap } from 'rxjs/operators';
 import { RegobsAuthService } from '../../../modules/auth/services/regobs-auth.service';
+import { of } from 'rxjs';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 
+const DEBUG_TAG = 'LocationService';
 @Injectable({
   providedIn: 'root',
 })
 export class LocationService {
-  constructor(private regobsAuthService: RegobsAuthService, private apiLocationService: RegobsApiLocationService) {}
+  constructor(
+    private regobsAuthService: RegobsAuthService,
+    private apiLocationService: RegobsApiLocationService,
+    private loggingService: LoggingService
+  ) {}
 
   getLocationWithinRadiusObservable(geoHazard: GeoHazard, lat: number, lng: number, radius: number) {
     return this.regobsAuthService.loggedInUser$.pipe(
@@ -20,7 +27,11 @@ export class LocationService {
           longitude: lng,
           returnCount: 100,
         })
-      )
+      ),
+      catchError((err) => {
+        this.loggingService.error(err, DEBUG_TAG, 'Could not fetch loactions within radius');
+        return of([]);
+      })
     );
   }
 }


### PR DESCRIPTION
Lagt til en catchError handler som ikke stopper observable LocationWithinRadius når den feiler, men returnerer en tom array. Den fortsetter å fungere som normalt når man er koblet mot internett på nytt