### PR TITLE
Flytta inject ut av rxjs-pipleline ellers kræsjer det på tlf

### DIFF
--- a/src/app/core/guards/start-wizard.guard.ts
+++ b/src/app/core/guards/start-wizard.guard.ts
@@ -6,14 +6,17 @@ import { timer, of } from 'rxjs';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const canActivateStartWizard: CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
-  return inject(UserSettingService).userSetting$.pipe(
+  const userSettingService = inject(UserSettingService);
+  const router = inject(Router);
+
+  return userSettingService.userSetting$.pipe(
     take(1),
     map((userSetting) => !userSetting.completedStartWizard),
     switchMap((notCompletedStartWizard) => {
       if (notCompletedStartWizard) {
         // Redirect router navigation to start wizard
         // Added 200ms timeout because of white screen on startup, this seems to help.
-        return timer(200).pipe(map(() => inject(Router).parseUrl('/start-wizard')));
+        return timer(200).pipe(map(() => router.parseUrl('/start-wizard')));
       }
       // Proceed with router navigation
       return of(true);


### PR DESCRIPTION
Første gang jeg tester å installere appen på tlf. fra fra utviklingsmiljø idag siden monster-oppgraderinga.
Appen gikk i "hvit skjerm" og fikk denne i konsollet:
 
console-logging.service.ts:62 RuntimeError: NG0203: inject() must be called from an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext`. Find more at https://angular.dev/errors/NG0203
    at start-wizard.guard.ts:16:42
 
Når jeg kommenterte ut den linja fikk jeg starta appen.

Takk til amish1188 for tips til fiks!