### PR TITLE
RO-2075: fjernet feil meldinger i konsolet på app nullstilling

### DIFF
--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -98,7 +98,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
   }
 
   get legalUrl() {
-    const language = this.userSettingInMemory.value.language;
+    const language = this.userSettingInMemory.value?.language;
     if (language == LangKey.nb || language == LangKey.nn) {
       return settings.legalUrl.nb;
     } else {

--- a/src/app/modules/shared/services/app-reset/app-reset.service.ts
+++ b/src/app/modules/shared/services/app-reset/app-reset.service.ts
@@ -17,7 +17,7 @@ export class AppResetService {
   ) {}
 
   async resetApp(): Promise<void> {
-    await Promise.all(this.services.map((s) => Promise.resolve(s.appOnReset())));
+    await Promise.all(this.services.map((s) => Promise.resolve(s.appOnReset ? s.appOnReset() : true)));
     await this.dbHelperService.resetDb((table) => {
       this.loggingService.log(`Error reset table ${table}`, null, LogLevel.Warning, DEBUG_TAG);
     });

--- a/src/app/pages/user-settings/user-settings.page.ts
+++ b/src/app/pages/user-settings/user-settings.page.ts
@@ -178,6 +178,6 @@ export class UserSettingsPage implements OnInit, OnDestroy {
 
   private async doReset() {
     this.stopSubscriptions();
-    return this.appResetService.resetApp();
+    return await this.appResetService.resetApp();
   }
 }


### PR DESCRIPTION
Så ikke gps markør feilet noe lenger, men det var et annet feil koblet mot promise calling på metoden som ikke eksisterte (nemlig appOnReset i offline-map-service). Måtte også sjekke om this.userSettingInMemory.value ikke er null etter nullstilling