### PR TITLE
RO-2612: Har gjort et forsøk på å vise flomsonekart fra ny karttjeneste

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "cordova-plugin-device": "^2.0.3",
         "cordova-sqlite-storage": "^6.0.0",
         "core-js": "^3.17.1",
+        "esri-leaflet": "^3.0.12",
         "fast-deep-equal": "^3.1.3",
         "globalthis": "^1.0.2",
         "ionic-appauth": "^2.0.0",
@@ -5364,6 +5365,19 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@terraformer/arcgis": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.1.2.tgz",
+      "integrity": "sha512-IvdfqehcNAUtKU1OFMKwPT8EvdKlVFZ7q7ZKzkIF8XzYZIVsZLuXuOS1UBdRh5u/o+X5Gax7jiZhD8U/4TV+Jw==",
+      "dependencies": {
+        "@terraformer/common": "^2.1.2"
+      }
+    },
+    "node_modules/@terraformer/common": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@terraformer/common/-/common-2.1.2.tgz",
+      "integrity": "sha512-cwPdTFzIpekZhZRrgDEkqLKNPoqbyCBQHiemaovnGIeUx0Pl336MY/eCxzJ5zXkrQLVo9zPalq/vYW5HnyKevQ=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -12692,6 +12706,18 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/esri-leaflet": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.12.tgz",
+      "integrity": "sha512-Yi7oH/mK4quOlCe920yuEYvUk0BjJRjmmE78ReAdJT5EbibW5wJoT9DtvG3JEJD22mQ0oF1LhcfL0Wb5jRhDAQ==",
+      "dependencies": {
+        "@terraformer/arcgis": "^2.1.0",
+        "tiny-binary-search": "^1.0.3"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.0.0"
       }
     },
     "node_modules/estraverse": {
@@ -24164,6 +24190,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/tiny-binary-search": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz",
+      "integrity": "sha512-STSHX/L5nI9WTLv6wrzJbAPbO7OIISX83KFBh2GVbX1Uz/vgZOU/ANn/8iV6t35yMTpoPzzO+3OQid3mifE0CA=="
     },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "cordova-plugin-device": "^2.0.3",
     "cordova-sqlite-storage": "^6.0.0",
     "core-js": "^3.17.1",
+    "esri-leaflet": "^3.0.12",
     "fast-deep-equal": "^3.1.3",
     "globalthis": "^1.0.2",
     "ionic-appauth": "^2.0.0",

--- a/src/app/core/models/support-tile.model.ts
+++ b/src/app/core/models/support-tile.model.ts
@@ -5,6 +5,8 @@ export interface SupportTile extends SubTile {
   opacity: L.TileLayerOptions['opacity'];
   geoHazardId: GeoHazard;
   subTile?: SubTile;
+  mapServerType?: 'wmts' | 'wms';
+  wmsLayers?: number[];
 }
 
 export interface SubTile extends SubTileStore {

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -286,6 +286,8 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
             ...tile.subTile,
             opacity: tile.opacity,
             geoHazardId: tile.geoHazardId,
+            mapServerType: tile.mapServerType,
+            wmsLayers: tile.wmsLayers,
           });
           delete tile.subTile;
         });
@@ -362,7 +364,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  appOnReset() {}
+  appOnReset() { }
 
   appOnResetComplete() {
     this.loggingService.debug('App reset complete. Re-init observables.', DEBUG_TAG);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -328,7 +328,7 @@ export const settings: ISettings = {
         {
           name: 'floodzoones',
           description: 'FLOOD_ZONES_MAP_DESCRIPTION',
-          url: 'https://gis3.nve.no/arcgis/rest/services/wmts/Flomsoner1/MapServer/tile/{z}/{y}/{x}',
+          url: 'https://nve.geodataonline.no/arcgis/rest/services/Flomsoner2/MapServer',
           enabled: true,
           checked: true,
           opacity: 0.5,
@@ -342,6 +342,8 @@ export const settings: ISettings = {
             [57.136239319177434, -0.17578125],
           ],
           maxNativeZoom: 17,
+          mapServerType: 'wms',
+          wmsLayers: [13, 14, 16, 17, 18, 19, 21]
         },
         {
           name: 'weakenedice',


### PR DESCRIPTION
Karttjenesten som vi bruker i Varsom-appen og på beta.regobs.no for å vise flomsonekartet, "Flomsoner1" på gis3 finnes ikke lengre, derfor vises ikke noe flomsonekart.

Jeg har funnet to karttjenester i skyen som inneholder data om flomsoner:
https://nve.geodataonline.no/arcgis/rest/services/Flomsoner1/mapserver
https://nve.geodataonline.no/arcgis/rest/services/Flomsoner2/mapServer

Det ser ut som https://temakart.nve.no/tema/flomsone bruker "Flomsoner2", derfor har jeg forsøkt å bruke dette.

Siden de nye karttjenestene i skyen ikke støtter WMTS, slik den gamle tjenesten gjorde, måtte jeg ta i bruk et nytt bibliotek, esri-leaflet, for å kunne vise kartet.

Jeg har tatt med de samme kartlagene som vi hadde før (13, 14, 16, 17, 18, 19, 21), men tegnforklaringa i appen stemmer ikke med det nye kartet. Det virker som karttjenesten er laget for å vise ett lag om gangen, og dette er ikke like enkelt å få til i Varsom-appen. 
Et annet problem er at det tar veldig lang tid å få opp kartet. Jeg har ikke testet, men det er mulig det går kjappere om vi kutter ut noen kartlag.

Jeg foreslår at noen som har greie på disse kartene tester det og tar stilling til:

- [ ] Hvilken karttjeneste skal vi bruke?
- [ ] Hvilke kartlag skal vi ha med?
- [ ] Hvilke farger skal vi bruke på de forskjellige kartlagene?