### PR TITLE
RO-2610: Få beskjed om kartpakkene dine er utdatert

### DIFF
--- a/src/app/core/models/user-settings.model.ts
+++ b/src/app/core/models/user-settings.model.ts
@@ -33,5 +33,5 @@ export interface UserSetting {
   /**
    * Ikke mas om utdaterte kartpakker før dette tidspunktet er passert
    */
-  suppressOfflineMapUpdateNotificationUntil?: Date;
+  suppressOfflineMapUpdateNotificationUntil?: string; // i ISO8601-format
 }

--- a/src/app/core/models/user-settings.model.ts
+++ b/src/app/core/models/user-settings.model.ts
@@ -29,4 +29,9 @@ export interface UserSetting {
    * false/undefined = use simple snow obs schema
    */
   preferCompleteSnowObservations: boolean;
+
+  /**
+   * Ikke mas om utdaterte kartpakker før dette tidspunktet er passert
+   */
+  suppressOfflineMapUpdateNotificationUntil?: Date;
 }

--- a/src/app/core/services/offline-map/offline-map.model.ts
+++ b/src/app/core/services/offline-map/offline-map.model.ts
@@ -1,6 +1,7 @@
 import { CompoundPackage } from '../../../pages/offline-map/metadata.model';
 import { Progress } from './progress.model';
 
