### PR TITLE
RO-2655: Fiks av: "Status for kartpakke endres ikke etter sletting"

### DIFF
--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -18,7 +18,7 @@ import {
   Subject,
   Subscription,
 } from 'rxjs';
-import { exhaustMap, finalize, map, mergeMap, switchMap, take, takeUntil } from 'rxjs/operators';
+import { exhaustMap, finalize, map, mergeMap, switchMap, takeUntil } from 'rxjs/operators';
 import { CompoundPackage, Part } from 'src/app/pages/offline-map/metadata.model';
 import { DownloadAndUnzip } from 'src/download-and-unzip-plugin';
 import { LogLevel } from '../../../modules/shared/services/logging/log-level.model';
@@ -221,7 +221,7 @@ export class OfflineMapService implements OnReset {
   }
 
   private startDownloadNextItemInQueue() {
-    const nextInQueue = this.downloadAndUnzipProgress.value.filter((p) => p.progress.step === ProgressStep.pending)[0];
+    const nextInQueue = this.downloadAndUnzipProgress.value.filter((p) => p.progress?.step === ProgressStep.pending)[0];
     if (nextInQueue != null) {
       this.onProgress(nextInQueue, {
         step: ProgressStep.download,

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -3,7 +3,7 @@ import { OfflineMapService } from '../../core/services/offline-map/offline-map.s
 import { OfflineMapPackage } from '../../core/services/offline-map/offline-map.model';
 import { HelperService } from '../../core/services/helpers/helper.service';
 import { AlertController, ModalController } from '@ionic/angular';
-import { BehaviorSubject, combineLatest, firstValueFrom, from, Observable, of, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, firstValueFrom, from, Observable, Subject } from 'rxjs';
 import { debounceTime, filter, map, switchMap, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 import * as L from 'leaflet';
 import { OfflinePackageModalComponent } from './offline-package-modal/offline-package-modal.component';

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
@@ -9,7 +9,6 @@ import { takeUntil, tap } from 'rxjs/operators';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 import { getDownloadCompleteDate, isPackageOutdated } from 'src/app/core/services/offline-map/utils';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
-import { filter } from 'rxjs/operators';
 
 const DEBUG_TAG = 'OfflinePackageModalComponent';
 
@@ -49,14 +48,16 @@ export class OfflinePackageModalComponent extends NgDestoryBase implements OnIni
   ngOnInit(): void {
     this.isCheckingAvailableDiskspace = false;
     this.offlinePackageStatusThatTriggersChangeDetection$ = this.offlinePackageStatus$.pipe(
-      filter((packageStatus) => packageStatus !== undefined), // Denne blir undefined etter vi har slettet pakken
       tap((packageStatus) => {
-        this.isPackageOutdated = isPackageOutdated(packageStatus, this.packageOnServer);
-        this.logger.debug('isPackageOutdated', DEBUG_TAG, {
-          isPackageOutdated: this.isPackageOutdated,
-          packageStatus,
-          packageOnServer: this.packageOnServer,
-        });
+        if (packageStatus) {
+          //hvis pakken blir slettet, er packageStatus undefined
+          this.isPackageOutdated = isPackageOutdated(packageStatus, this.packageOnServer);
+          this.logger.debug('isPackageOutdated', DEBUG_TAG, {
+            isPackageOutdated: this.isPackageOutdated,
+            packageStatus,
+            packageOnServer: this.packageOnServer,
+          });
+        }
       }),
       tap(() => this.cdr.detectChanges())
     );


### PR DESCRIPTION
Status om slettede pakker må ikke filtreres vekk, da får vi ikke med oss at en pakke blir sletta.
En konsekvens av at vi slipper slettede pakker gjennom er at vi må ta høyde for at status på pakka kan være undefined.