### PR TITLE
Fix RO-2636: await delete before update

### DIFF
--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -166,15 +166,26 @@ export class OfflineMapService implements OnReset {
     packageMetadataCombined: CompoundPackage,
     checkAvailableDiskSpace = false
   ): Promise<void> {
+    const packageInfo = {
+      name: packageMetadataCombined.getName(),
+      xyz: packageMetadataCombined.getXYZ(),
+      size: packageMetadataCombined.getSizeInMiB(),
+      parts: packageMetadataCombined.getParts(),
+    };
+
+    this.loggingService.debug('downloadPackage', DEBUG_TAG, { packageInfo, checkAvailableDiskSpace });
+
     if (checkAvailableDiskSpace) {
       //TODO: Ask user to prefer saving to external SD card if available?
       const availableSpace = await this.checkAvailableDiskSpace(packageMetadataCombined);
       if (!availableSpace) {
+        this.loggingService.debug('Not enough disk space to save and extract package', DEBUG_TAG, { packageInfo });
         return;
       }
     }
 
     if (await this.isPermissionToSaveFilesDenied()) {
+      this.loggingService.debug('Permission to save files denied', DEBUG_TAG, { packageInfo });
       return;
     }
 
@@ -595,6 +606,7 @@ export class OfflineMapService implements OnReset {
   }
 
   async removeMapPackageByName(packageNameToRemove: string) {
+    this.loggingService.debug('Removing map package:', DEBUG_TAG, { packageNameToRemove });
     // Delete files
     const root = await this.getRootFileUrl();
     await this.deleteDirectory(root, packageNameToRemove);

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -12,6 +12,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 import { PackageIndexService } from 'src/app/core/services/offline-map/package-index.service';
 import { isPackageOutdated } from 'src/app/core/services/offline-map/utils';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 
 const filledTileOpacity = 0.8;
 const notFilledTileOpacity = 0.1;
@@ -34,6 +35,8 @@ interface PackageTotals {
   numPackages: number;
   spaceUsed: string;
 }
+
+const DEBUG_TAG = 'OfflineMapPage';
 
 @Component({
   selector: 'app-offline-map',
@@ -65,7 +68,8 @@ export class OfflineMapPage extends NgDestoryBase {
     private alertController: AlertController,
     private translateService: TranslateService,
     private packageIndex: PackageIndexService,
-    private zone: NgZone
+    private zone: NgZone,
+    private logger: LoggingService
   ) {
     super();
 
@@ -304,13 +308,15 @@ export class OfflineMapPage extends NgDestoryBase {
 
   async update(map: OfflineMapPackage, event: Event) {
     event.stopPropagation();
+    this.logger.debug('Update package', DEBUG_TAG, { name: map.name });
     await this.delete(map);
     const packageOnServer = this.packagesOnServer.get(map.name);
     this.offlineMapService.downloadPackage(packageOnServer, false);
   }
 
   private async delete(map: OfflineMapPackage) {
-    this.offlineMapService.removeMapPackageByName(map.name);
+    this.logger.debug('Delete package', DEBUG_TAG, { name: map.name });
+    await this.offlineMapService.removeMapPackageByName(map.name);
   }
 
   isDownloaded(map: OfflineMapPackage): boolean {


### PR DESCRIPTION
Legger til en endring på offline-kart-siden, der man trigge oppdatering av kartpakker fra.
Når man nå oppdaterer en kartpakke venter den på at sletting er ferdig før den starter nedlasting.
På iOS ble sletting ferdig etter at kartpakkene hadde blitt lagt i køen for nedlasting, det førte til at kartpakkene kun ble sletta og ikke lastet ned på nytt. Usikkert hvorfor dette ikke skjedde på android.

Legger også til en del ekstra logging knyttet til oppdatering av kartpakker.