### PR TITLE
Fix RO-2536: Do not freeze if trip is null++

### DIFF
--- a/src/app/core/services/trip-logger/trip-logger.service.spec.ts
+++ b/src/app/core/services/trip-logger/trip-logger.service.spec.ts
@@ -1,5 +1,64 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { isTripNotFoundError } from './trip-logger.service';
+import { isTripFromToday, isTripNotFoundError } from './trip-logger.service';
+import { LegacyTrip } from './legacy-trip.model';
+import moment from 'moment';
+
+describe('isTripFromToday', () => {
+  it('Should return true if trip is from today', () => {
+    const trip: LegacyTrip = {
+      id: 'legacytrip',
+      timestamp: moment().unix(),
+      request: {},
+    };
+
+    const result = isTripFromToday(trip);
+
+    expect(result).toBeTrue();
+  });
+
+  it('Should return false if trip is from yesterday', () => {
+    const trip: LegacyTrip = {
+      id: 'legacytrip',
+      timestamp: moment().subtract(1, 'day').unix(),
+      request: {},
+    };
+
+    const result = isTripFromToday(trip);
+    expect(result).toBeFalse();
+  });
+
+  it('Should return false if timestamp is zero', () => {
+    const trip: LegacyTrip = {
+      id: 'legacytrip',
+      timestamp: 0,
+      request: {},
+    };
+
+    const result = isTripFromToday(trip);
+    expect(result).toBeFalse();
+  });
+
+  it('Should return false if timestamp is null', () => {
+    const trip: LegacyTrip = {
+      id: 'legacytrip',
+      timestamp: null,
+      request: {},
+    };
+
+    const result = isTripFromToday(trip);
+    expect(result).toBeFalse();
+  });
+
+  it('Should return false if trip is null', () => {
+    const result = isTripFromToday(null);
+    expect(result).toBeFalse();
+  });
+
+  it('Should return false if trip is undefined', () => {
+    const result = isTripFromToday(undefined);
+    expect(result).toBeFalse();
+  });
+});
 
 describe('isTripNotFoundError', () => {
   it('should return true for HttpErrorResponse objects with trip error', () => {

--- a/src/app/core/services/trip-logger/trip-logger.service.ts
+++ b/src/app/core/services/trip-logger/trip-logger.service.ts
@@ -185,7 +185,7 @@ export class TripLoggerService {
       timeout(5000),
       catchError((err) => {
         if (isTripNotFoundError(err)) {
-          this.loggingService.debug('Trip not found, probably stopped by API at midnight', DEBUG_TAG, trip);
+          this.loggingService.debug('Trip not found, probably stopped by API at midnight', DEBUG_TAG, { trip });
           return of(true);
         }
 
@@ -199,7 +199,8 @@ export class TripLoggerService {
     this.getLegacyTripAsObservable()
       .pipe(
         take(1),
-        tap((trip) => this.loggingService.log('Stopping trip', null, LogLevel.Info, DEBUG_TAG, trip)),
+        tap((trip) => this.loggingService.log('Stopping trip', null, LogLevel.Info, DEBUG_TAG, { trip })),
+        // EMPTY makes the observable just complete if no trip is found in db - trip is falsy
         concatMap((trip) => (trip ? this.stopTripAndSucceedIfTripNotFound(trip) : EMPTY)),
         concatMap(() => this.deleteLegacyTripsFromDb()),
         concatMap(() => this.infoMessage(false))


### PR DESCRIPTION
Appen har egentlig mekanismer som skal fjerne turer som er en dag gamle eller mer.
I noen tilfeller kan likevel det at det finnes en pågående tur være cachet i appen.
Denne PRen tillater å stoppe en tur som ikke finnes lengre ved å fjerne et rxjs-filter som tidligere førte til at ting bare hang etter man trykket på stopp tur.