+/** Opplysninger om nedlasta kart på telefonen */
 export interface OfflineTilesMetadata {
   mapId: string;
   rootTile: {
@@ -11,6 +12,7 @@ export interface OfflineTilesMetadata {
   zMax: number;
   template: string;
   url?: string;
+  lastModified?: string;
 }
 
 export interface OfflinePackageMetadata {

--- a/src/app/core/services/offline-map/offline-map.service.spec.ts
+++ b/src/app/core/services/offline-map/offline-map.service.spec.ts
@@ -1,20 +1,26 @@
 import { Platform } from '@ionic/angular';
 import { Platforms } from '@ionic/core';
-import { of } from 'rxjs';
+import { ReplaySubject, of } from 'rxjs';
 import { TestLoggingService } from '../../../modules/shared/services/logging/test-logging.service';
 import { CompoundPackage } from '../../../pages/offline-map/metadata.model';
 import { OfflineMapService } from './offline-map.service';
 import { ProgressStep } from './progress-step.model';
+import { PackageIndexService } from './package-index.service';
 
 describe('OfflineMapService', () => {
   let offlineMapService: OfflineMapService;
   let platformMock: Platform;
+  let packageIndexServiceMock: PackageIndexService;
 
   beforeEach(() => {
     platformMock = jasmine.createSpyObj('Platform', {
       is: (platformName: Platforms) => false,
     });
-    offlineMapService = new OfflineMapService(new TestLoggingService(), null, null, platformMock, null, null, null);
+    const packages = new ReplaySubject<Map<string, CompoundPackage>>();
+    packageIndexServiceMock = jasmine.createSpyObj('PackageIndexService', {}, {
+      packages$: packages.asObservable(),
+    });
+    offlineMapService = new OfflineMapService(new TestLoggingService(), null, null, platformMock, null, null, null, packageIndexServiceMock);
   });
 
   it('progress value for 10% for download step of part 1 of 2 should be 0.10 / 4 =  0.025', () => {

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -105,7 +105,7 @@ export class OfflineMapService {
       });
 
     combineLatest([this.packageIndex.packages$, this.packages$])
-      .pipe(take(1))
+      .pipe(takeUntil(this.hasOutdatedPackages$))
       .subscribe(([packageIndex, downloadedPackages]) => {
         for (const downloadedPackage of downloadedPackages) {
           const serverPackage = packageIndex.get(downloadedPackage.name);

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -32,6 +32,7 @@ import { ProgressStep } from './progress-step.model';
 import { Progress } from './progress.model';
 import { PackageIndexService } from './package-index.service';
 import { isPackageOutdated } from './utils';
+import { OnReset } from 'src/app/modules/shared/interfaces/on-reset.interface';
 
 const DEBUG_TAG = 'OfflineMapService';
 const METADATA_FILE = 'metadata.json';
@@ -46,7 +47,7 @@ function arrayBufferToBase64(buffer: ArrayBuffer) {
 @Injectable({
   providedIn: 'root',
 })
-export class OfflineMapService {
+export class OfflineMapService implements OnReset {
   private packages: BehaviorSubject<OfflineMapPackage[]> = new BehaviorSubject([]);
   packages$: Observable<OfflineMapPackage[]> = this.packages.asObservable();
 
@@ -941,8 +942,7 @@ export class OfflineMapService {
       });
   }
 
-  // TODO: Kan vi bruke disse til noe?
-  // Dette blir kalt når brukeren trykker "resett app" i innstillinger, så her må alle kartpakker slettes fra disk..
-  // appOnReset(): void | Promise<any> {}
-  // appOnResetComplete(): void | Promise<any> {}
+  appOnReset(): void | Promise<any> {
+    this.hasOutdatedPackages$.next(false); // så vi slipper å få en ny advarsel hvis vi resetter appen
+  }
 }

--- a/src/app/core/services/offline-map/package-index.service.ts
+++ b/src/app/core/services/offline-map/package-index.service.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, map, shareReplay } from 'rxjs';
+import { CompoundPackage, CompoundPackageMetadata } from 'src/app/pages/offline-map/metadata.model';
+
+type PackageIndex = CompoundPackageMetadata[];
+
+const PACKAGE_INDEX_URL = 'https://offlinemap.blob.core.windows.net/metadata/packageIndex_v5.json';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PackageIndexService {
+  packages$: Observable<Map<string, CompoundPackage>>;
+
+  constructor(http: HttpClient) {
+    // Download package index from azure
+    this.packages$ = http.get<PackageIndex>(PACKAGE_INDEX_URL).pipe(
+      // Map downloaded package index to a packageName => package map
+      map((packageIndex) => {
+        const nameAndPkg: [string, CompoundPackage][] = packageIndex.map((p) => [
+          CompoundPackage.GetNameFromXYZ(...p.xyz),
+          new CompoundPackage(p),
+        ]);
+        return new Map(nameAndPkg);
+      }),
+      shareReplay()
+    );
+  }
+}

--- a/src/app/core/services/offline-map/utils.spec.ts
+++ b/src/app/core/services/offline-map/utils.spec.ts
@@ -1,0 +1,105 @@
+import { CompoundPackage } from 'src/app/pages/offline-map/metadata.model';
+import { OfflineMapPackage, OfflineTilesMetadata } from './offline-map.model';
+import { isPackageOutdated } from './utils';
+
+describe('isPackageOutdated', () => {
+  const packageOnServer = new CompoundPackage({
+    bbox: [1, 2, 3, 4],
+    id: 'pakke-1',
+    xyz: [1, 2, 3],
+    sizeInMib: 1.0,
+    maps: [
+      {
+        name: '1',
+        lastModified: '2021-01-01T00:00:01Z',
+        urls: [],
+        sizeInMib: 0,
+      },
+      {
+        name: '2',
+        lastModified: '2021-01-03T00:00:01Z',
+        urls: [],
+        sizeInMib: 0,
+      },
+    ]
+  });
+
+  it('burde returnere true hvis pakka på server er nyere enn nedlasta pakke', () => {
+    const outdatedDownloadedPackage: OfflineMapPackage = {
+      name: 'utdatert-nedlasta-pakke',
+      maps: {
+        '1': {
+          mapId: '1',
+          rootTile: { z: 1, x: 2, y: 3 },
+          zMax: 4,
+          template: '1-2-3',
+          lastModified: '2021-01-01T00:00:01Z',
+        },
+        '2': {
+          mapId: '2',
+          rootTile: { z: 1, x: 2, y: 3 },
+          zMax: 4,
+          template: '1-2-3',
+          lastModified: '2021-01-02T00:00:01Z',
+        },
+      }
+    };
+    expect(isPackageOutdated(outdatedDownloadedPackage, packageOnServer)).toBe(true);
+  });
+
+  it('burde returnere true hvis nedlastet kartpakke mangler produksjonsdato (dvs. at den er produsert før vi innførte produksjonsdato)', () => {
+    const mapWithoutLastModified: OfflineTilesMetadata = {
+      mapId: '1',
+      rootTile: { z: 1, x: 2, y: 3 },
+      zMax: 4,
+      template: '1-2-3',
+    };
+
+    const mapWithEmptyLastModified: OfflineTilesMetadata = {
+      mapId: '1',
+      rootTile: { z: 1, x: 2, y: 3 },
+      zMax: 4,
+      template: '1-2-3',
+      lastModified: ''
+    };
+
+    const oldDownloadedPackage: OfflineMapPackage = {
+      name: 'nedlastet-pakke-uten-produksjonsdato',
+      maps: {
+        '1': mapWithoutLastModified,
+        '2': mapWithEmptyLastModified
+      }
+    };
+
+    expect(isPackageOutdated(oldDownloadedPackage, packageOnServer)).toBe(true);
+
+    const downloadedPackageWithoutMaps: OfflineMapPackage = {
+      name: 'nedlastet-pakke-uten-produksjonsdato',
+      maps: {},
+    };
+    expect(isPackageOutdated(downloadedPackageWithoutMaps, packageOnServer)).toBe(true);
+  });
+
+  it('Burde returnere false hvis pakka på server ikke er nyere enn nedlasta pakke', () => {
+    const freshDownloadedPackage: OfflineMapPackage = {
+      name: 'fersk-nedlasta-pakke',
+      maps: {
+        '1': {
+          mapId: '1',
+          rootTile: { z: 1, x: 2, y: 3 },
+          zMax: 4,
+          template: '1-2-3',
+          lastModified: '2021-01-01T00:00:01Z',
+        },
+        '2': {
+          mapId: '1',
+          rootTile: { z: 1, x: 2, y: 3 },
+          zMax: 4,
+          template: '1-2-3',
+          lastModified: '2021-01-03T00:00:01Z'
+        },
+      },
+    }
+    expect(isPackageOutdated(freshDownloadedPackage, packageOnServer)).toBe(false);
+  });
+});

--- a/src/app/core/services/offline-map/utils.ts
+++ b/src/app/core/services/offline-map/utils.ts
@@ -1,0 +1,9 @@
+import { CompoundPackage } from 'src/app/pages/offline-map/metadata.model';
+import { OfflineMapPackage } from './offline-map.model';
+
+// Add test
+export function isPackageOutdated(downloadedPackage: OfflineMapPackage, packageOnServer: CompoundPackage) {
+  const downloadedPackageUpdateDate = downloadedPackage.compoundPackageMetadata.getLastModified();
+  const packageOnServerUpdateDate = packageOnServer.getLastModified();
+  return downloadedPackageUpdateDate < packageOnServerUpdateDate;
+}

--- a/src/app/core/services/offline-map/utils.ts
+++ b/src/app/core/services/offline-map/utils.ts
@@ -3,7 +3,12 @@ import { OfflineMapPackage } from './offline-map.model';
 
 // Add test
 export function isPackageOutdated(downloadedPackage: OfflineMapPackage, packageOnServer: CompoundPackage) {
-  const downloadedPackageUpdateDate = downloadedPackage.compoundPackageMetadata.getLastModified();
+  const downloadDate = getDownloadCompleteDate(downloadedPackage);
   const packageOnServerUpdateDate = packageOnServer.getLastModified();
-  return downloadedPackageUpdateDate < packageOnServerUpdateDate;
+  return downloadDate < packageOnServerUpdateDate;
+}
+
+export function getDownloadCompleteDate(downloadedPackage: OfflineMapPackage): Date {
+  const timeInMs = downloadedPackage.downloadComplete * 1000;
+  return new Date(timeInMs);
 }

--- a/src/app/core/services/offline-map/utils.ts
+++ b/src/app/core/services/offline-map/utils.ts
@@ -1,13 +1,30 @@
 import { CompoundPackage } from 'src/app/pages/offline-map/metadata.model';
 import { OfflineMapPackage } from './offline-map.model';
+import moment from 'moment';
 
-// Add test
+/** Returnerer true om pakka som kan lastes ned nå er nyere enn den du allerede har lastet ned */
 export function isPackageOutdated(downloadedPackage: OfflineMapPackage, packageOnServer: CompoundPackage) {
-  const downloadDate = getDownloadCompleteDate(downloadedPackage);
+  const downloadedPackageUpdateDate = getProductionDate(downloadedPackage);
   const packageOnServerUpdateDate = packageOnServer.getLastModified();
-  return downloadDate < packageOnServerUpdateDate;
+  if (!downloadedPackageUpdateDate) {
+    return true;
+  }
+  return downloadedPackageUpdateDate < packageOnServerUpdateDate;
 }
 
+/** Gir deg produksjonsdato for angitt kartpakke, eller 01.01.1970 00:00 om produksjonsdato mangler */
+export function getProductionDate(downloadedPackage: OfflineMapPackage): Date {
+  let latestDate = moment(0);
+  const maps = Object.values(downloadedPackage.maps);
+  for (const map of maps) {
+    if (map.lastModified) {
+      latestDate = moment.max(latestDate, moment(map.lastModified));
+    }
+  }
+  return latestDate.toDate();
+}
+
+/** Gir deg tidspunktet for når pakka ble lastet ned */
 export function getDownloadCompleteDate(downloadedPackage: OfflineMapPackage): Date {
   const timeInMs = downloadedPackage.downloadComplete * 1000;
   return new Date(timeInMs);

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -180,7 +180,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
 
     this.offlineMapUpdateNotificationNotSuppressed$ = this.userSetting$.pipe(
       map((userSetting) => userSetting.suppressOfflineMapUpdateNotificationUntil),
-      map((date) => date == null || date < new Date()),
+      map((date) => date == null || new Date(date) < new Date()),
       distinctUntilChanged(),
       shareReplay(1)
     );
@@ -372,7 +372,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  appOnReset() { }
+  appOnReset() {}
 
   appOnResetComplete() {
     this.loggingService.debug('App reset complete. Re-init observables.', DEBUG_TAG);

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -75,6 +75,9 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
   public readonly userSetting$: Observable<UserSetting>;
   public readonly daysBackForCurrentGeoHazard$: Observable<number>;
 
+  /** Hvis true er det på lov å mase om utdaterte kartpakker */
+  public readonly offlineMapUpdateNotificationNotSuppressed$: Observable<boolean>;
+
   private userSettingInMemory = new BehaviorSubject<UserSetting>(null);
   // private userSettingsReady = new BehaviorSubject(false);
 
@@ -172,6 +175,13 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
       }),
       distinctUntilChanged(),
       tap((val) => this.loggingService?.debug('daysBackForCurrentGeoHazard changed to: ', DEBUG_TAG, { val })),
+      shareReplay(1)
+    );
+
+    this.offlineMapUpdateNotificationNotSuppressed$ = this.userSetting$.pipe(
+      map((userSetting) => userSetting.suppressOfflineMapUpdateNotificationUntil),
+      map((date) => date == null || date < new Date()),
+      distinctUntilChanged(),
       shareReplay(1)
     );
   }
@@ -362,7 +372,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  appOnReset() {}
+  appOnReset() { }
 
   appOnResetComplete() {
     this.loggingService.debug('App reset complete. Re-init observables.', DEBUG_TAG);

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -13,6 +13,7 @@ import {
   concatMap,
   debounceTime,
   distinctUntilChanged,
+  exhaustMap,
   filter,
   map,
   startWith,
@@ -454,6 +455,45 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
     }
   }
 
+  private async createOutdatedMapPackagesAlert() {
+    const translations = await firstValueFrom(
+      this.translateService.get([
+        'OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE',
+        'OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS',
+        'ALERT.OK',
+      ])
+    );
+    const toast = await this.alertService.create({
+      cssClass: 'multiline-alert-checkbox', // in global.scss
+      message: translations['OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE'],
+      backdropDismiss: false,
+      inputs: [
+        {
+          type: 'checkbox',
+          label: translations['OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS'],
+          value: 'suppress',
+        },
+      ],
+      buttons: [
+        {
+          text: translations['ALERT.OK'],
+          role: 'confirm',
+        },
+      ],
+    });
+    await toast.present();
+    const result = await toast.onDidDismiss();
+    if (result.data.values.includes('suppress')) {
+      const oneMonthAhead = new Date();
+      oneMonthAhead.setDate(oneMonthAhead.getDate() + 30);
+      const currentSettings = await firstValueFrom(this.userSettingService.userSetting$);
+      this.userSettingService.saveUserSettings({
+        ...currentSettings,
+        suppressOfflineMapUpdateNotificationUntil: oneMonthAhead.toISOString(),
+      });
+    }
+  }
+
   private async warnAboutOutdatedMapPackages() {
     if (Capacitor.isNativePlatform()) {
       // Vis advarsel om utdaterte kartpakker hvis aktuelt
@@ -469,46 +509,11 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
               hasOutdatedPackages &&
               !userSetting.showGeoSelectInfo && // Ikke vis mens bruker ser på coachmarks
               userSetting.completedStartWizard
-          )
+          ),
+          // exhaustMap ignores other values until the promise completes,
+          exhaustMap(() => this.createOutdatedMapPackagesAlert())
         )
-        .subscribe(async () => {
-          const translations = await firstValueFrom(
-            this.translateService.get([
-              'OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE',
-              'OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS',
-              'ALERT.OK',
-            ])
-          );
-          const toast = await this.alertService.create({
-            cssClass: 'multiline-alert-checkbox', // in global.scss
-            message: translations['OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE'],
-            backdropDismiss: false,
-            inputs: [
-              {
-                type: 'checkbox',
-                label: translations['OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS'],
-                value: 'suppress',
-              },
-            ],
-            buttons: [
-              {
-                text: translations['ALERT.OK'],
-                role: 'confirm',
-              },
-            ],
-          });
-          await toast.present();
-          const result = await toast.onDidDismiss();
-          if (result.data.values.includes('suppress')) {
-            const oneMonthAhead = new Date();
-            oneMonthAhead.setDate(oneMonthAhead.getDate() + 30);
-            const currentSettings = await firstValueFrom(this.userSettingService.userSetting$);
-            this.userSettingService.saveUserSettings({
-              ...currentSettings,
-              suppressOfflineMapUpdateNotificationUntil: oneMonthAhead.toISOString(),
-            });
-          }
-        });
+        .subscribe();
     }
   }
 }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -2,7 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { AfterViewChecked, Component, Inject, NgZone, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Capacitor } from '@capacitor/core';
-import { ToastController } from '@ionic/angular';
+import { AlertController, ToastController } from '@ionic/angular';
 import { TranslateService } from '@ngx-translate/core';
 import { Feature, Point } from 'geojson';
 import * as L from 'leaflet';
@@ -104,6 +104,7 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
     private loggingService: LoggingService,
     private mapService: MapService,
     private toastService: ToastController,
+    private alertService: AlertController,
     private translateService: TranslateService,
     private offlineMapService: OfflineMapService,
     @Inject(DOCUMENT) private document: Document
@@ -475,35 +476,38 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
             this.translateService.get([
               'OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE',
               'OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS',
-              'CLOSE',
+              'ALERT.OK',
             ])
           );
-          const toast = await this.toastService.create({
+          const toast = await this.alertService.create({
+            cssClass: 'multiline-alert-checkbox', // in global.scss
             message: translations['OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE'],
-            position: 'bottom',
-            cssClass: 'toast',
+            backdropDismiss: false,
+            inputs: [
+              {
+                type: 'checkbox',
+                label: translations['OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS'],
+                value: 'suppress',
+              },
+            ],
             buttons: [
               {
-                text: translations['OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS'],
-                role: 'suppress',
-                handler: async () => {
-                  // Lagrer at bruker ikke vil ha beskjed før om 30 dager
-                  const oneMonthAhead = new Date();
-                  oneMonthAhead.setDate(oneMonthAhead.getDate() + 30);
-                  const currentSettings = await firstValueFrom(this.userSettingService.userSetting$);
-                  this.userSettingService.saveUserSettings({
-                    ...currentSettings,
-                    suppressOfflineMapUpdateNotificationUntil: oneMonthAhead.toISOString(),
-                  });
-                },
-              },
-              {
-                text: translations['CLOSE'],
-                role: 'cancel',
+                text: translations['ALERT.OK'],
+                role: 'confirm',
               },
             ],
           });
           await toast.present();
+          const result = await toast.onDidDismiss();
+          if (result.data.values.includes('suppress')) {
+            const oneMonthAhead = new Date();
+            oneMonthAhead.setDate(oneMonthAhead.getDate() + 30);
+            const currentSettings = await firstValueFrom(this.userSettingService.userSetting$);
+            this.userSettingService.saveUserSettings({
+              ...currentSettings,
+              suppressOfflineMapUpdateNotificationUntil: oneMonthAhead.toISOString(),
+            });
+          }
         });
     }
   }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -456,39 +456,55 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
   private async warnAboutOutdatedMapPackages() {
     if (Capacitor.isNativePlatform()) {
       // Vis advarsel om utdaterte kartpakker hvis aktuelt
-      combineLatest([this.userSettingService.offlineMapUpdateNotificationNotSuppressed$, this.offlineMapService.hasOutdatedPackages$]).pipe(
-        filter(([notificationNotSuppressed, hasOutdatedPackages]) => notificationNotSuppressed && hasOutdatedPackages)
-      ).subscribe(async () => {
-        const translations = await firstValueFrom(this.translateService.get(['OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE', 'OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS', 'CLOSE']));
-        const toast = await this.toastService.create({
-          message: translations['OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE'],
-          position: 'bottom',
-          cssClass: 'toast',
-          buttons: [
-            {
-              text: translations['OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS'],
-              role: 'suppress',
-              handler: async () => {
-                // Lagrer at bruker ikke vil ha beskjed før om 30 dager
-                const oneMonthAhead = new Date();
-                oneMonthAhead.setDate(oneMonthAhead.getDate() + 30);
-
-                const currentSettings = await firstValueFrom(this.userSettingService.userSetting$);
-                this.userSettingService.saveUserSettings({
-                  ...currentSettings,
-                  suppressOfflineMapUpdateNotificationUntil: oneMonthAhead,
-                });
+      combineLatest([
+        this.userSettingService.offlineMapUpdateNotificationNotSuppressed$,
+        this.offlineMapService.hasOutdatedPackages$,
+        this.userSettingService.userSetting$,
+      ])
+        .pipe(
+          filter(
+            ([notificationNotSuppressed, hasOutdatedPackages, userSetting]) =>
+              notificationNotSuppressed &&
+              hasOutdatedPackages &&
+              !userSetting.showGeoSelectInfo && // Ikke vis mens bruker ser på coachmarks
+              userSetting.completedStartWizard
+          )
+        )
+        .subscribe(async () => {
+          const translations = await firstValueFrom(
+            this.translateService.get([
+              'OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE',
+              'OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS',
+              'CLOSE',
+            ])
+          );
+          const toast = await this.toastService.create({
+            message: translations['OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE'],
+            position: 'bottom',
+            cssClass: 'toast',
+            buttons: [
+              {
+                text: translations['OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS'],
+                role: 'suppress',
+                handler: async () => {
+                  // Lagrer at bruker ikke vil ha beskjed før om 30 dager
+                  const oneMonthAhead = new Date();
+                  oneMonthAhead.setDate(oneMonthAhead.getDate() + 30);
+                  const currentSettings = await firstValueFrom(this.userSettingService.userSetting$);
+                  this.userSettingService.saveUserSettings({
+                    ...currentSettings,
+                    suppressOfflineMapUpdateNotificationUntil: oneMonthAhead.toISOString(),
+                  });
+                },
               },
-            },
-            {
-              text: translations['CLOSE'],
-              role: 'cancel',
-            },
-          ],
+              {
+                text: translations['CLOSE'],
+                role: 'cancel',
+              },
+            ],
+          });
+          await toast.present();
         });
-        await toast.present();
-      }
-      )
     }
   }
 }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -46,6 +46,7 @@ import { LoggingService } from '../../modules/shared/services/logging/logging.se
 import { TabsService, TABS } from '../tabs/tabs.service';
 import { RegObsGeoJson } from './geojson';
 import { RegObsMarkerClusterLayer } from './markerCluster.layer';
+import { OfflineMapService } from 'src/app/core/services/offline-map/offline-map.service';
 
 const DEBUG_TAG = 'HomePage';
 
@@ -104,6 +105,7 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
     private mapService: MapService,
     private toastService: ToastController,
     private translateService: TranslateService,
+    private offlineMapService: OfflineMapService,
     @Inject(DOCUMENT) private document: Document
   ) {
     super(router, route);
@@ -138,6 +140,7 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
       })
     );
 
