### PR TITLE
Fix RO-2491: Remove /auth/callback from history when routing

### DIFF
--- a/src/app/modules/auth/services/regobs-auth.service.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.ts
@@ -239,9 +239,10 @@ export class RegobsAuthService {
       if (returnUrl) {
         localStorage.removeItem(RETURN_URL_KEY);
         this.location.replaceState(this.router.serializeUrl(this.router.createUrlTree([''])));
-        await this.navCtrl.navigateForward(returnUrl);
+        // Use replaceUrl to remove /auth/callback from history
+        await this.navCtrl.navigateForward(returnUrl, { replaceUrl: true });
       } else {
-        await this.navCtrl.navigateRoot('');
+        await this.navCtrl.navigateRoot('', { replaceUrl: true });
       }
     }
   }


### PR DESCRIPTION
Etter å ha logget inn var det mulig å navigere tilbake til /auth/callback ved å trykke på tilbakeknappen. Appen kom da i en tilstand hvor det bare var en side med spinner på uten mulighet til å komme seg videre.