### PR TITLE
RO-2689: Vis detaljert profil og stort bilde ved klikk på bilde i karusell

### DIFF
--- a/src/app/components/observation/observation/observation.component.html
+++ b/src/app/components/observation/observation/observation.component.html
@@ -19,7 +19,7 @@
 
     <!-- lazy-preload-prev-next="2" -->
     @for (attachment of attachments(); track attachment.AttachmentId) {
-      <swiper-slide>
+      <swiper-slide (click)="imageClicked(attachment)">
         <!-- <div class="img-desc">
           @if (attachment.Comment) {
             <ion-icon name="chatbubble-ellipses" color="primary"></ion-icon>

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -14,14 +14,13 @@ import {
   IonCard,
   IonCardContent,
   IonCardHeader,
-  IonCardSubtitle,
   IonCardTitle,
   IonChip,
   IonIcon,
   IonLabel,
   ToastController,
 } from '@ionic/angular/standalone';
-import { RegistrationService, RegistrationViewModel } from 'src/app/modules/common-regobs-api';
+import { AttachmentViewModel, RegistrationService, RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 import { addIcons } from 'ionicons';
 import {
   calendarNumberOutline,
@@ -70,7 +69,6 @@ const FETCH_OBS_TIMEOUT_MS = 5000;
     IonCard,
     IonCardHeader,
     IonCardContent,
-    IonCardSubtitle,
     IonCardTitle,
     IonChip,
     IonIcon,
@@ -261,6 +259,15 @@ export class ObservationComponent {
     });
 
     return promise;
+  }
+
+  //TODO: Midlertidig løsning for å åpne detaljert snøprofil og se større bilder direkte fra karusellen.
+  //På sikt skal nok klikk på bildet i karusell ta deg via en modal før du går videre til detaljert profil
+  imageClicked(attachment: AttachmentViewModel) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const url = (attachment as any).Href || attachment.Url;
+    //kun snøprofil-bilder har href. Href er link til detaljert snøprofil. Andre biler åpnes i maks størrelse
+    window.open(url, '_blank');
   }
 }
 


### PR DESCRIPTION
Midlertidig løsning for å åpne detaljert snøprofil og se større bilder når man klikker på et bilde i karusellen i observasjonskortet.
På sikt skal nok klikk på bildet i karusell ta deg via en modal før du går videre til detaljert profil og bilde i maks størrelse.

Prøvde først å legge en `<a>` rundt `<swiper-slide>`, men da ødela jeg bredden på bildene i karusellen. Tenkte at vi uansett trenger en click-handler når vi skal ha en modal her, så da ble det slik i stedet.

- [x] Må teste hvordan dette funker i app. Funka ganske bra i Android. Det er bare å bruke tilbake-knappen nederst til høyre for å komme tilbake til appen etter å ha åpna et bilde eller detaljert snøprofil.