+    this.warnAboutOutdatedMapPackages();
     this.initSearch();
   }
 
@@ -447,6 +450,45 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
       this.mapCenterInfoHeight.next(height);
     } else {
       this.mapCenterInfoHeight.next(0);
+    }
+  }
+
+  private async warnAboutOutdatedMapPackages() {
+    if (Capacitor.isNativePlatform()) {
+      // Vis advarsel om utdaterte kartpakker hvis aktuelt
+      combineLatest([this.userSettingService.offlineMapUpdateNotificationNotSuppressed$, this.offlineMapService.hasOutdatedPackages$]).pipe(
+        filter(([notificationNotSuppressed, hasOutdatedPackages]) => notificationNotSuppressed && hasOutdatedPackages)
+      ).subscribe(async () => {
+        const translations = await firstValueFrom(this.translateService.get(['OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE', 'OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS', 'CLOSE']));
+        const toast = await this.toastService.create({
+          message: translations['OFFLINE_MAP.OUTDATED_PACKAGES.MESSAGE'],
+          position: 'bottom',
+          cssClass: 'toast',
+          buttons: [
+            {
+              text: translations['OFFLINE_MAP.OUTDATED_PACKAGES.SUPPRESS'],
+              role: 'suppress',
+              handler: async () => {
+                // Lagrer at bruker ikke vil ha beskjed før om 30 dager
+                const oneMonthAhead = new Date();
+                oneMonthAhead.setDate(oneMonthAhead.getDate() + 30);
+
+                const currentSettings = await firstValueFrom(this.userSettingService.userSetting$);
+                this.userSettingService.saveUserSettings({
+                  ...currentSettings,
+                  suppressOfflineMapUpdateNotificationUntil: oneMonthAhead,
+                });
+              },
+            },
+            {
+              text: translations['CLOSE'],
+              role: 'cancel',
+            },
+          ],
+        });
+        await toast.present();
+      }
+      )
     }
   }
 }

