### PR TITLE
Fix RO-2506: Object captured as exception in sentry

### DIFF
--- a/src/app/core/helpers/http-error-response-helper.ts
+++ b/src/app/core/helpers/http-error-response-helper.ts
@@ -1,0 +1,51 @@
+import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
+import { RegistrationDraftErrorCode } from '../services/draft/draft-model';
+
+/**
+ * Create a formatted message for an angular HttpErrorResponse
+ *
+ * @param error Angular HttpErrorResponse
+ * @returns Message and Regobs Draft Error Code. NB: RegistrationDraftErrorCode has nothing to do with Http status code
+ *   it is just an internal regobs app error status code used to find out what to do with the draft.
+ */
+export const getHttpErrorResponseMessageAndCode = (
+  error: HttpErrorResponse
+): { message: string; code: RegistrationDraftErrorCode } => {
+  let code: RegistrationDraftErrorCode;
+  let message: string;
+
+  if (error.status === 0) {
+    code = RegistrationDraftErrorCode.NoNetworkOrTimedOut;
+    message = error.message || 'Response failed with status code 0, probably no network?';
+  } else if (error.status === HttpStatusCode.BadRequest) {
+    code = RegistrationDraftErrorCode.RegistrationError;
+    // Regobs api returns additional info for bad requests.
+    // Put this info into a readable error message.
+    let messages = [];
+    if (error.error?.Message) {
+      messages.push(error.error.Message);
+    }
+    if (error.error?.ModelState) {
+      messages = [...messages, ...Object.values(error.error.ModelState)];
+    }
+    if (messages.length > 0) {
+      message = messages.join(' ');
+    } else {
+      message = error.message || `Response failed with ${error.status} - ${error.statusText}`;
+    }
+  } else if (error.status === HttpStatusCode.Conflict) {
+    code = RegistrationDraftErrorCode.ConflictError;
+    message = error.message || `Registration conflict ${error.status} - ${error.statusText}`;
+  } else if (error.status === HttpStatusCode.Gone) {
+    code = RegistrationDraftErrorCode.GoneError;
+    message = error.message || `Registration is deleted in Regobs ${error.status} - ${error.statusText}`;
+  } else if (error.status > HttpStatusCode.BadRequest) {
+    code = RegistrationDraftErrorCode.ServerError;
+    message = error.message || `Response failed with ${error.status} - ${error.statusText}`;
+  } else {
+    code = RegistrationDraftErrorCode.Unknown;
+    message = error.message || `Got an unknown http error: ${error.status} - ${error.statusText}`;
+  }
+
+  return { code, message };
+};

--- a/src/app/modules/shared/services/logging/sentry.service.ts
+++ b/src/app/modules/shared/services/logging/sentry.service.ts
@@ -9,6 +9,10 @@ import { LoggingService } from './logging.service';
 import { LogLevel } from './log-level.model';
 import { FileLoggingService } from './file-logging.service';
 import { makeFetchTransport } from '@sentry/browser';
+import { HttpErrorResponse } from '@angular/common/http';
+import { getHttpErrorResponseMessageAndCode } from 'src/app/core/helpers/http-error-response-helper';
+import { RegistrationDraftErrorCode } from 'src/app/core/services/draft/draft-model';
+import type { CaptureContext } from '@sentry/types';
 
 @Injectable({
   providedIn: 'root',
@@ -57,8 +61,8 @@ export class SentryService implements LoggingService {
     }
   }
 
-  log(message?: string, error?: Error, level?: LogLevel, tag?: string, optionalParams?: { [key: string]: any }) {
-    this.fileLoggingService.log(message, error, level, tag, optionalParams);
+  log(message?: string, error?: unknown, level?: LogLevel, tag?: string, optionalParams?: { [key: string]: any }) {
+    this.fileLoggingService.log(message, error as Error, level, tag, optionalParams);
     if (message && (level === LogLevel.Warning || level === LogLevel.Info || level === LogLevel.Error)) {
       const breadcrumb: Sentry.Breadcrumb = {
         category: tag,
@@ -73,7 +77,28 @@ export class SentryService implements LoggingService {
       Sentry.addBreadcrumb(breadcrumb);
     }
     if (error && level === LogLevel.Error) {
-      if (error) {
+      if (error instanceof HttpErrorResponse) {
+        // Angular HttpErrorResponses are not instance of Error and are just logged as
+        // "Object captured as exception with keys: error, headers, message, name, ok" in Sentry.
+        // See https://github.com/getsentry/sentry-javascript/issues/2292.
+        // Here we turn the HttpErrorResponse into useful info for Sentry.
+        const { message: errorMessage, code } = getHttpErrorResponseMessageAndCode(error);
+
+        const context: CaptureContext = {
+          level: code === RegistrationDraftErrorCode.NoNetworkOrTimedOut ? 'warning' : 'error',
+          extra: {
+            status: error.status,
+            statusText: error.statusText,
+            error: error.error,
+            message: error.message,
+            url: error.url,
+          },
+        };
+
+        Sentry.captureMessage(errorMessage, context);
+      } else {
+        // Assume instance of error, we can add additional if checks if we see that we more custom error objects are
+        // thrown and we are getting more "Object captured as exception with keys" events in Sentry
         Sentry.captureException(error);
       }
     }


### PR DESCRIPTION
Man kan kun logge faktiske Error objekter som arver fra "Error" med Sentry.captureException.
Angular HttpErrorResponse som kastes når en http request feiler arver ikke fra Error og fører derfor til at vi får masse
"Object captured as exception" events i Sentry. Denne endringen fikser problemet ved å sende infoen til sentry vha captureMessage i stedet.