### PR TITLE
RO-1024: redigere lokasjons navn hvis den ikke var lagret før

### DIFF
--- a/src/app/modules/common-regobs-api/models/obs-locations-response-dto-v2.ts
+++ b/src/app/modules/common-regobs-api/models/obs-locations-response-dto-v2.ts
@@ -1,11 +1,11 @@
 /* tslint:disable */
 import { LatLngObject } from './lat-lng-object';
 export interface ObsLocationsResponseDtoV2 {
-  Description?: string;
   Distance?: number;
   GeoHazardId?: number;
   Id?: number;
   LatLngObject?: LatLngObject;
+  LocationDescription?: string;
   Name?: string;
   ObserverGroupId?: number;
   ObserverGroupName?: string;

--- a/src/app/modules/common-regobs-api/models/obs-locations-response-dto-v2.ts
+++ b/src/app/modules/common-regobs-api/models/obs-locations-response-dto-v2.ts
@@ -3,6 +3,7 @@ import { LatLngObject } from './lat-lng-object';
 export interface ObsLocationsResponseDtoV2 {
   Distance?: number;
   GeoHazardId?: number;
+  Description?: string;
   Id?: number;
   LatLngObject?: LatLngObject;
   Name?: string;

--- a/src/app/modules/common-regobs-api/models/obs-locations-response-dto-v2.ts
+++ b/src/app/modules/common-regobs-api/models/obs-locations-response-dto-v2.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 import { LatLngObject } from './lat-lng-object';
 export interface ObsLocationsResponseDtoV2 {
+  Description?: string;
   Distance?: number;
   GeoHazardId?: number;
-  Description?: string;
   Id?: number;
   LatLngObject?: LatLngObject;
   Name?: string;

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -540,7 +540,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
     if (this.editLocationName && this.locationName && this.locationName.length > 0) {
       obsLocation.ObsLocationID = undefined;
       obsLocation.LocationName = this.locationName.substring(0, 60);
-    } else if (this.selectedLocation?.Name !== this.selectedLocation?.Description) {
+    } else if (this.selectedLocation?.Name !== this.selectedLocation?.LocationDescription) {
       obsLocation.ObsLocationID = this.selectedLocation.Id;
       obsLocation.LocationName = this.selectedLocation.Name;
     }

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -423,6 +423,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
     this.ngZone.run(() => {
       this.mapService.followMode = false;
       this.selectedLocation = location;
+      this.allowEditLocationName = false;
       this.setLocationMarkerLatLng(L.latLng(location.LatLngObject.Latitude, location.LatLngObject.Longitude));
       this.map.panTo(this.locationMarker.getLatLng());
     });
@@ -431,6 +432,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
   private moveLocationMarkerToCenter(): void {
     this.mapService.followMode = false;
     this.selectedLocation = null;
+    this.allowEditLocationName = true;
     const center = this.map.getCenter();
     this.locationMarker.setLatLng(center);
     this.updatePathAndDistance();

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -109,7 +109,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
    * Show a dotted line between the location you choose and the location of the device. Defaults to true in native mode.
    */
   @Input() showPolyline = Capacitor.isNativePlatform();
-  @Input() allowEditLocationName = false;
+  @Input() allowEditLocationName: boolean;
   @Input() setObsTime = false;
   @Input() localDate: string;
   @Input() sourceTid: number;
@@ -143,7 +143,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
   @ViewChild('editLocationNameInput') editLocationNameInput: IonInput;
 
   get canEditLocationName() {
-    return this.allowEditLocationName && !(this.selectedLocation && this.selectedLocation.Id);
+    return this.allowEditLocationName;
   }
 
   constructor(
@@ -534,10 +534,11 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
       Longitude: this.locationMarker.getLatLng().lng,
       UTMSourceTID: UtmSource.SelectedInMap,
     };
+    // check if location name is the same as location description if yes then allow edition
     if (this.editLocationName && this.locationName && this.locationName.length > 0) {
       obsLocation.ObsLocationID = undefined;
       obsLocation.LocationName = this.locationName.substring(0, 60);
-    } else if (this.selectedLocation) {
+    } else if (this.selectedLocation?.Name !== this.selectedLocation?.Description) {
       obsLocation.ObsLocationID = this.selectedLocation.Id;
       obsLocation.LocationName = this.selectedLocation.Name;
     }

--- a/src/app/modules/registration/pages/obs-location/obs-location.page.html
+++ b/src/app/modules/registration/pages/obs-location/obs-location.page.html
@@ -13,7 +13,7 @@
     [locationMarker]="locationMarker"
     (locationTimeSet)="onLocationTimeSet($event)"
     [selectedLocation]="selectedLocation"
-    [allowEditLocationName]="true"
+    [allowEditLocationName]="allowEditLocationName"
     [setObsTime]="true"
     [localDate]="draft?.registration?.DtObsTime"
     [sourceTid]="draft?.registration?.SourceTID"

--- a/src/app/modules/registration/pages/obs-location/obs-location.page.ts
+++ b/src/app/modules/registration/pages/obs-location/obs-location.page.ts
@@ -24,6 +24,7 @@ import { LocationService } from 'src/app/modules/common-regobs-api';
 export class ObsLocationPage implements OnInit, OnDestroy {
   locationMarker: L.Marker;
   isLoaded = false;
+  allowEditLocationName = true;
   selectedLocation: ObsLocationsResponseDtoV2;
   draft: RegistrationDraft;
   fullscreen$: Observable<boolean>;
@@ -79,13 +80,16 @@ export class ObsLocationPage implements OnInit, OnDestroy {
       this.setLocationMarker(location.Latitude, location.Longitude);
       this.selectedLocation = {
         Name: location.LocationName || location.LocationDescription,
+        Description: location.LocationDescription,
         Id: locationId,
       };
     } else if (this.hasLocation(this.draft)) {
       const obsLocation = this.draft.registration.ObsLocation;
+      this.allowEditLocationName = obsLocation.LocationName && obsLocation.ObsLocationID ? false : true;
       this.setLocationMarker(obsLocation.Latitude, obsLocation.Longitude);
       this.selectedLocation = {
         Name: obsLocation.LocationName || obsLocation.LocationDescription,
+        Description: obsLocation.LocationDescription,
         Id: obsLocation.ObsLocationID,
       };
     }

--- a/src/app/modules/registration/pages/obs-location/obs-location.page.ts
+++ b/src/app/modules/registration/pages/obs-location/obs-location.page.ts
@@ -80,7 +80,7 @@ export class ObsLocationPage implements OnInit, OnDestroy {
       this.setLocationMarker(location.Latitude, location.Longitude);
       this.selectedLocation = {
         Name: location.LocationName || location.LocationDescription,
-        Description: location.LocationDescription,
+        LocationDescription: location.LocationDescription,
         Id: locationId,
       };
     } else if (this.hasLocation(this.draft)) {
@@ -89,7 +89,7 @@ export class ObsLocationPage implements OnInit, OnDestroy {
       this.setLocationMarker(obsLocation.Latitude, obsLocation.Longitude);
       this.selectedLocation = {
         Name: obsLocation.LocationName || obsLocation.LocationDescription,
-        Description: obsLocation.LocationDescription,
+        LocationDescription: obsLocation.LocationDescription,
         Id: obsLocation.ObsLocationID,
       };
     }


### PR DESCRIPTION
Jeg lagde et property til i ObsLocationsResponseDtoV2 som heter Description, det er fordi hvis man ikke setter navn på lokasjonen den lagrer description navn istedenfor så jeg kan sammenlikne om de to er det samme, hvis ja såp betyr det at lokasjonens navn var aldri endret av bruker (men bruker gikk med defualt) som igjen gjør at man kan endre neste gang man redigerer observasjonen.