### PR TITLE
RO-2629: Tilpasset innstillinger til slik karttjenesten for svekket is er nå

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -359,7 +359,7 @@ export const settings: ISettings = {
             [81.36128726057069, -0.17578125],
             [57.136239319177434, -0.17578125],
           ],
-          maxNativeZoom: 16,
+          maxNativeZoom: 17,
         },
       ],
     },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -359,10 +359,7 @@ export const settings: ISettings = {
             [81.36128726057069, -0.17578125],
             [57.136239319177434, -0.17578125],
           ],
-          // maxNativeZoom som om zoomOffset allerede var tatt med i beregningen.
-          // I dette tilfellet svarer karttjenesten med 500 for zoomnivå større enn 12.
-          maxNativeZoom: 17,
-          zoomOffset: -5,
+          maxNativeZoom: 16,
         },
       ],
     },


### PR DESCRIPTION
IGD har nå har gjort om wmts-tjenesten for svekket is igjen, så nå er den nesten slik den var for noen uker siden.
Tjenesten trenger ikke lengre zoomOffset, så det må vi skru av.
I praksis har jeg rullet tilbake innstillingene til slik de var før, men måtte justere maxNativeZoom. Fikk 404 på fliser på zoom 17 og mer, så jeg satte den til 16.
Jeg hører med IGD om det kommer flere endringer på karttjenesten.