### PR TITLE
RO-2622: Fiks svekket is-kart

### DIFF
--- a/src/app/core/models/support-tile.model.ts
+++ b/src/app/core/models/support-tile.model.ts
@@ -13,6 +13,7 @@ export interface SubTile extends SubTileStore {
   availableOffline?: boolean;
   bounds: L.TileLayerOptions['bounds'];
   maxNativeZoom?: L.TileLayerOptions['maxNativeZoom'];
+  zoomOffset?: L.TileLayerOptions['zoomOffset'];
 }
 
 export interface SupportTileStore extends SubTileStore {

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -600,6 +600,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
           updateWhenIdle: true,
           minZoom: settings.map.tiles.minZoomSupportMaps,
           bounds: supportMap.bounds,
+          zoomOffset: supportMap.zoomOffset,
         };
 
         if (supportMap.maxNativeZoom) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -359,7 +359,10 @@ export const settings: ISettings = {
             [81.36128726057069, -0.17578125],
             [57.136239319177434, -0.17578125],
           ],
-          maxNativeZoom: 19,
+          // maxNativeZoom som om zoomOffset allerede var tatt med i beregningen.
+          // I dette tilfellet svarer karttjenesten med 500 for zoomnivå større enn 12.
+          maxNativeZoom: 17,
+          zoomOffset: -5,
         },
       ],
     },


### PR DESCRIPTION
Legger til støtte for zoomOffset - innstilling for støttekart, og bruker dette for å fikse svekket-is-kartet.