### PR TITLE
Fiks feil som gjorde at zoom ble satt til NaN for support maps

### DIFF
--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -600,7 +600,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
           updateWhenIdle: true,
           minZoom: settings.map.tiles.minZoomSupportMaps,
           bounds: supportMap.bounds,
-          zoomOffset: supportMap.zoomOffset,
+          zoomOffset: supportMap.zoomOffset || 0, // zoomOffset is not required, so set it to 0 if it is undefined
         };
 
         if (supportMap.maxNativeZoom) {


### PR DESCRIPTION
Dette fikser en bug som gjorde at zoom ble satt til "NaN" for alle støttekart hvor ikke zoomOffset var satt i settings.