### PR TITLE
RO-2348: ikke sende et tomt generalbObservation objekt til api

### DIFF
--- a/src/app/modules/common-registration/helpers/registration.helper.spec.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.spec.ts
@@ -88,13 +88,13 @@ describe('registration.helper', () => {
   });
 
   it('hasAnyDataBesidesPropertyToExclude should return false if there is no other data except the excluded fields', () => {
-    expect(hasAnyDataBesidesPropertyToExclude(viewModel.AvalancheActivityObs[0], 'DtAvalancheTime')).toBeFalse();
+    expect(hasAnyDataBesidesPropertyToExclude(viewModel.AvalancheActivityObs[0], ['DtAvalancheTime'])).toBeFalse();
   });
 
   it('hasAnyDataBesidesPropertyToExclude should return true if there is other data except the excluded fields', () => {
     const copyObject = { ...viewModel.AvalancheActivityObs[0] };
     copyObject.Comment = 'this test is good';
-    expect(hasAnyDataBesidesPropertyToExclude(copyObject, 'DtAvalancheTime')).toBeTrue();
+    expect(hasAnyDataBesidesPropertyToExclude(copyObject, ['DtAvalancheTime'])).toBeTrue();
   });
 
   it('Empty registrationTid should return all attachments', () => {

--- a/src/app/modules/common-registration/helpers/registration.helper.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.ts
@@ -132,16 +132,16 @@ export function isObservationModelEmptyForRegistrationTid(
 
 /*
   If in AvalancheObs data model we want to exclude DtAvalancheTime from 'isEmpty' validation we need to pass that property
-  in the function. In that case we set hasAnyDataBesidesPropertyToExclude(AvalancheObs, 'DtAvalancheTime')
+  in the function. In that case we set hasAnyDataBesidesPropertyToExclude(AvalancheObs, ['DtAvalancheTime'])
 */
-export function hasAnyDataBesidesPropertyToExclude<T>(dataModel: T, propertyToExclude: string) {
+export function hasAnyDataBesidesPropertyToExclude<T>(dataModel: T, propertyToExclude: string[]) {
   // have to remove the property to exclude from the object and then check values on the rest
   //
   if (dataModel) {
     const dataModelCopy = { ...dataModel };
-    delete dataModelCopy[propertyToExclude];
-    const allValues = Object.values(dataModelCopy);
-    return allValues.some((v) => v);
+    propertyToExclude.forEach((p) => delete dataModelCopy[p]);
+    const isEmtpy = isEmpty(dataModelCopy);
+    return !isEmtpy;
   }
 }
 

--- a/src/app/modules/registration/pages/general-comment/general-comment.page.ts
+++ b/src/app/modules/registration/pages/general-comment/general-comment.page.ts
@@ -22,7 +22,7 @@ export class GeneralCommentPage extends BasePage {
     ) {
       return false;
     }
-    // check if there are any attachments connected to the generalObservationG
+    // check if there are any attachments connected to the generalObservation
     const hasAttachments = await super.hasAttachments(RegistrationTid.GeneralObservation);
     if (hasAttachments) {
       return false;

--- a/src/app/modules/registration/pages/general-comment/general-comment.page.ts
+++ b/src/app/modules/registration/pages/general-comment/general-comment.page.ts
@@ -16,17 +16,13 @@ export class GeneralCommentPage extends BasePage {
   }
   async isEmpty(): Promise<boolean> {
     //check if the existing generalObservation has any data besides excluded fields
-    if (this.draft.registration.GeneralObservation.GeoHazardTID) {
-      if (
-        hasAnyDataBesidesPropertyToExclude(this.draft.registration.GeneralObservation, [
-          'GeoHazardTID',
-          'GeoHazardName',
-        ])
-      ) {
-        return false;
-      } else return true;
+    if (
+      this.draft.registration.GeneralObservation.GeoHazardTID &&
+      hasAnyDataBesidesPropertyToExclude(this.draft.registration.GeneralObservation, ['GeoHazardTID', 'GeoHazardName'])
+    ) {
+      return false;
     }
-    // check if there are any attachments connected to the generalObservation
+    // check if there are any attachments connected to the generalObservationG
     const hasAttachments = await super.hasAttachments(RegistrationTid.GeneralObservation);
     if (hasAttachments) {
       return false;

--- a/src/app/modules/registration/pages/general-comment/general-comment.page.ts
+++ b/src/app/modules/registration/pages/general-comment/general-comment.page.ts
@@ -3,6 +3,7 @@ import { RegistrationTid } from 'src/app/modules/common-registration/registratio
 import { BasePage } from '../base.page';
 import { BasePageService } from '../base-page-service';
 import { ActivatedRoute } from '@angular/router';
+import { hasAnyDataBesidesPropertyToExclude } from 'src/app/modules/common-registration/registration.helpers';
 
 @Component({
   selector: 'app-general-comment',
@@ -12,5 +13,27 @@ import { ActivatedRoute } from '@angular/router';
 export class GeneralCommentPage extends BasePage {
   constructor(basePageService: BasePageService, activatedRoute: ActivatedRoute) {
     super(RegistrationTid.GeneralObservation, basePageService, activatedRoute);
+  }
+  async isEmpty(): Promise<boolean> {
+    //check if the existing generalObservation has any data besides excluded fields
+    if (this.draft.registration.GeneralObservation.GeoHazardTID) {
+      if (
+        hasAnyDataBesidesPropertyToExclude(this.draft.registration.GeneralObservation, [
+          'GeoHazardTID',
+          'GeoHazardName',
+        ])
+      ) {
+        return false;
+      } else return true;
+    }
+    // check if there are any attachments connected to the generalObservation
+    const hasAttachments = await super.hasAttachments(RegistrationTid.GeneralObservation);
+    if (hasAttachments) {
+      return false;
+    }
+
+    // check if a new generalObservation is not emtpy
+    const isGeneralObservationEmpty = await super.isEmpty(RegistrationTid.GeneralObservation);
+    return isGeneralObservationEmpty;
   }
 }

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -177,7 +177,7 @@ export class AvalancheObsPage extends BasePage {
     // we need to ignore the default value of DtAvalancheTime
     if (
       this.avalancheObs.DtAvalancheTime &&
-      (hasAnyDataBesidesPropertyToExclude(this.avalancheObs, 'DtAvalancheTime') ||
+      (hasAnyDataBesidesPropertyToExclude(this.avalancheObs, ['DtAvalancheTime']) ||
         this.dtAvalancheTimeIsDifferentThanObsTime)
     ) {
       return false;


### PR DESCRIPTION
Det er best å teste PRen med https://dev.azure.com/NVE-devops/Varsom%20Regobs/_git/regobs/pullrequest/3667

Hvis man redigerer en eksisterende generalObservation (eller bilder, obscomment, og url linker i vann obs) og fjerner alt, så burde vi ikke sende et objekt med GeoHazardTID og GeoHazardName eller et tomt objekt men sende null isteden så at den ikke vises på atglance kort. 
I tillegg hvis man fjerner alt i generalobs skjema gjennom redigering burde det vises som et tomt skjema. Det gjelder bare skjemaer som ble lagret i db fra før. 

- [x] fyll et generalobservation skjema og send til API. Deretter rediger skjemaet og fjern alle synlige feltene (bilder inkludert). Nå burde skjema være tomt på overviewPage. 
- [x] sjekk at man ikke sender et tomt GeneralObservation objekt til API 
- [x] hvis du tester PRen med PRen på api Notater burde ikke vises på atglance kort etter du har slettet alt fra genobs skjema