### PR TITLE
Endret url til kartverket-wmts iht. gjeldende dok

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -133,7 +133,8 @@ export const settings: ISettings = {
         statensKartverk: {
           // Alternativ url (sånn bruker norgeskart.no dette):
           // url: 'https://cache.kartverket.no/topo/v1/wmts/1.0.0/?layer=topo&style=default&tilematrixset=googlemaps&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fpng&TileMatrix={z}&TileCol={x}&TileRow={y}',
-          url: 'https://cache.kartverket.no/topo/v1/wmts/1.0.0/default/googlemaps/{z}/{y}/{x}.png',
+          // Se https://cache.kartverket.no/ for dokumentasjon
+          url: 'https://cache.kartverket.no/v1/wmts/1.0.0/topo/default/webmercator/{z}/{y}/{x}.png',
           options: {
             zIndex: MapLayerZIndex.OnlineBackgroundLayer,
             bounds: [


### PR DESCRIPTION
Plutselig fikk vi 404 på alle fliser fra Kartverkets wmts-tjeneste.
Sjekket dokumentasjonen på https://cache.kartverket.no/ og justerte url'en til slik dokumentasjonen er nå.
Finner ingen tegn til at den gamle url'en vi brukte er bytta ut. Kanskje var det noe midlertidige greier?