### PR TITLE
Always call getFallbackData if something fails in getDataObservale()

### DIFF
--- a/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
+++ b/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
@@ -88,16 +88,27 @@ export abstract class ApiSyncOfflineBaseService<T> {
    */
   private getDataObservable(): Observable<T> {
     return combineLatest([this.userSettingService.language$, this.userSettingService.appMode$]).pipe(
-      switchMap(([langKey, appMode]) =>
-        this.getOfflineDataAndReturnIfDataIsUpToDate(appMode, langKey).pipe(
-          take(1),
-          switchMap((updatedData) =>
-            updatedData != null
-              ? of(updatedData)
-              : this.getUpdatedDataAndSaveResultIfSuccessOrFallbackToAssetsFolder(appMode, langKey)
-          )
-        )
-      )
+      switchMap(([langKey, appMode]) => {
+        try {
+          return this.getOfflineDataAndReturnIfDataIsUpToDate(appMode, langKey).pipe(
+            take(1),
+            switchMap((updatedData) =>
+              updatedData != null
+                ? of(updatedData)
+                : this.getUpdatedDataAndSaveResultIfSuccessOrFallbackToAssetsFolder(appMode, langKey)
+            ),
+            // This handles errors inside the observable stream
+            catchError((err) => {
+              this.logger.error(err, this.getDebugTag(), 'Error in getDataObservable');
+              return this.getFallbackDataWithLogging(appMode, langKey);
+            })
+          );
+        } catch (error) {
+          // This handles errors thrown before the observable from getOfflineDataAndReturnIfDataIsUpToDate
+          // has been created properly
+          return this.getFallbackDataWithLogging(appMode, langKey);
+        }
+      })
     );
   }
 
@@ -202,6 +213,16 @@ export abstract class ApiSyncOfflineBaseService<T> {
   }
 
   /**
+   * Just a wrapper around this.getFallbackData with logging.
+   *
+   * this.getFallbackData is abstract and must be implemented by the child class.
+   */
+  private getFallbackDataWithLogging(appMode: AppMode, langKey: LangKey) {
+    this.logger.debug('Get fallback data', this.getDebugTag());
+    return this.getFallbackData(appMode, langKey);
+  }
+
+  /**
    * Get offline data or fallback to something if no offline data
    * @param appMode App mode
    * @param langKey Language
@@ -216,7 +237,7 @@ export abstract class ApiSyncOfflineBaseService<T> {
             LogLevel.Warning,
             this.getDebugTag()
           );
-          return this.getFallbackData(appMode, langKey);
+          return this.getFallbackDataWithLogging(appMode, langKey);
         }
         return of(val.data);
       })

--- a/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
+++ b/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
@@ -106,6 +106,7 @@ export abstract class ApiSyncOfflineBaseService<T> {
         } catch (error) {
           // This handles errors thrown before the observable from getOfflineDataAndReturnIfDataIsUpToDate
           // has been created properly
+          this.logger.error(error, this.getDebugTag(), 'Error in getDataObservable init');
           return this.getFallbackDataWithLogging(appMode, langKey);
         }
       })


### PR DESCRIPTION
Forsøk på fiks på RO-2645, det står litt mer om feilen der.

Jeg tror at fallback-data nå alltid skal bli brukt, uansett om rxdb eller noe annet feiler inne i observable-streamen eller når den lager getDataObservable.

Noe kan fortsatt feile når den henter appMode og langKey, men da feiler nok også veldig mye annet i appen...

Prøv gjerne å fremprovosere at den ikke får opp nedtrekksmenyer under testing.