### PR TITLE
Skjuler grønn farge i tegnforklaringa for bratthetskart med utløp i Norge

### DIFF
--- a/src/app/modules/side-menu/components/support-tiles-menu/legends/steepness-common-legend/steepness-common-legend.component.html
+++ b/src/app/modules/side-menu/components/support-tiles-menu/legends/steepness-common-legend/steepness-common-legend.component.html
@@ -1,6 +1,6 @@
 <p>{{ "SUPPORT_MAP.STEEPNESS_COLOR_INFO" | translate }}</p>
 <ion-grid>
-  <ion-row>
+  <ion-row *ngIf="show27to30">
     <ion-col size="1.5" class="ion-no-padding">
       <img
         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAADpJREFUOI1jYaAyYKGlgf+pYB4jigtVSsg36U4PhKapl0cNHDVw1MBRA7EbCCuCyASM6AYyUmQcFAAA2w4Eu02XbecAAAAASUVORK5CYII="

--- a/src/app/modules/side-menu/components/support-tiles-menu/legends/steepness-common-legend/steepness-common-legend.component.ts
+++ b/src/app/modules/side-menu/components/support-tiles-menu/legends/steepness-common-legend/steepness-common-legend.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
 import { ModalController } from '@ionic/angular';
 import { SupportMapInfoPage } from '../../../../../map/pages/support-map-info/support-map-info.page';
 
@@ -9,6 +9,8 @@ import { SupportMapInfoPage } from '../../../../../map/pages/support-map-info/su
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SteepnessCommonLegendComponent {
+  @Input() show27to30 = true;
+
   constructor(private modalController: ModalController) {}
 
   async openAboutMapsModal() {

--- a/src/app/modules/side-menu/components/support-tiles-menu/legends/steepness-legend/steepness-legend.component.html
+++ b/src/app/modules/side-menu/components/support-tiles-menu/legends/steepness-legend/steepness-legend.component.html
@@ -30,5 +30,6 @@
     <p [innerHTML]="'SUPPORT_MAP.STEEPNESS_OFFLINE_DISCLAMER' | translate"></p>
     <br />
   </ng-container>
+  <!-- Bratthetskart MED utløpssoner markerer ikke høyde 27-30 med grønn farge -->
+  <app-steepness-common-legend [show27to30]="!isOutletsActive(supportTiles)"></app-steepness-common-legend>
 </ng-container>
-<app-steepness-common-legend [show27to30]="false"></app-steepness-common-legend>

--- a/src/app/modules/side-menu/components/support-tiles-menu/legends/steepness-legend/steepness-legend.component.html
+++ b/src/app/modules/side-menu/components/support-tiles-menu/legends/steepness-legend/steepness-legend.component.html
@@ -31,4 +31,4 @@
     <br />
   </ng-container>
 </ng-container>
-<app-steepness-common-legend></app-steepness-common-legend>
+<app-steepness-common-legend [show27to30]="false"></app-steepness-common-legend>


### PR DESCRIPTION
Nå har vi tatt bort grønn farge i tegnforklaringa for bratthetskart med utløp i Norge, siden denne fargen ikke lengre brukes i bratthetskart med utløp.
Grønland har fortsatt grønn farge, så der må vi ha det med i tegnforklaringa.

Siden vi bruker en felles komponent for å vise tegnforklaring for Grønland og Norge, valgte jeg å løse det med en parameter til komponenten.
Dette bør vi sikkert forenkle hvis Grønland og Norge får et felles kartlag for bratthet etterhvert.
Sånn ser det ut nå:

![image](https://github.com/NVE/regObs4/assets/71138449/362c7148-e7d3-46b5-bcb8-789689bf0aa3)


