### PR TITLE
RO-1796: Byttet ut gamle Varsom-url'er med de som gjelder nå

### DIFF
--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -198,7 +198,7 @@
     "TITLE": "Mine observationer"
   },
   "MY_PROFILE": {
-    "COMPETENCE": "<a href=\"https://varsom.no/regobs/kompetanse/\">Læs mere om kompetencer</a>",
+    "COMPETENCE": "<a href=\"https://varsom.no/om-varsom/regobs/kompetanse/\">Læs mere om kompetencer</a>",
     "COPYRIGHT": "Ophavsret",
     "EDIT": "Rediger",
     "MY_COMPETENCE": "Min kompetence",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -224,7 +224,7 @@
     "TITLE": "My observations"
   },
   "MY_PROFILE": {
-    "COMPETENCE": "<a href=\"https://varsom.no/regobs/kompetanse/\">Read more about competence</a>",
+    "COMPETENCE": "<a href=\"https://varsom.no/om-varsom/regobs/kompetanse/\">Read more about competence</a>",
     "COPYRIGHT": "Copyright",
     "EDIT": "Edit",
     "MY_COMPETENCE": "My competence",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -224,7 +224,7 @@
     "TITLE": "Mine observasjoner"
   },
   "MY_PROFILE": {
-    "COMPETENCE": "<a href=\"https://varsom.no/regobs/kompetanse/\">Les mer om kompetanse</a>",
+    "COMPETENCE": "<a href=\"https://varsom.no/om-varsom/regobs/kompetanse/\">Les mer om kompetanse</a>",
     "COPYRIGHT": "Opphavsrett",
     "EDIT": "Rediger",
     "MY_COMPETENCE": "Min kompetanse",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -210,7 +210,7 @@
     "TITLE": "Mine observasjonar"
   },
   "MY_PROFILE": {
-    "COMPETENCE": "<a href=\"https://varsom.no/regobs/kompetanse/\">Les meir om kompetanse</a>",
+    "COMPETENCE": "<a href=\"https://varsom.no/om-varsom/regobs/kompetanse/\">Les meir om kompetanse</a>",
     "COPYRIGHT": "Opphavsrett",
     "EDIT": "Rediger",
     "MY_COMPETENCE": "Min kompetanse",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -224,7 +224,7 @@
     "TITLE": "Mina observationer"
   },
   "MY_PROFILE": {
-    "COMPETENCE": "<a href=\"https://varsom.no/regobs/kompetanse/\"> Läs mer om kompetens </a>",
+    "COMPETENCE": "<a href=\"https://varsom.no/om-varsom/regobs/kompetanse/\"> Läs mer om kompetens </a>",
     "COPYRIGHT": "upphovsrätt",
     "EDIT": "Redigera",
     "MY_COMPETENCE": "Min kompetens",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -84,24 +84,24 @@ export const settings: ISettings = {
       Snow: {
         apiUrl: 'https://api01.nve.no/hydrology/forecast/avalanche/v4.0.2/api',
         webUrl: {
-          nb: 'http://www.varsom.no/snoskredvarsling/varsel/{regionName}/{day}?utm_source=regobs&utm_medium=app&utm_campaign=avalanche',
-          en: 'http://www.varsom.no/en/avalanche-bulletins/forecast/{regionName}/{day}?utm_source=regobs&utm_medium=app&utm_campaign=avalanche',
+          nb: 'https://www.varsom.no/snoskred/varsling/varsel/{regionName}/{day}?utm_source=regobs&utm_medium=app&utm_campaign=avalanche',
+          en: 'https://www.varsom.no/en/snow/forecast/warning/{regionName}/{day}?utm_source=regobs&utm_medium=app&utm_campaign=avalanche',
         },
         featureName: 'omradeID',
       },
       Soil: {
         apiUrl: 'https://api01.nve.no/hydrology/forecast/landslide/v1.0.6/api',
         webUrl: {
-          nb: 'http://www.varsom.no/flom-og-jordskredvarsling/varsel/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=landslide',
-          en: 'http://www.varsom.no/en/flood-and-landslide-warning-service/forecast/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=landslide',
+          nb: 'https://www.varsom.no/flom-og-jordskred/varsling/varsel/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=landslide',
+          en: 'https://www.varsom.no/en/flood-and-landslide-warning-service/forecast/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=landslide',
         },
         featureName: 'fylkesnummer',
       },
       Water: {
         apiUrl: 'https://api01.nve.no/hydrology/forecast/flood/v1.0.6/api',
         webUrl: {
-          nb: 'http://www.varsom.no/flom-og-jordskredvarsling/varsel/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=flood',
-          en: 'http://www.varsom.no/en/flood-and-landslide-warning-service/forecast/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=flood',
+          nb: 'https://www.varsom.no/flom-og-jordskred/varsling/varsel/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=flood',
+          en: 'https://www.varsom.no/en/flood-and-landslide-warning-service/forecast/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=flood',
         },
         featureName: 'fylkesnummer',
       },
@@ -399,7 +399,7 @@ export const settings: ISettings = {
     ],
   },
   legalUrl: {
-    en: 'https://www.varsom.no/en/about/regobs/regobs-terms-of-service/',
+    en: 'https://varsom.no/en/about/regobs/regobs-about-data-terms-of-service-and-privacy-policy/',
     nb: 'https://varsom.no/om-varsom/regobs/regobs-brukervilkar/',
   },
 };


### PR DESCRIPTION
Jeg har bare sjekket hvilke sider vi ender opp på (etter videresending internt i Varsom), når vi navigerer fra appen til varsom.no.
Deretter har jeg byttet ut linkene med disse mål-sidene.
Linker som er endret:
- "om data..." i hovedmenyen og i oppstartsvegviser
-  om kompetanse i oppstartsvegviser (denne vises ikke i app nå, men vil komme på "Min side" etterhvert)
- linker for varsler på snø, vann og jord 
PS! Linker til isvarsel virker ikke. Lager en [egen sak](https://nveprojects.atlassian.net/browse/RO-2477) på dette.

