### PR TITLE
Legg til test-service for offline-map-page og fiks litt på visninga

### DIFF
--- a/src/app/app.providers.ts
+++ b/src/app/app.providers.ts
@@ -41,6 +41,7 @@ import { SearchService } from './modules/common-regobs-api';
 import { ConsoleLoggingService } from './modules/shared/services/logging/console-logging.service';
 import { LoggingService } from './modules/shared/services/logging/logging.service';
 import { SentryService } from './modules/shared/services/logging/sentry.service';
+import { OfflineMapTestService } from './core/services/offline-map/offline-map-test.service';
 
 export class DynamicLocaleId extends String {
   constructor(protected service: TranslateService) {
@@ -168,5 +169,9 @@ export const APP_PROVIDERS: Provider[] = [
   {
     provide: SearchService,
     useClass: isPlatform('hybrid') ? OfflineCapableSearchService : SearchService,
+  },
+  {
+    provide: OfflineMapService,
+    useClass: isPlatform('hybrid') ? OfflineMapService : OfflineMapTestService,
   },
 ];

--- a/src/app/core/services/offline-map/offline-map-test.service.ts
+++ b/src/app/core/services/offline-map/offline-map-test.service.ts
@@ -1,0 +1,151 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { OfflineMapPackage } from './offline-map.model';
+import { OfflineMapService } from './offline-map.service';
+import { ProgressStep } from './progress-step.model';
+
+const TEST_PACKAGES: OfflineMapPackage[] = [
+  {
+    name: '134-72-8',
+    // Lagres i "completeFile" på telefonen.
+    // completeFile inneholder kun totalt antall bytes
+    // for en kartpakke
+    size: 30_000_000,
+    // Leses fra stat mtime på "completeFile" på telefonen.
+    // Dette er dato i sekunder siden 1970
+    // 1635827773 = 2021-11-02T04:36:13.000Z (ca)
+    downloadComplete: 1635827773,
+
+    maps: {
+      statensKartverk: {
+        mapId: 'statensKartverk',
+        rootTile: { z: 8, x: 134, y: 72 },
+        zMax: 14,
+        template: '',
+        // lastModified: '2021-11-02T04:36:13.500Z',
+      },
+      'steepness-outlet': {
+        mapId: 'steepness-outlet',
+        rootTile: { z: 8, x: 134, y: 72 },
+        zMax: 14,
+        template: '',
+        // lastModified: '2021-11-02T04:36:13.500Z',
+      },
+    },
+  },
+  {
+    name: '134-73-8',
+    size: 32_000_000,
+    downloadComplete: 1645827773,
+
+    maps: {
+      statensKartverk: {
+        mapId: 'statensKartverk',
+        rootTile: { z: 8, x: 134, y: 73 },
+        zMax: 14,
+        template: '',
+        lastModified: '2024-04-06T04:36:13.500Z',
+      },
+      'steepness-outlet': {
+        mapId: 'steepness-outlet',
+        rootTile: { z: 8, x: 134, y: 73 },
+        zMax: 14,
+        template: '',
+        lastModified: '2024-04-06T04:36:13.500Z',
+      },
+    },
+  },
+];
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OfflineMapTestService extends OfflineMapService {
+  packages$: Observable<OfflineMapPackage[]> = new BehaviorSubject([
+    ...TEST_PACKAGES,
+    ...TEST_PACKAGES,
+    ...TEST_PACKAGES,
+    ...TEST_PACKAGES,
+  ]);
+
+  availableDiskspace = {
+    available: 500_000_000, // 500 MB
+    used: TEST_PACKAGES.reduce((acc, p) => acc + p.size, 0),
+  };
+
+  downloadAndUnzipProgress$: Observable<OfflineMapPackage[]> = new BehaviorSubject([
+    {
+      name: '134-74-8',
+      size: 203_456_000,
+      progress: {
+        percentage: 0.58,
+        step: ProgressStep.download,
+        description: 'Test...',
+      },
+      downloadStart: Date.now() / 1000,
+      maps: {
+        statensKartverk: {
+          mapId: 'statensKartverk',
+          rootTile: { z: 8, x: 134, y: 74 },
+          zMax: 14,
+          template: '',
+        },
+        'steepness-outlet': {
+          mapId: 'steepness-outlet',
+          rootTile: { z: 8, x: 134, y: 74 },
+          zMax: 14,
+          template: '',
+        },
+      },
+    },
+    {
+      name: '134-75-8',
+      size: 198_123_000,
+      progress: {
+        percentage: 0,
+        step: ProgressStep.pending,
+        description: 'In queue...',
+      },
+      downloadStart: Date.now() / 1000,
+      maps: {
+        statensKartverk: {
+          mapId: 'statensKartverk',
+          rootTile: { z: 8, x: 134, y: 75 },
+          zMax: 14,
+          template: '',
+        },
+        'steepness-outlet': {
+          mapId: 'steepness-outlet',
+          rootTile: { z: 8, x: 134, y: 75 },
+          zMax: 14,
+          template: '',
+        },
+      },
+    },
+    {
+      name: '134-76-8',
+      size: 198_123_000,
+      error: new Error('Test error'),
+      progress: {
+        percentage: 0.78,
+        step: ProgressStep.extractZip,
+        description: 'Pakker ut..',
+      },
+      downloadStart: Date.now() / 1000,
+      maps: {
+        statensKartverk: {
+          mapId: 'statensKartverk',
+          rootTile: { z: 8, x: 134, y: 76 },
+          zMax: 14,
+          template: '',
+        },
+        'steepness-outlet': {
+          mapId: 'steepness-outlet',
+          rootTile: { z: 8, x: 134, y: 76 },
+          zMax: 14,
+          template: '',
+        },
+      },
+    },
+  ]);
+}

--- a/src/app/core/services/offline-map/offline-map.model.ts
+++ b/src/app/core/services/offline-map/offline-map.model.ts
@@ -25,7 +25,7 @@ export interface OfflinePackageMetadata {
 
 export interface OfflineMapPackage extends OfflinePackageMetadata {
   name: string;
-  size?: number;
+  size?: number; // Size in bytes ? TODO: Rename to sizeInBytes if this really is in bytes
   progress?: Progress;
   downloadStart?: number; //in epoch seconds
   downloadComplete?: number; //in epoch seconds

--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -24,19 +24,22 @@
     ></app-map>
   </div>
 </ion-content>
-<ion-footer>
+<ion-footer *ngIf="packageTotals$ | async as packageTotals">
   <ion-list>
-    <ion-item *ngIf="packageTotals$ | async as packageTotals" (click)="expanded = !expanded" lines="full">
+    <ion-item (click)="expanded = !expanded" lines="full">
       <ion-label *ngIf="packageTotals.numPackages === 1" class="package-count"
         >{{ 'OFFLINE_MAP.PACKAGE_COUNT_SINGLE' | translate:{packageCount: packageTotals.numPackages} }}</ion-label
       >
       <ion-label *ngIf="packageTotals.numPackages !== 1" class="package-count"
         >{{ 'OFFLINE_MAP.PACKAGE_COUNT_MULTIPLE' | translate:{packageCount: packageTotals.numPackages} }}</ion-label
       >
+
       <ion-label class="packages-size">{{ packageTotals.spaceUsed }}</ion-label>
+
       <ion-label class="space-available"
         >({{ 'OFFLINE_MAP.SPACE_AVAILABLE' | translate:{spaceAvailable: getSpaceAvailable()} }})</ion-label
       >
+
       <ion-icon
         *ngIf="packageTotals.numPackages > 0"
         slot="end"
@@ -44,20 +47,38 @@
         class="expand-icon"
       ></ion-icon>
     </ion-item>
+    <ng-container *ngIf="nPackagesToUpdate$ | async as nPackagesToUpdate">
+      <ion-item *ngIf="nPackagesToUpdate" lines="full" color="warning" (click)="expanded = !expanded">
+        <ion-label>{{ 'OFFLINE_MAP.N_PACKAGES_TO_UPDATE' | translate:{n:nPackagesToUpdate} }} </ion-label>
+      </ion-item>
+    </ng-container>
     <div class="footer">
       <ng-container *ngIf="expanded && allPackages$ | async as items">
         <ion-item (click)="showPackageModalForPackage(item)" *ngFor="let item of items" lines="full">
+          <!-- Kolonne 1 -->
           <ion-label>{{ item.name }}</ion-label>
+
+          <!-- Kolonne 2 -->
           <ion-label>{{ humanReadableByteSize(item.size) }}</ion-label>
+
+          <!-- Kolonne 3 -->
           <ion-label>{{ formatProgressIfDownloading(item) }}</ion-label>
-          <ion-icon slot="end" *ngIf="isPackageOutdated(item)" (click)="update(item, $event)" name="refresh"></ion-icon>
-          <ion-icon slot="end" *ngIf="item.error" name="warning-outline"></ion-icon>
-          <ion-icon
-            slot="end"
-            *ngIf="!(item.error)"
-            (click)="cancelOrDelete(item, $event)"
-            name="trash-outline"
-          ></ion-icon>
+
+          <!-- Kolonne 4 -->
+          <div class="buttons" slot="end">
+            <div class="button" *ngIf="isPackageOutdated(item)" (click)="update(item, $event)">
+              <ion-icon name="refresh"></ion-icon>
+              <ion-label>{{ 'OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.UPDATE_BUTTON' | translate }}</ion-label>
+            </div>
+            <div class="button" *ngIf="item.error">
+              <ion-icon name="warning-outline"></ion-icon>
+              <ion-label>{{ 'OFFLINE_MAP.ERROR_ICON_LABEL' | translate }}</ion-label>
+            </div>
+            <div class="button" *ngIf="!(item.error)" (click)="cancelOrDelete(item, $event)">
+              <ion-icon name="trash-outline"></ion-icon>
+              <ion-label>{{ 'OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DELETE_BUTTON' | translate }}</ion-label>
+            </div>
+          </div>
         </ion-item>
       </ng-container>
     </div>

--- a/src/app/pages/offline-map/offline-map.page.scss
+++ b/src/app/pages/offline-map/offline-map.page.scss
@@ -45,3 +45,25 @@
 .expand-icon {
   color: var(--ion-text-color-heading);
 }
+
+.buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+  margin-right: 0;
+  line-height: 24px;
+  width: 72px;
+  font-size: 24px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+
+  .button {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    ion-label {
+      font-size: 14px;
+    }
+  }
+}

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -3,7 +3,7 @@ import { OfflineMapService } from '../../core/services/offline-map/offline-map.s
 import { OfflineMapPackage } from '../../core/services/offline-map/offline-map.model';
 import { HelperService } from '../../core/services/helpers/helper.service';
 import { AlertController, ModalController } from '@ionic/angular';
-import { BehaviorSubject, combineLatest, firstValueFrom, from, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, firstValueFrom, from, Observable, of, Subject } from 'rxjs';
 import { debounceTime, filter, map, switchMap, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 import * as L from 'leaflet';
 import { OfflinePackageModalComponent } from './offline-package-modal/offline-package-modal.component';
@@ -56,6 +56,8 @@ export class OfflineMapPage extends NgDestoryBase {
   featureMap = new Map<string, { feature: CompoundPackageFeature; layer: L.Layer }>();
   expanded = false; //show list of downloads if this is true
 
+  nPackagesToUpdate$ = new Subject<number>();
+
   constructor(
     private helperService: HelperService,
     private modalController: ModalController,
@@ -95,6 +97,16 @@ export class OfflineMapPage extends NgDestoryBase {
     );
   }
 
+  private checkPackagesToUpdate() {
+    let n = 0;
+    for (const p of this.installedPackages.values()) {
+      if (this.isPackageOutdated(p)) {
+        n++;
+      }
+    }
+    this.nPackagesToUpdate$.next(n);
+  }
+
   onMapReady(map: L.Map) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).LEAFLET_MAP = map;
@@ -126,6 +138,7 @@ export class OfflineMapPage extends NgDestoryBase {
         this.installedPackages = installedPackages;
         this.packagesOnServer = packageIndex;
         this.setStyleForPackages();
+        this.checkPackagesToUpdate();
       });
 
     this.downloadAndUnzipProgress$

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -299,7 +299,7 @@
       "TRY_AGAIN_BUTTON": "Try again",
       "UPDATE_BUTTON": "Update"
     },
-    "N_PACKAGES_TO_UPDATE": "{{n}} map packages should be updated",
+    "N_PACKAGES_TO_UPDATE": "{{n}} map package(s) should be updated",
     "OFFLINE_MAP_PAGE_TITLE": "Offline map",
     "OUTDATED_PACKAGES": {
       "HEADER": "Outdated offline maps",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -285,6 +285,7 @@
     "DELETE_PACKAGE_CONFIRM": "Delete this map package?",
     "DISKSPACE_ERROR_MESSAGE": "Not enough disk space available to store offline map package. Please free up some disk space and try again.",
     "DOWNLOAD_ERROR_MESSAGE": "Could not download map package. Make sure you have a stable internet connection.",
+    "ERROR_ICON_LABEL": "Error",
     "MAP_PACKAGE_DETAILS_PAGE": {
       "CANCEL_DOWNLOAD_BUTTON": "Cancel download",
       "DELETE_BUTTON": "Delete",
@@ -298,6 +299,7 @@
       "TRY_AGAIN_BUTTON": "Try again",
       "UPDATE_BUTTON": "Update"
     },
+    "N_PACKAGES_TO_UPDATE": "{{n}} map packages should be updated",
     "OFFLINE_MAP_PAGE_TITLE": "Offline map",
     "OUTDATED_PACKAGES": {
       "HEADER": "Outdated offline maps",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -285,6 +285,7 @@
     "DELETE_PACKAGE_CONFIRM": "Vil du slette denne kartpakka?",
     "DISKSPACE_ERROR_MESSAGE": "Beklager, du har ikke nok plass tilgjengelig på telefonen til å lagre kartpakken. Vennligst frigjør plass og prøv på nytt.",
     "DOWNLOAD_ERROR_MESSAGE": "Klarte ikke laste ned kartpakke. Pass på at du har stabil og god internett-kobling.",
+    "ERROR_ICON_LABEL": "Error",
     "MAP_PACKAGE_DETAILS_PAGE": {
       "CANCEL_DOWNLOAD_BUTTON": "Avbryt nedlasting",
       "DELETE_BUTTON": "Slett",
@@ -298,6 +299,7 @@
       "TRY_AGAIN_BUTTON": "Prøv på nytt",
       "UPDATE_BUTTON": "Oppdater"
     },
+    "N_PACKAGES_TO_UPDATE": "{{n}} kartpakker bør oppdateres",
     "OFFLINE_MAP_PAGE_TITLE": "Offlinekart",
     "OUTDATED_PACKAGES": {
       "HEADER": "Offlinekart er utdatert",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -285,7 +285,7 @@
     "DELETE_PACKAGE_CONFIRM": "Vil du slette denne kartpakka?",
     "DISKSPACE_ERROR_MESSAGE": "Beklager, du har ikke nok plass tilgjengelig på telefonen til å lagre kartpakken. Vennligst frigjør plass og prøv på nytt.",
     "DOWNLOAD_ERROR_MESSAGE": "Klarte ikke laste ned kartpakke. Pass på at du har stabil og god internett-kobling.",
-    "ERROR_ICON_LABEL": "Error",
+    "ERROR_ICON_LABEL": "Feil",
     "MAP_PACKAGE_DETAILS_PAGE": {
       "CANCEL_DOWNLOAD_BUTTON": "Avbryt nedlasting",
       "DELETE_BUTTON": "Slett",
@@ -299,7 +299,7 @@
       "TRY_AGAIN_BUTTON": "Prøv på nytt",
       "UPDATE_BUTTON": "Oppdater"
     },
-    "N_PACKAGES_TO_UPDATE": "{{n}} kartpakker bør oppdateres",
+    "N_PACKAGES_TO_UPDATE": "{{n}} kartpakke(r) bør oppdateres",
     "OFFLINE_MAP_PAGE_TITLE": "Offlinekart",
     "OUTDATED_PACKAGES": {
       "HEADER": "Offlinekart er utdatert",


### PR DESCRIPTION
- Legger til en test-service for offline-map.service. Foreløpig er den veldig begrensa, den gir oss bare noen testpakker for å kunne bruke listevisninga lettere. Kan sikkert legge til falsk nedlasting osv etter hvert om vi ønsker...
- Fikser litt på listevisninga for å lettere vise at man bør oppdatere kartpakker
- Legger til tekst på ikonene for å forklare hva som er oppdater-knappen