### PR TITLE
RO-2600: Spesifisert hvilken versjon av Xcode vi vil bruke

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -148,6 +148,7 @@ steps:
     actions: 'build'
     configuration: 'Release'
     sdk: 'iphoneos'
+    xcodeVersion: '15'
     xcWorkspacePath: '$(system.defaultworkingdirectory)/ios/App/App.xcworkspace'
     scheme: 'App'
     packageApp: true

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -11,7 +11,7 @@ variables:
 - group: sentryProperties
 
 pool:
-  vmImage: 'macOS-latest'
+  vmImage: 'macos-13'
   demands: xcode
 
 steps:


### PR DESCRIPTION
Dette er for å fikse denne beskjeden vi har fått de siste gangene vi har distribuert ny versjon av appen:
_ITMS-90725: SDK version issue - This app was built with the iOS 16.2 SDK. Starting April 29, 2024, all iOS and iPadOS apps must be built with the iOS 17 SDK or later, included in Xcode 15 or later, in order to be uploaded to App Store Connect or submitted for distribution._

Vi har tidligere brukt VM-imaget 'macOS-latest', og iflg. dokumentasjonen peker denne fortsatt på macOS 12. Dette OS'et har ikke Xcode 15, vi må opp på macOS 13 for å kunne bruke Xcode 15:
https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software
https://developercommunity.visualstudio.com/t/Xcode-15--not-deployed-on-azure-devops/10542011?space=62&sort=newest

Dette får vi ikke sjekket om funker før vi faktisk prøver å lage en ny versjon av appen, så det blir spennede:)