### PR TITLE
Fix RO-2555: Oppdater filter og ext verdi ved endring av cause

### DIFF
--- a/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.html
@@ -20,7 +20,8 @@
       <app-kdv-select
         label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER"
         kdvKey="Snow_AvalCauseKDV"
-        [(value)]="avalancheEvalProblemCopy.AvalCauseTID"
+        [value]="avalancheEvalProblemCopy.AvalCauseTID"
+        (valueChange)="setAvalCauseTID($event)"
       ></app-kdv-select>
       <app-kdv-select
         label="REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER_DEPTH"

--- a/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.ts
@@ -23,12 +23,20 @@ export class AvalancheProblemModalPage implements OnInit, OnDestroy {
   isNew = false;
   avalancheExtKdvFilter: (id: number) => boolean;
 
+  setAvalCauseTID(value: AvalancheEvalProblem2EditModel['AvalCauseTID']) {
+    this.avalancheEvalProblemCopy.AvalCauseTID = value;
+    this.avalancheExtKdvFilter = this.getAvalancheExtKdvFilter();
+    if (!this.avalancheExtKdvFilter(this.avalancheEvalProblemCopy.AvalancheExtTID)) {
+      this.avalancheEvalProblemCopy.AvalancheExtTID = null;
+    }
+  }
+
   get noWeakLayers() {
     return this.avalancheEvalProblemCopy.AvalCauseTID === NO_WEAK_LAYER_KDV_VALUE;
   }
 
   set noWeakLayers(val: boolean) {
-    this.avalancheEvalProblemCopy.AvalCauseTID = val ? NO_WEAK_LAYER_KDV_VALUE : undefined;
+    this.setAvalCauseTID(val ? NO_WEAK_LAYER_KDV_VALUE : undefined);
   }
 
   avalancheProblemView: AvalancheProblemKeys[];
@@ -40,8 +48,6 @@ export class AvalancheProblemModalPage implements OnInit, OnDestroy {
   constructor(private modalController: ModalController, private kdvService: KdvService) {}
 
   ngOnInit() {
-    this.avalancheExtKdvFilter = this.internalAvalancheExtKdvFilter.bind(this);
-
     if (this.avalancheEvalProblem) {
       this.avalancheEvalProblemCopy = { ...this.avalancheEvalProblem };
     } else {
@@ -55,6 +61,7 @@ export class AvalancheProblemModalPage implements OnInit, OnDestroy {
     ]).subscribe(([snowCauseAttributesKdvElements, avalancheProblemView]) => {
       this.avalancheProblemView = avalancheProblemView as AvalancheProblemKeys[];
       this.avalancheCauseAttributes = this.getAvalancheCauseAttributes(snowCauseAttributesKdvElements);
+      this.avalancheExtKdvFilter = this.getAvalancheExtKdvFilter();
     });
   }
 
@@ -64,12 +71,12 @@ export class AvalancheProblemModalPage implements OnInit, OnDestroy {
     }
   }
 
-  internalAvalancheExtKdvFilter(id: number) {
+  private getAvalancheExtKdvFilter() {
     const avalCauseTid = this.avalancheEvalProblemCopy.AvalCauseTID || 0;
-    const views = this.avalancheProblemView
+    const extTids = this.avalancheProblemView
       .filter((v) => v.AvalCauseTID === avalCauseTid)
       .map((v) => v.AvalancheExtTID);
-    return views.indexOf(id) >= 0;
+    return (tid: AvalancheEvalProblem2EditModel['AvalancheExtTID']) => extTids.indexOf(tid) >= 0;
   }
 
   getAvalancheCauseAttributes(kdvElements: KdvElement[]): {

--- a/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem-modal/avalanche-problem-modal.page.ts
@@ -25,10 +25,9 @@ export class AvalancheProblemModalPage implements OnInit, OnDestroy {
 
   setAvalCauseTID(value: AvalancheEvalProblem2EditModel['AvalCauseTID']) {
     this.avalancheEvalProblemCopy.AvalCauseTID = value;
-    this.avalancheExtKdvFilter = this.getAvalancheExtKdvFilter();
-    if (!this.avalancheExtKdvFilter(this.avalancheEvalProblemCopy.AvalancheExtTID)) {
-      this.avalancheEvalProblemCopy.AvalancheExtTID = null;
-    }
+    // Filteret på AvalancheExt (skredtype) verdier baserer seg på hvilken AvalCause (skredproblem) som er valgt.
+    // Oppdater derfor filteret når AvalCause endrer seg.
+    this.updateAvalancheExtKdvFilter();
   }
 
   get noWeakLayers() {
@@ -61,7 +60,7 @@ export class AvalancheProblemModalPage implements OnInit, OnDestroy {
     ]).subscribe(([snowCauseAttributesKdvElements, avalancheProblemView]) => {
       this.avalancheProblemView = avalancheProblemView as AvalancheProblemKeys[];
       this.avalancheCauseAttributes = this.getAvalancheCauseAttributes(snowCauseAttributesKdvElements);
-      this.avalancheExtKdvFilter = this.getAvalancheExtKdvFilter();
+      this.updateAvalancheExtKdvFilter();
     });
   }
 
@@ -71,12 +70,19 @@ export class AvalancheProblemModalPage implements OnInit, OnDestroy {
     }
   }
 
-  private getAvalancheExtKdvFilter() {
+  private updateAvalancheExtKdvFilter() {
     const avalCauseTid = this.avalancheEvalProblemCopy.AvalCauseTID || 0;
     const extTids = this.avalancheProblemView
       .filter((v) => v.AvalCauseTID === avalCauseTid)
       .map((v) => v.AvalancheExtTID);
-    return (tid: AvalancheEvalProblem2EditModel['AvalancheExtTID']) => extTids.indexOf(tid) >= 0;
+
+    this.avalancheExtKdvFilter = (tid: AvalancheEvalProblem2EditModel['AvalancheExtTID']) => extTids.indexOf(tid) >= 0;
+
+    // Sjekk om filteret fortsatt sier at den AvalancheExt vi har valgt er gyldig.
+    // Hvis den ikke er gyldig, nullstill AvalancheExt-verdien.
+    if (!this.avalancheExtKdvFilter(this.avalancheEvalProblemCopy.AvalancheExtTID)) {
+      this.avalancheEvalProblemCopy.AvalancheExtTID = null;
+    }
   }
 
   getAvalancheCauseAttributes(kdvElements: KdvElement[]): {


### PR DESCRIPTION
Jeg har ikke klart å gjenskape feilen selv, så jeg er ikke 100% på at dette er riktig fiks.
Men jeg ser at vi sender en filterfunksjon til `<app-kdv-select>` som angular ikke skjønner at endrer seg basert på hvilket skredproblem som er valgt.
Med denne endringen vil angular skjønne at filterfunksjonen også endrer seg når vi endrer skredproblem.