### PR TITLE
Lagre kartutsnitt-info oftere

### DIFF
--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -407,8 +407,8 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       this.startInvalidateSizeMapTimer();
 
       fromEventPattern(
-        (handler) => this.map.on('resize moveend', handler),
-        (handler) => this.map.off('resize moveend', handler)
+        (handler) => this.map.on('resize moveend zoomend', handler),
+        (handler) => this.map.off('resize moveend zoomend', handler)
       )
         .pipe(
           takeUntil(this.ngDestroy$),

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -413,8 +413,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
         .pipe(
           takeUntil(this.ngDestroy$),
           filter(() => this.isActive.value),
-          debounceTime(200),
-          skip(1)
+          debounceTime(200)
         )
         .subscribe(() => {
           this.updateMapView();

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -92,7 +92,9 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() showObserverTrips = false;
 
   /**
-   * Update MapService.mapView$ when extent changes
+   * Update MapService.mapView$ when extent changes.
+   *
+   * NB: Changes to this input after map init are not reflected.
    */
   @Input() updateMapViewOnExtentChange = false;
 
@@ -297,7 +299,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     // Det virker som kartet noen ganger kan zoome til hele verden om vi kaller
-    // fitBounds uten noe tiemout først. Med en timeout fungerer det fint.
+    // fitBounds uten noe timeout først. Med en timeout fungerer det fint.
     timer(50)
       .pipe(takeUntil(this.ngDestroy$))
       .subscribe(() => {
@@ -406,18 +408,18 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     this.zone.runOutsideAngular(() => {
       this.startInvalidateSizeMapTimer();
 
-      fromEventPattern(
-        (handler) => this.map.on('resize moveend zoomend', handler),
-        (handler) => this.map.off('resize moveend zoomend', handler)
-      )
-        .pipe(
-          takeUntil(this.ngDestroy$),
-          filter(() => this.isActive.value),
-          debounceTime(200)
+      // this.updateMapViewOnExtentChange er en input, og kan i prinsippet endre seg.
+      // Tror ikke vi bruker dette i dag, men hvis vi starter med det, så bør denne if-sjekken fjernes..
+      if (this.updateMapViewOnExtentChange) {
+        fromEventPattern(
+          (handler) => this.map.on('resize moveend zoomend', handler),
+          (handler) => this.map.off('resize moveend zoomend', handler)
         )
-        .subscribe(() => {
-          this.updateMapView();
-        });
+          .pipe(takeUntil(this.ngDestroy$))
+          .subscribe(() => {
+            this.updateMapView();
+          });
+      }
     });
 
     if (isAndroidOrIos(this.platform)) {

--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -13,6 +13,7 @@ import {
   take,
   filter,
   startWith,
+  debounceTime,
 } from 'rxjs/operators';
 import { IMapViewAndArea } from './map-view-and-area.interface';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
@@ -222,6 +223,7 @@ export class MapService {
 
   private getMapViewThatHasRelevantChange(metersBuffer = 10) {
     return this.mapView$.pipe(
+      debounceTime(500), // Det må være rolig 500ms før den emiter nyeste verdi
       bufferWhen(() => this.triggerWhenMetersReached(metersBuffer)),
       switchMap((buffer) =>
         buffer.length > 0 && !!buffer[buffer.length - 1] ? of(buffer[buffer.length - 1]) : this.mapView$.pipe(take(1))

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -126,6 +126,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
   private locations: ObsLocationsResponseDtoV2[] = [];
   private ngDestroy$ = new Subject<void>();
   private mapView$: Observable<IMapView>;
+  initialZoom$: Observable<number>;
 
   isDesktop: boolean;
   spatialAccuracyOptions: SelectOption[] = [];
@@ -163,6 +164,11 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit(): Promise<void> {
+    this.initialZoom$ = this.mapService.mapView$.pipe(
+      take(1),
+      map((mapView) => (mapView?.zoom > INITIAL_ZOOM_MINIMUM ? mapView.zoom : INITIAL_ZOOM_MINIMUM))
+    );
+
     this.breakpointService.isDesktopView().subscribe((isDesktop) => {
       this.isDesktop = isDesktop;
     });
@@ -201,12 +207,6 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.ngDestroy$.next();
     this.ngDestroy$.complete();
-  }
-
-  get initialZoom$(): Observable<number> {
-    return this.mapService.mapView$.pipe(
-      map((mapView) => (mapView?.zoom > INITIAL_ZOOM_MINIMUM ? mapView.zoom : INITIAL_ZOOM_MINIMUM))
-    );
   }
 
   private getLocationsObservable(): Observable<ObsLocationsResponseDtoV2[]> {

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -40,7 +40,7 @@ export interface LocationTime {
   spatialAccuracy: number;
 }
 
-const INITIAL_ZOOM_MINIMUM = 15;
+const INITIAL_ZOOM_MINIMUM = 7;
 
 const defaultIcon = L.icon({
   iconUrl: 'leaflet/marker-icon.png',

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -41,7 +41,7 @@ export interface LocationTime {
   spatialAccuracy: number;
 }
 
-const INITIAL_ZOOM_MINIMUM = 7;
+const INITIAL_ZOOM_MINIMUM = 15;
 
 const defaultIcon = L.icon({
   iconUrl: 'leaflet/marker-icon.png',

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -32,6 +32,7 @@ import { ViewInfo } from '../../../map/services/map-search/view-info.model';
 import { MapService } from '../../../map/services/map/map.service';
 import { IPolygon } from '../../models/polygon';
 import { UtmSource } from '../../pages/obs-location/utm-source.enum';
+import { settings } from 'src/settings';
 
 export interface LocationTime {
   location: ObsLocationEditModel;
@@ -181,22 +182,16 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
     this.followMode = !this.locationMarker && !this.fromMarker;
     this.mapService.followMode = this.followMode;
     if (!this.locationMarker) {
+      let latLng: L.LatLngExpression = settings.map.unknownMapCenter;
       if (this.fromMarker) {
-        this.locationMarker = L.marker(this.fromMarker.getLatLng(), {
-          icon: locationMarkerIcon,
-        });
+        latLng = this.fromMarker.getLatLng();
       } else {
         const initialMapView = await firstValueFrom(this.mapService.mapView$);
         if (initialMapView) {
-          this.locationMarker = L.marker(initialMapView.center, {
-            icon: locationMarkerIcon,
-          });
-        } else {
-          this.locationMarker = L.marker(L.latLng(59.1, 10.3), {
-            icon: locationMarkerIcon,
-          });
+          latLng = initialMapView.center;
         }
       }
+      this.locationMarker = L.marker(latLng, { icon: locationMarkerIcon });
     }
     this.translateService.onLangChange.subscribe((params: LangChangeEvent) => {
       this.locale = params.lang;

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -311,7 +311,7 @@ export class SetLocationInMapComponent implements OnInit, OnDestroy {
       .subscribe((pos) => this.positionChange(pos));
 
     if (!this.followMode) {
-      this.map.setView(this.locationMarker.getLatLng(), INITIAL_ZOOM_MINIMUM);
+      this.map.setView(this.locationMarker.getLatLng());
     }
 
     this.initPolygons();


### PR DESCRIPTION
Forsøk på fiks for RO-2583, at kartet hopper til oslo eller sandefjord når man starter ny obs.

Jeg fikk gjenskapt et av tilfellene (men ikke at den hopper til sandefjord), ved å legge til kode som gjorde at gps-posisjonen min oppdaterte seg sjeldnere. Hvis jeg deretter startet registrering av ny obs innen 5 sek etter at appen startet fikk jeg posisjon i Oslo selv om gps-markøren min og opprinnelig utsatt var der hvor jeg var. 

La til `throttleTime(5000)` i denne koden i `geo-position.service.ts`:

```ts
get currentPosition$(): Observable<Position> {
  return this.currentPosition.pipe(
    filter((cp) => cp !== null),
    throttleTime(5000)
  );
}
```

Effekten av det er at det tar litt mer tid før kartet "beveger på seg" og `this.updateMapView();` kalles. På videoene som viser feilen ser det ut som kartet ikke hopper noen ting før ny registrering startes, pluss at det virka som map view ikke ble oppdatert så ofte som det burde blitt i loggene.

Når jeg tester på egen telefon begynner posisjonen min å hoppe litt rundt med en gang, derfor har ikke jeg fått feilen så ofte som Morten, og derfor trengte jeg å legge til `throttleTime`-koden over for å framprovosere feilen.

Som jeg skrev i den ene commit-meldingen så ble trolig `skip(1)` lagt til for å hindre at det ble fyrt av et ekstra søk til apiet under oppstart av applikasjonen. Tror det er bedre at vi håndterer det på en annen måte, feks i `search-criteria.service.ts` eller der hvor selve søket lages, i `home.page.ts`.