### PR TITLE
RO-2174: Fikset direkte-linker til ny observasjon, som brukes av iskart

### DIFF
--- a/src/app/components/img-swiper/image-location.model.ts
+++ b/src/app/components/img-swiper/image-location.model.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 
 export interface ImageLocation {

--- a/src/app/core/helpers/leaflet/user-marker/user-marker.ts
+++ b/src/app/core/helpers/leaflet/user-marker/user-marker.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { Subscription } from 'rxjs';
 import { Position } from '@capacitor/geolocation';
 

--- a/src/app/core/models/support-tile.model.ts
+++ b/src/app/core/models/support-tile.model.ts
@@ -1,5 +1,5 @@
 import { GeoHazard } from 'src/app/modules/common-core/models';
-import * as L from 'leaflet';
+import L from 'leaflet';
 
 export interface SupportTile extends SubTile {
   opacity: L.TileLayerOptions['opacity'];

--- a/src/app/modules/map-image/map-image.component.ts
+++ b/src/app/modules/map-image/map-image.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, effect, input, untracked } from '@angular/core';
 import { booleanWithin, point } from '@turf/turf';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { NORWAY_BOUNDS } from 'src/app/core/helpers/leaflet/norway-bounds';
 import { SVALBARD_BOUNDS } from 'src/app/core/helpers/leaflet/svalbard-bounds';
 import { TopoMapLayer } from 'src/app/core/models/topo-map-layer.enum';

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.ts
@@ -19,14 +19,14 @@ import { HelperService } from 'src/app/core/services/helpers/helper.service';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 import { Position } from '@capacitor/geolocation';
 import { LocationName } from '../../services/map-search/location-name.model';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { ViewInfo } from '../../services/map-search/view-info.model';
 import { Capacitor } from '@capacitor/core';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { ExternalLinkService } from 'src/app/core/services/external-link/external-link.service';
 import { HttpClient, HttpRequest, HttpResponse } from '@angular/common/http';
 import { StrictHttpResponse } from 'src/app/modules/common-regobs-api/strict-http-response';
-import * as turf from '@turf/turf';
+import { booleanPointInPolygon } from '@turf/turf';
 import { NORWAY_BOUNDS } from 'src/app/core/helpers/leaflet/norway-bounds';
 import { NgIf, NgStyle, DecimalPipe } from '@angular/common';
 import { AbsPipe } from '../../../shared/pipes/abs.pipe';
@@ -138,7 +138,7 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
         debounceTime(1500),
         switchMap((newMapView) =>
           iif(
-            () => turf.booleanPointInPolygon([newMapView.center.lng, newMapView.center.lat], NORWAY_BOUNDS),
+            () => booleanPointInPolygon([newMapView.center.lng, newMapView.center.lat], NORWAY_BOUNDS),
             this.getLocationInfo$(newMapView.center),
             of(null)
           )

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -15,7 +15,7 @@ import {
 import { Capacitor } from '@capacitor/core';
 import { Position } from '@capacitor/geolocation';
 import { Platform } from '@ionic/angular/standalone';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { BehaviorSubject, combineLatest, fromEventPattern, race, Subject, timer } from 'rxjs';
 import { distinctUntilChanged, filter, take, takeUntil, withLatestFrom } from 'rxjs/operators';
 import { isAndroidOrIos } from 'src/app/core/helpers/ionic/platform-helper';

--- a/src/app/modules/map/core/classes/regobs-geohazard-marker.ts
+++ b/src/app/modules/map/core/classes/regobs-geohazard-marker.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 
 export class RegobsGeoHazardMarker extends L.DivIcon {

--- a/src/app/modules/map/core/classes/regobs-tile-layer.ts
+++ b/src/app/modules/map/core/classes/regobs-tile-layer.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { OfflineTilesRegistry } from 'src/app/core/services/offline-map/offline-tiles-registry';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { Polygon } from 'geojson';

--- a/src/app/modules/map/helpers/leaflet-cluser.helper.ts
+++ b/src/app/modules/map/helpers/leaflet-cluser.helper.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { settings } from '../../../../settings';
 import 'leaflet.markercluster';
 

--- a/src/app/modules/map/pages/modal-search/modal-search.page.ts
+++ b/src/app/modules/map/pages/modal-search/modal-search.page.ts
@@ -17,7 +17,7 @@ import { MapSearchService } from '../../services/map-search/map-search.service';
 import { MapSearchResponse } from '../../services/map-search/map-search-response.model';
 import { UntypedFormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { NumberHelper } from '../../../../core/helpers/number-helper';
 import { NgIf, NgFor } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -61,6 +61,7 @@ export class ModalSearchPage implements ViewDidEnter {
     request: () => this.searchText(),
     loader: ({ request: searchText }) => this.mapSearchService.searchAll(searchText),
   });
+
   searchResults = computed(() => this.mapSearch.value() || []);
   showHistory = computed(
     () => this.searchResults().length == 0 && !this.mapSearch.isLoading() && this.searchHistory().length > 0

--- a/src/app/modules/map/services/map-search/map-search.service.ts
+++ b/src/app/modules/map/services/map-search/map-search.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { settings } from '../../../../../settings';
 import { MapSearchResponse } from './map-search-response.model';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { map, switchMap, catchError } from 'rxjs/operators';
 import { Observable, forkJoin, of, Subject, firstValueFrom } from 'rxjs';
 import { ViewInfo } from './view-info.model';

--- a/src/app/modules/map/services/map-search/view-info.model.ts
+++ b/src/app/modules/map/services/map-search/view-info.model.ts
@@ -1,5 +1,5 @@
 import { LocationName } from './location-name.model';
-import * as L from 'leaflet';
+import L from 'leaflet';
 
 export interface ViewInfo {
   location?: LocationName;

--- a/src/app/modules/map/services/map/map-view.interface.ts
+++ b/src/app/modules/map/services/map/map-view.interface.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 
 export interface IMapView {
   bounds: L.LatLngBounds;

--- a/src/app/modules/registration/components/damage-obs/damage-obs.component.ts
+++ b/src/app/modules/registration/components/damage-obs/damage-obs.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, inject } from '@angular/core';
 import { IonCheckbox, IonIcon, IonItem, IonLabel, IonList, IonText, ModalController } from '@ionic/angular/standalone';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { SetDamageLocationPage } from '../../pages/set-damage-location/set-damage-location.page';
 import { ObsLocationEditModel } from 'src/app/modules/common-regobs-api/models';
 import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -67,7 +67,6 @@ import { FormsModule } from '@angular/forms';
 import { addIcons } from 'ionicons';
 import { calendarOutline, createOutline, radioButtonOn, timeOutline } from 'ionicons/icons';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { LeafletModule } from '@bluehalo/ngx-leaflet';
 
 export interface LocationTime {
   location: ObsLocationEditModel;
@@ -137,7 +136,6 @@ function computeMapViewRadius(bounds: L.LatLngBounds): number {
     IonSpinner,
     IonToggle,
     KdvSelectComponent,
-    LeafletModule,
     MapComponent,
     NgClass,
     NgFor,

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.ts
@@ -29,7 +29,7 @@ import {
   Platform,
 } from '@ionic/angular/standalone';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import 'leaflet-draw';
 import moment from 'moment';
 import { concat, firstValueFrom, fromEventPattern, Observable, Subject } from 'rxjs';
@@ -67,6 +67,7 @@ import { FormsModule } from '@angular/forms';
 import { addIcons } from 'ionicons';
 import { calendarOutline, createOutline, radioButtonOn, timeOutline } from 'ionicons/icons';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { LeafletModule } from '@bluehalo/ngx-leaflet';
 
 export interface LocationTime {
   location: ObsLocationEditModel;
@@ -136,6 +137,7 @@ function computeMapViewRadius(bounds: L.LatLngBounds): number {
     IonSpinner,
     IonToggle,
     KdvSelectComponent,
+    LeafletModule,
     MapComponent,
     NgClass,
     NgFor,

--- a/src/app/modules/registration/models/polygon.ts
+++ b/src/app/modules/registration/models/polygon.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 import 'leaflet-draw';
 import { settings } from 'src/settings';
 

--- a/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.ts
+++ b/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.ts
@@ -18,7 +18,7 @@ import {
   ModalController,
 } from '@ionic/angular/standalone';
 import { SetAvalanchePositionPage } from '../../set-avalanche-position/set-avalanche-position.page';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import moment from 'moment';
 import { HeaderColorDirective } from '../../../../shared/directives/header-color/header-color.directive';
 import { NgIf, NgClass, DecimalPipe } from '@angular/common';

--- a/src/app/modules/registration/pages/obs-location/obs-location.page.ts
+++ b/src/app/modules/registration/pages/obs-location/obs-location.page.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, NgZone, OnDestroy, inject } from '@angular/core';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import {
   IonBackButton,
   IonButtons,

--- a/src/app/modules/registration/pages/set-avalanche-position/set-avalanche-position.page.ts
+++ b/src/app/modules/registration/pages/set-avalanche-position/set-avalanche-position.page.ts
@@ -10,7 +10,7 @@ import {
   ModalController,
 } from '@ionic/angular/standalone';
 import { TranslateService, TranslatePipe, TranslationObject } from '@ngx-translate/core';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { Observable, Subject } from 'rxjs';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 import { settings } from 'src/settings';

--- a/src/app/modules/registration/pages/set-damage-location/set-damage-location.page.ts
+++ b/src/app/modules/registration/pages/set-damage-location/set-damage-location.page.ts
@@ -9,7 +9,7 @@ import {
   ModalController,
 } from '@ionic/angular/standalone';
 import { DamageObsEditModel, ObsLocationEditModel } from 'src/app/modules/common-regobs-api/models';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { IsEmptyHelper } from '../../../../core/helpers/is-empty.helper';
 import {
   LocationTime,

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.ts
@@ -1,5 +1,4 @@
 import { Component, inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import {
   IonBackButton,
   IonButton,
@@ -18,7 +17,7 @@ import {
   IonToolbar,
   ModalController,
 } from '@ionic/angular/standalone';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import moment from 'moment';
 import { IncidentValidation } from 'src/app/core/helpers/incident-validation';
 import {
@@ -28,7 +27,6 @@ import {
 import { RegistrationTid } from 'src/app/modules/common-registration/registration.models';
 import { AvalancheObsEditModel, IncidentEditModel } from 'src/app/modules/common-regobs-api';
 import { SelectOption } from '../../../../shared/components/input/select/select-option.model';
-import { BasePageService } from '../../base-page-service';
 import { BasePage } from '../../base.page';
 import { SetAvalanchePositionPage } from '../../set-avalanche-position/set-avalanche-position.page';
 import { HeaderColorDirective } from '../../../../shared/directives/header-color/header-color.directive';

--- a/src/app/pages/home/geojson.ts
+++ b/src/app/pages/home/geojson.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { Feature, Point } from 'geojson';
 import { AtAGlanceViewModel } from 'src/app/modules/common-regobs-api';
 import { RegobsGeoHazardMarker } from 'src/app/modules/map/core/classes/regobs-geohazard-marker';

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -5,7 +5,7 @@ import { Capacitor } from '@capacitor/core';
 import { AlertController, IonContent, ToastController } from '@ionic/angular/standalone';
 import { TranslateService } from '@ngx-translate/core';
 import { Feature, Point } from 'geojson';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import 'leaflet.markercluster';
 import { combineLatest, firstValueFrom, Observable, race, Subject, scan, BehaviorSubject, of } from 'rxjs';
 import {

--- a/src/app/pages/home/markerCluster.layer.ts
+++ b/src/app/pages/home/markerCluster.layer.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet';
+import L from 'leaflet';
 import 'leaflet.markercluster';
 import { Feature, Point } from 'geojson';
 import { RegistrationViewModel } from 'src/app/modules/common-regobs-api';

--- a/src/app/pages/legacy-trip/legacy-trip.page.ts
+++ b/src/app/pages/legacy-trip/legacy-trip.page.ts
@@ -27,7 +27,6 @@ import { GeoHazard } from '../../modules/common-core/models';
 import { HelpModalPage } from '../../modules/registration/pages/modal-pages/help-modal/help-modal.page';
 import { LoggingService } from '../../modules/shared/services/logging/logging.service';
 import { LogLevel } from '../../modules/shared/services/logging/log-level.model';
-import * as utils from '@nano-sql/core/lib/utilities';
 import { SelectOption } from '../../modules/shared/components/input/select/select-option.model';
 import { GeoPositionService } from '../../core/services/geo-position/geo-position.service';
 import { RegobsAuthService } from '../../modules/auth/services/regobs-auth.service';
@@ -38,7 +37,7 @@ import { KdvSelectComponent } from '../../components/kdv-select/kdv-select.compo
 import { SelectComponent } from '../../modules/shared/components/input/select/select.component';
 import { TextCommentComponent } from '../../modules/registration/components/text-comment/text-comment.component';
 import { SvgIconComponent } from 'angular-svg-icon';
-import { isEmpty } from 'src/app/modules/common-core/helpers';
+import { isEmpty, uuidv4 } from 'src/app/modules/common-core/helpers';
 
 const DEBUG_TAG = 'LegacyTripPage';
 
@@ -167,7 +166,7 @@ export class LegacyTripPage implements OnInit, OnDestroy {
         this.isLoading = true;
         // this.tripDto.ObserverGuid = loggedInUser.user.Guid; // TODO: Fix api to use access token for this call
         this.tripDto.GeoHazardID = GeoHazard.Snow;
-        this.tripDto.DeviceGuid = utils.uuid();
+        this.tripDto.DeviceGuid = uuidv4();
         try {
           if (this.currentPosition && this.currentPosition.coords) {
             this.tripDto.Lat = this.currentPosition.coords.latitude.toString();

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -19,7 +19,7 @@ import {
 } from '@ionic/angular/standalone';
 import { BehaviorSubject, combineLatest, firstValueFrom, from, Observable, Subject } from 'rxjs';
 import { debounceTime, filter, map, switchMap, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { OfflinePackageModalComponent } from './offline-package-modal/offline-package-modal.component';
 import { CompoundPackage, CompoundPackageFeature } from './metadata.model';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
@@ -12,7 +12,7 @@ import {
   IonToolbar,
   ModalController,
 } from '@ionic/angular/standalone';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { CompoundPackageFeature, CompoundPackage } from '../metadata.model';
 import { OfflineMapService } from '../../../core/services/offline-map/offline-map.service';
 import { Observable } from 'rxjs';

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { AngularSvgIconModule } from 'angular-svg-icon';
 import { LeafletModule } from '@bluehalo/ngx-leaflet';
 import { RegobsApiModuleWithConfig } from './app/modules/common-regobs-api';
 import { AppComponent } from './app/app.component';
-import * as CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
+import CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
 import { provideRouter, RouteReuseStrategy, withComponentInputBinding } from '@angular/router';
 import { routes } from './app/app.routes';
 import { Requestor, StorageBackend } from '@openid/appauth';

--- a/src/settings.model.ts
+++ b/src/settings.model.ts
@@ -1,5 +1,5 @@
 import { Polygon } from 'geojson';
-import * as L from 'leaflet';
+import L from 'leaflet';
 import { SupportTile } from './app/core/models/support-tile.model';
 import { TopoMapLayer } from './app/core/models/topo-map-layer.enum';
 import { TopoMap } from './app/core/models/topo-map.enum';

--- a/translations/common.ts
+++ b/translations/common.ts
@@ -1,18 +1,18 @@
-import * as fs from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { EOL } from 'os';
 import { JSON_SPACES } from './settings';
 
 export type Translations = { [key: string]: string | Translations };
 
 export async function readTranslationFile(path: string): Promise<Translations> {
-  const content = await fs.readFile(path);
+  const content = await readFile(path);
   const translations = JSON.parse(content.toString());
   return translations;
 }
 
 export async function writeTranslationFile(path: string, translations: string) {
   const translationsWithEol = translations.endsWith(EOL) ? translations : translations + EOL;
-  await fs.writeFile(path, translationsWithEol);
+  await writeFile(path, translationsWithEol);
 }
 
 // Edited version of this SO answer: https://stackoverflow.com/a/53593328

--- a/translations/sortTranslations.ts
+++ b/translations/sortTranslations.ts
@@ -1,13 +1,13 @@
 /* eslint-disable no-console */
 
-import * as fs from 'fs/promises';
+import { readdir } from 'fs/promises';
 
 import { join } from 'path';
 import { TRANSLATIONS_FOLDER } from './settings';
 import { JSONstringifyOrder, readTranslationFile, writeTranslationFile } from './common';
 
 async function sortLocalTranslations() {
-  const files = await fs.readdir(TRANSLATIONS_FOLDER, { withFileTypes: true });
+  const files = await readdir(TRANSLATIONS_FOLDER, { withFileTypes: true });
   for (const file of files) {
     if (file.isFile() && file.name.indexOf('.json') > -1) {
       const filePath = join(TRANSLATIONS_FOLDER, file.name);

--- a/translations/updateDbFallback.ts
+++ b/translations/updateDbFallback.ts
@@ -8,7 +8,7 @@ import { GeoHazard, LangKey } from '../src/app/modules/common-core/models';
 import { settings } from '../src/settings';
 import { get, RequestOptions } from 'https';
 import { IncomingMessage } from 'http';
-import * as path from 'path';
+import { resolve } from 'path';
 import { createWriteStream } from 'fs';
 
 const opts: RequestOptions = {
@@ -47,15 +47,15 @@ for (const { lang } of <{ lang: string }[]>settings.language.supportedLanguages)
   const langKey = LangKey[lang];
 
   const searchCriteriaUrl = `${settings.services.regObs.apiUrl.PROD}/Search/SearchCriteria/${allGeoHazards}/${langKey}`;
-  const searchCriteriaPath = path.resolve(__dirname, '..', `src/assets/json/searchcriteria.${lang.toLowerCase()}.json`);
+  const searchCriteriaPath = resolve(__dirname, '..', `src/assets/json/searchcriteria.${lang.toLowerCase()}.json`);
   requests.push(download(searchCriteriaUrl, searchCriteriaPath));
 
   const kdvUrl = `${settings.services.regObs.apiUrl.PROD}/KdvElements?langkey=${langKey}&isActive=true&sortOrder=true`;
-  const kdvPath = path.resolve(__dirname, '..', `src/assets/json/kdvelements.${lang.toLowerCase()}.json`);
+  const kdvPath = resolve(__dirname, '..', `src/assets/json/kdvelements.${lang.toLowerCase()}.json`);
   requests.push(download(kdvUrl, kdvPath));
 
   const helptextsUrl = `${settings.services.regObs.apiUrl.PROD}/HelpText?langKey=${langKey}`;
-  const helptextsPath = path.resolve(__dirname, '..', `src/assets/json/helptexts.${lang.toLowerCase()}.json`);
+  const helptextsPath = resolve(__dirname, '..', `src/assets/json/helptexts.${lang.toLowerCase()}.json`);
   requests.push(download(helptextsUrl, helptextsPath));
 }
 


### PR DESCRIPTION
På beta.regobs.no får vi denne feilen i konsollet hvis vi prøver denne linken: https://beta.regobs.no/registration/new/70
```
 Uncaught TypeError: Q.markerClusterGroup is not a function
    at a.createMarkerClusterGroup
```

Med god hjelp av Jørgen fant vi ut at det kræsjer i leaflet-cluser.helper.ts som lastes når vi går direkte inn på sida for å stedfeste en observasjon. Å bytte ut importen fra `import * as L from 'leaflet'` til `import L from 'leaflet'` fikset problemet.
Vi har byttet ut alle slike import-uttrykk i koden.
Har også byttet ut de fleste steder med `import * as` med en mer moderne variant.