--- a/src/app/pages/offline-map/metadata.model.ts
+++ b/src/app/pages/offline-map/metadata.model.ts
@@ -3,6 +3,7 @@ import moment from 'moment';
 
 type XYZ = [number, number, number];
 
+/** Opplysninger om et offlinekart for et begrenset område */
 export interface PackageMetadata {
   name: string;
   lastModified: string; // in UTC
@@ -10,6 +11,7 @@ export interface PackageMetadata {
   sizeInMib: number;
 }
 
+/** Opplysninger om en sammensatt kartpakke. Består gjerne av både bakgrunnskart og hjelpekart (f.eks. svekket is) */
 export interface CompoundPackageMetadata {
   id: string;
   xyz: XYZ;
@@ -71,11 +73,15 @@ export class CompoundPackage {
     return CompoundPackage.GetNameFromXYZ(x, y, z);
   }
 
+  /** Returnerer produksjonstidspunkt for den nyeste pakka. Hvis produksjonstidspunkt mangler, returneres 01.01.1970 00:00 */
   getLastModified(): Date {
-    if (this.metadata.maps.length === 0) {
-      return null;
+    let latestDate = moment(0);
+    for (const map of this.metadata.maps) {
+      if (map.lastModified) {
+        latestDate = moment.max(latestDate, moment(map.lastModified));
+      }
     }
-    return moment.max(this.metadata.maps.map((p) => moment(p.lastModified))).toDate();
+    return latestDate.toDate();
   }
 
   getParts(): Part[] {

--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -50,6 +50,7 @@
           <ion-label>{{ item.name }}</ion-label>
           <ion-label>{{ humanReadableByteSize(item.size) }}</ion-label>
           <ion-label>{{ formatProgressIfDownloading(item) }}</ion-label>
+          <ion-icon slot="end" *ngIf="isPackageOutdated(item)" (click)="update(item, $event)" name="refresh"></ion-icon>
           <ion-icon slot="end" *ngIf="item.error" name="warning-outline"></ion-icon>
           <ion-icon
             slot="end"

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -11,6 +11,7 @@ import { CompoundPackage, CompoundPackageFeature } from './metadata.model';
 import { TranslateService } from '@ngx-translate/core';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 import { PackageIndexService } from 'src/app/core/services/offline-map/package-index.service';
+import { isPackageOutdated } from 'src/app/core/services/offline-map/utils';
 
 const filledTileOpacity = 0.8;
 const notFilledTileOpacity = 0.1;
@@ -269,7 +270,7 @@ export class OfflineMapPage extends NgDestoryBase {
           {
             text: translations['DIALOGS.DELETE'],
             handler: () => {
-              this.offlineMapService.removeMapPackageByName(map.name);
+              this.delete(map);
             },
           },
         ],
@@ -278,6 +279,25 @@ export class OfflineMapPage extends NgDestoryBase {
     } else {
       this.offlineMapService.cancelDownloadPackage(map);
     }
+  }
+
+  isPackageOutdated(offlinePackage: OfflineMapPackage): boolean {
+    if (offlinePackage.downloadComplete) {
+      const packageOnServer = this.packagesOnServer.get(offlinePackage.name);
+      return isPackageOutdated(offlinePackage, packageOnServer);
+    }
+    return false;
+  }
+
+  async update(map: OfflineMapPackage, event: Event) {
+    event.stopPropagation();
+    await this.delete(map);
+    const packageOnServer = this.packagesOnServer.get(map.name);
+    this.offlineMapService.downloadPackage(packageOnServer, false);
+  }
+
+  private async delete(map: OfflineMapPackage) {
+    this.offlineMapService.removeMapPackageByName(map.name);
   }
 
   isDownloaded(map: OfflineMapPackage): boolean {

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.html
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.html
@@ -45,7 +45,7 @@
           <span *ngIf="!!packageStatus.downloadComplete"
             >{{
               "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_DOWNLOADED_DATE"
-                | translate: { date: packageStatus.downloadComplete * 1000 | date: "short" }
+                | translate: { date: getDownloadCompleteDate(packageStatus) | date: "short" }
             }}
           </span>
           <span *ngIf="!packageStatus.downloadComplete">({{ getPercentage(packageStatus) + "%" }})</span>
@@ -81,7 +81,7 @@
         </ion-col>
       </ion-row>
       <ion-row class="buttons-container" *ngIf="packageStatus.downloadComplete">
-        <ion-col>
+        <ion-col *ngIf="isPackageOutdated">
           <!-- TODO: Vis hvis det finnes en nyere versjon -->
           <ion-button expand="block" (click)="update()">
             <ion-icon slot="start" name="refresh"></ion-icon>

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.html
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.html
@@ -70,14 +70,29 @@
       </ion-row>
       <ion-row class="buttons-container" *ngIf="packageStatus.error">
         <ion-col>
-          <ion-button expand="block" color="varsom-orange" (click)="startDownload()">{{
+          <ion-button expand="block" (click)="startDownload()">{{
             "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.TRY_AGAIN_BUTTON" | translate
           }}</ion-button>
         </ion-col>
-        <ion-col *ngIf="!!packageStatus.downloadComplete || packageStatus.error">
+        <ion-col>
           <ion-button (click)="delete()" expand="block" color="danger">{{
             "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DELETE_BUTTON" | translate
           }}</ion-button>
+        </ion-col>
+      </ion-row>
+      <ion-row class="buttons-container" *ngIf="packageStatus.downloadComplete">
+        <ion-col>
+          <!-- TODO: Vis hvis det finnes en nyere versjon -->
+          <ion-button expand="block" (click)="update()">
+            <ion-icon slot="start" name="refresh"></ion-icon>
+            {{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.UPDATE_BUTTON" | translate }}
+          </ion-button>
+        </ion-col>
+        <ion-col>
+          <ion-button (click)="delete()" expand="block" color="danger">
+            <ion-icon slot="start" name="trash"></ion-icon>
+            {{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DELETE_BUTTON" | translate }}
+          </ion-button>
         </ion-col>
       </ion-row>
     </div>
@@ -90,13 +105,9 @@
   </ion-row>
   <ion-row>
     <ion-col>
-      <ion-button
-        [disabled]="isCheckingAvailableDiskspace"
-        (click)="startDownload()"
-        expand="block"
-        color="varsom-orange"
-        >{{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DOWNLOAD_BUTTON" | translate }}</ion-button
-      >
+      <ion-button [disabled]="isCheckingAvailableDiskspace" (click)="startDownload()" expand="block">{{
+        "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DOWNLOAD_BUTTON" | translate
+      }}</ion-button>
     </ion-col>
   </ion-row>
 </ng-template>

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
@@ -7,6 +7,10 @@ import { Observable } from 'rxjs';
 import { OfflineMapPackage } from 'src/app/core/services/offline-map/offline-map.model';
 import { takeUntil, tap } from 'rxjs/operators';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
+import { getDownloadCompleteDate, isPackageOutdated } from 'src/app/core/services/offline-map/utils';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+
+const DEBUG_TAG = 'OfflinePackageModalComponent';
 
 /**
  * Shows detail info about a specific offline map package. From here you may download or delete the package.
@@ -25,20 +29,33 @@ export class OfflinePackageModalComponent extends NgDestoryBase implements OnIni
   center: number[];
   tileLayer: L.GeoJSON;
   isCheckingAvailableDiskspace: boolean;
-
+  isPackageOutdated: boolean;
   offlinePackageStatusThatTriggersChangeDetection$: Observable<OfflineMapPackage>;
 
   constructor(
     private modalController: ModalController,
     private offlineMapService: OfflineMapService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private logger: LoggingService
   ) {
     super();
+  }
+
+  getDownloadCompleteDate(downloadedPackage: OfflineMapPackage): Date {
+    return getDownloadCompleteDate(downloadedPackage);
   }
 
   ngOnInit(): void {
     this.isCheckingAvailableDiskspace = false;
     this.offlinePackageStatusThatTriggersChangeDetection$ = this.offlinePackageStatus$.pipe(
+      tap((packageStatus) => {
+        this.isPackageOutdated = isPackageOutdated(packageStatus, this.packageOnServer);
+        this.logger.debug('isPackageOutdated', DEBUG_TAG, {
+          isPackageOutdated: this.isPackageOutdated,
+          packageStatus,
+          packageOnServer: this.packageOnServer,
+        });
+      }),
       tap(() => this.cdr.detectChanges())
     );
     this.tileLayer = new L.GeoJSON(this.feature);

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
@@ -81,8 +81,13 @@ export class OfflinePackageModalComponent extends NgDestoryBase implements OnIni
     this.offlineMapService.cancelDownloadPackage(map);
   }
 
-  delete() {
+  async delete() {
     this.offlineMapService.removeMapPackageByName(this.packageOnServer.getName());
+  }
+
+  async update() {
+    await this.delete();
+    this.startDownload();
   }
 
   dismiss() {

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
@@ -9,6 +9,7 @@ import { takeUntil, tap } from 'rxjs/operators';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 import { getDownloadCompleteDate, isPackageOutdated } from 'src/app/core/services/offline-map/utils';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { filter } from 'rxjs/operators';
 
 const DEBUG_TAG = 'OfflinePackageModalComponent';
 
@@ -48,6 +49,7 @@ export class OfflinePackageModalComponent extends NgDestoryBase implements OnIni
   ngOnInit(): void {
     this.isCheckingAvailableDiskspace = false;
     this.offlinePackageStatusThatTriggersChangeDetection$ = this.offlinePackageStatus$.pipe(
+      filter((packageStatus) => packageStatus !== undefined), // Denne blir undefined etter vi har slettet pakken
       tap((packageStatus) => {
         this.isPackageOutdated = isPackageOutdated(packageStatus, this.packageOnServer);
         this.logger.debug('isPackageOutdated', DEBUG_TAG, {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -295,7 +295,8 @@
       "PACKAGE_PRODUCED_DATE": "Produced:",
       "PACKAGE_SIZE": "Size:",
       "PACKAGE_SIZE_VALUE_WITH_UNIT": "{{size}} MB",
-      "TRY_AGAIN_BUTTON": "Try again"
+      "TRY_AGAIN_BUTTON": "Try again",
+      "UPDATE_BUTTON": "Update"
     },
     "OFFLINE_MAP_PAGE_TITLE": "Offline map",
     "PACKAGE_COUNT_MULTIPLE": "{{packageCount}} packages",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -299,6 +299,10 @@
       "UPDATE_BUTTON": "Update"
     },
     "OFFLINE_MAP_PAGE_TITLE": "Offline map",
+    "OUTDATED_PACKAGES": {
+      "MESSAGE": "You have outdated offline maps. Please update them get the latest maps.",
+      "SUPPRESS": "Remind me in 30 days"
+    },
     "PACKAGE_COUNT_MULTIPLE": "{{packageCount}} packages",
     "PACKAGE_COUNT_SINGLE": "{{packageCount}} package",
     "SPACE_AVAILABLE": "{{spaceAvailable}} free",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -290,12 +290,13 @@
       "DELETE_BUTTON": "Slett",
       "DOWNLOAD_BUTTON": "Last ned",
       "HEADER": "Kartpakke {{name}}",
-      "PACKAGE_DOWNLOADED_DATE": "Lasted ned {{date}}",
+      "PACKAGE_DOWNLOADED_DATE": "Lastet ned {{date}}",
       "PACKAGE_DOWNLOAD_STATUS": "Status:",
       "PACKAGE_PRODUCED_DATE": "Produsert:",
       "PACKAGE_SIZE": "Størrelse:",
       "PACKAGE_SIZE_VALUE_WITH_UNIT": "{{size}} MB",
-      "TRY_AGAIN_BUTTON": "Prøv på nytt"
+      "TRY_AGAIN_BUTTON": "Prøv på nytt",
+      "UPDATE_BUTTON": "Oppdater"
     },
     "OFFLINE_MAP_PAGE_TITLE": "Offlinekart",
     "PACKAGE_COUNT_MULTIPLE": "{{packageCount}} pakker",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -299,6 +299,10 @@
       "UPDATE_BUTTON": "Oppdater"
     },
     "OFFLINE_MAP_PAGE_TITLE": "Offlinekart",
+    "OUTDATED_PACKAGES": {
+      "MESSAGE": "Du har utdaterte offlinekart. Gå til offlinekart i menyen for å få de siste kartene.",
+      "SUPPRESS": "Ikke vis dette igjen før om en måned"
+    },
     "PACKAGE_COUNT_MULTIPLE": "{{packageCount}} pakker",
     "PACKAGE_COUNT_SINGLE": "{{packageCount}} pakke",
     "SPACE_AVAILABLE": "{{spaceAvailable}} ledig",

--- a/src/global.scss
+++ b/src/global.scss
@@ -836,3 +836,16 @@ ion-modal.modal-fullscreen::part(content) {
 ion-toast.sync-toast {
   --ion-safe-area-bottom: 64px;
 }
+
+// For å tillate at høyden på label til checkbox i alert
+// som lages i home.page.ts warnAboutOutdatedMapPackages blir riktig
+.multiline-alert-checkbox {
+  .alert-checkbox-label {
+    white-space: unset;
+  }
+
+  button.alert-tappable {
+    height: fit-content;
+    contain: content;
+  }
+}


### PR DESCRIPTION
Har testet på Android og logikk for visning av oppdateringsknapp og selve oppdateringsfunksjonen ser ut til å virke bra:

- Kartpakker som _ikke_ inneholder lastModified i metadatafila blir behandlet som utdaterte pakker
- Kartpakker som _inneholder_ lastModified i metadatafila blir _ikke_ behandlet som utdaterte pakker. Det gjenstår å teste om selve datosjekken virker, men da trenger vi å ha lastet ned en kartpakke med en lastModified i metadatafila som er eldre enn det som ligger på server.

Jeg synes det er forvirrende at vi har forskjellige metadata-strukturer for nedlasta kartpakker og pakkene på server. Det er vanskelig å skjønne hva som brukes hvor. Dette kan kanskje løses med navngiving og dokumentasjon?
Jeg fant ingen god felles måte å implementere getLastModified() på for både pakker på server og nedlasta pakker, derfor har vi nå to like implementasjoner.

Har også laget en oppdateringsknapp i lista over nedlasta pakker. Denne funker, men den skyver på kolonne 2 når den dukker opp. Har ikke funnet noen gode løsninger på dette foreløpig:

![image](https://github.com/NVE/regObs4/assets/71138449/e90b1595-1742-4e25-a0a5-8a93cb903f97)

**Har forsøkt å lage en melding om utdaterte kartpakker ved oppstart i home.page, men det vises ingen melding. Så her trengs det feilsøking.**
