### PR TITLE
RO-1345: legge til himmelretning og opphavsrett under bilder

### DIFF
--- a/src/app/modules/auth/services/regobs-auth.service.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.ts
@@ -198,7 +198,7 @@ export class RegobsAuthService {
     return undefined;
   }
 
-  private async showSetNickDialog(): Promise<string> {
+  public async showSetNickDialog(): Promise<string> {
     const headerTextKey = 'SET_NICK_ALERT.INPUT_TEXT';
     const messageTextKey = 'SET_NICK_ALERT.HELP_TEXT';
     const okTextKey = 'DIALOGS.OK';

--- a/src/app/modules/auth/services/regobs-auth.service.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.ts
@@ -198,7 +198,7 @@ export class RegobsAuthService {
     return undefined;
   }
 
-  public async showSetNickDialog(): Promise<string> {
+  private async showSetNickDialog(): Promise<string> {
     const headerTextKey = 'SET_NICK_ALERT.INPUT_TEXT';
     const messageTextKey = 'SET_NICK_ALERT.HELP_TEXT';
     const okTextKey = 'DIALOGS.OK';

--- a/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.ts
+++ b/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, model, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { IonButton, IonIcon, IonInput, IonItem, IonList, ModalController, IonText } from '@ionic/angular/standalone';
+import { IonButton, IonIcon, IonInput, IonItem, IonList, ModalController } from '@ionic/angular/standalone';
 import { TranslatePipe } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
 import { close } from 'ionicons/icons';
@@ -9,7 +9,7 @@ import { close } from 'ionicons/icons';
   selector: 'app-edit-user-nickname-modal',
   templateUrl: './edit-user-nickname-modal.component.html',
   styleUrls: ['./edit-user-nickname-modal.component.scss'],
-  imports: [IonText, FormsModule, IonButton, IonIcon, IonInput, IonItem, IonList, TranslatePipe],
+  imports: [FormsModule, IonButton, IonIcon, IonInput, IonItem, IonList, TranslatePipe],
 })
 export class EditUserNicknameModalComponent {
   modalController = inject(ModalController);

--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -19,6 +19,42 @@
       [rows]="2"
       placeholder="{{ pictureCommentPlaceholder() | translate }}"
     ></app-text-comment>
+    <ion-accordion-group>
+      <ion-accordion>
+        <ion-item slot="header" class="accordion-button">
+          <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.SHOW_MORE" | translate }}</ion-label>
+        </ion-item>
+        <div class="ion-padding" slot="content">
+          <ion-item>
+            <app-select
+              label="REGISTRATION.IMAGE_ASPECT"
+              [(selectedValue)]="attachment.Aspect"
+              [options]="aspectOptions()"
+            ></app-select>
+          </ion-item>
+          <ion-item>
+            <ion-input
+              [value]="attachment.Photographer"
+              (ionChange)="updateExistingAttachmentPhotographer(attachment, $event)"
+              [label]="'MY_PROFILE.PHOTOGRAPHER' | translate"
+              labelPlacement="stacked"
+              [placeholder]="'MY_PROFILE.PHOTOGRAPHER' | translate"
+            >
+            </ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-input
+              [value]="attachment.Copyright || userSettings()?.copyright"
+              (ionChange)="updateExistingAttachmentCopyright(attachment, $event)"
+              [label]="'MY_PROFILE.COPYRIGHT' | translate"
+              labelPlacement="stacked"
+              [placeholder]="'MY_PROFILE.COPYRIGHT' | translate"
+            >
+            </ion-input>
+          </ion-item>
+        </div>
+      </ion-accordion>
+    </ion-accordion-group>
   </div>
 
   <!-- New attachments -->
@@ -51,6 +87,43 @@
       [rows]="2"
       placeholder="{{ pictureCommentPlaceholder() | translate }}"
     ></app-text-comment>
+    <ion-accordion-group>
+      <ion-accordion>
+        <ion-item slot="header" class="accordion-button">
+          <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.SHOW_MORE" | translate }}</ion-label>
+        </ion-item>
+        <div class="ion-padding" slot="content">
+          <ion-item>
+            <app-select
+              label="REGISTRATION.IMAGE_ASPECT"
+              [(selectedValue)]="attachment.Aspect"
+              [options]="aspectOptions()"
+              (ionChange)="addNewAttachmentAspect(attachment, $event)"
+            ></app-select>
+          </ion-item>
+          <ion-item>
+            <ion-input
+              [value]="attachment.Photographer"
+              (ionChange)="addNewAttachmentPhotographer(attachment, $event)"
+              label="PHOTOGRAPHER"
+              labelPlacement="stacked"
+              placeholder="Photographer"
+            >
+            </ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-input
+              [value]="attachment.Copyright || userSettings()?.copyright"
+              (ionChange)="addNewAttachmentCopyright(attachment, $event)"
+              label="COPYRIGHT"
+              labelPlacement="stacked"
+              placeholder="Copyright"
+            >
+            </ion-input>
+          </ion-item>
+        </div>
+      </ion-accordion>
+    </ion-accordion-group>
   </div>
 </div>
 

--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -44,7 +44,7 @@
           </ion-item>
           <ion-item>
             <ion-input
-              [value]="attachment.Copyright || userSettings()?.copyright"
+              [value]="attachment.Copyright || userSettings()?.copyright || myPage()?.NickName"
               (ionChange)="updateExistingAttachmentCopyright(attachment, $event)"
               [label]="('MY_PROFILE.COPYRIGHT' | translate).toUpperCase()"
               labelPlacement="stacked"

--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -29,14 +29,14 @@
             <app-select
               label="REGISTRATION.IMAGE_ASPECT"
               [(selectedValue)]="attachment.Aspect"
-              [options]="aspectOptions()"
+              [options]="aspectOptions"
             ></app-select>
           </ion-item>
           <ion-item>
             <ion-input
-              [value]="attachment.Photographer"
+              [value]="attachment.Photographer || userSettings()?.photographer"
               (ionChange)="updateExistingAttachmentPhotographer(attachment, $event)"
-              [label]="'MY_PROFILE.PHOTOGRAPHER' | translate"
+              [label]="('MY_PROFILE.PHOTOGRAPHER' | translate).toUpperCase()"
               labelPlacement="stacked"
               [placeholder]="'MY_PROFILE.PHOTOGRAPHER' | translate"
             >
@@ -46,7 +46,7 @@
             <ion-input
               [value]="attachment.Copyright || userSettings()?.copyright"
               (ionChange)="updateExistingAttachmentCopyright(attachment, $event)"
-              [label]="'MY_PROFILE.COPYRIGHT' | translate"
+              [label]="('MY_PROFILE.COPYRIGHT' | translate).toUpperCase()"
               labelPlacement="stacked"
               [placeholder]="'MY_PROFILE.COPYRIGHT' | translate"
             >
@@ -97,27 +97,27 @@
             <app-select
               label="REGISTRATION.IMAGE_ASPECT"
               [(selectedValue)]="attachment.Aspect"
-              [options]="aspectOptions()"
+              [options]="aspectOptions"
               (ionChange)="addNewAttachmentAspect(attachment, $event)"
             ></app-select>
           </ion-item>
           <ion-item>
             <ion-input
-              [value]="attachment.Photographer"
+              [value]="attachment.Photographer || userSettings()?.photographer"
               (ionChange)="addNewAttachmentPhotographer(attachment, $event)"
-              label="PHOTOGRAPHER"
+              [label]="('MY_PROFILE.PHOTOGRAPHER' | translate).toUpperCase()"
               labelPlacement="stacked"
-              placeholder="Photographer"
+              [placeholder]="'MY_PROFILE.PHOTOGRAPHER' | translate"
             >
             </ion-input>
           </ion-item>
           <ion-item>
             <ion-input
-              [value]="attachment.Copyright || userSettings()?.copyright"
+              [value]="attachment.Copyright || userSettings()?.copyright || myPage()?.NickName"
               (ionChange)="addNewAttachmentCopyright(attachment, $event)"
-              label="COPYRIGHT"
+              [label]="('MY_PROFILE.COPYRIGHT' | translate).toUpperCase()"
               labelPlacement="stacked"
-              placeholder="Copyright"
+              [placeholder]="'MY_PROFILE.COPYRIGHT' | translate"
             >
             </ion-input>
           </ion-item>

--- a/src/app/modules/registration/components/edit-images/edit-images.component.scss
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.scss
@@ -36,3 +36,12 @@
     }
   }
 }
+
+.accordion-button::part(native) {
+  background: var(--ion-background-color);
+}
+
+.accordion-button ion-label {
+  --color: var(--ion-color-primary) !important;
+  width: fit-content;
+}

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -1,10 +1,13 @@
-import { Component, OnInit, ChangeDetectionStrategy, inject, input, model } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject, input, model, computed } from '@angular/core';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 import {
   ActionSheetController,
+  IonAccordion,
+  IonAccordionGroup,
   IonFab,
   IonFabButton,
   IonIcon,
+  IonInput,
   IonItem,
   IonLabel,
   IonProgressBar,
@@ -42,6 +45,10 @@ import { TextCommentComponent } from '../text-comment/text-comment.component';
 import { BlobImageComponent } from '../blob-image/blob-image.component';
 import { addIcons } from 'ionicons';
 import { camera, close } from 'ionicons/icons';
+import { SelectComponent } from '../../../shared/components/input/select/select.component';
+import { SelectOption } from 'src/app/modules/shared/components/input/select/select-option.model';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 
 const DEBUG_TAG = 'AddPictureItemComponent';
 const MIME_TYPE = 'image/jpeg';
@@ -65,9 +72,12 @@ interface NewAttachment extends AttachmentUploadEditModelWithBlob, AddAttachment
     AsyncPipe,
     BlobImageComponent,
     IonFab,
+    IonAccordion,
+    IonAccordionGroup,
     IonFabButton,
     IonIcon,
     IonItem,
+    IonInput,
     IonLabel,
     IonProgressBar,
     NgClass,
@@ -77,6 +87,7 @@ interface NewAttachment extends AttachmentUploadEditModelWithBlob, AddAttachment
     RemoteImageComponent,
     TextCommentComponent,
     TranslatePipe,
+    SelectComponent,
   ],
 })
 export class EditImagesComponent implements OnInit {
@@ -88,6 +99,7 @@ export class EditImagesComponent implements OnInit {
   private toastController = inject(ToastController);
   private actionSheetController = inject(ActionSheetController);
   private dropZoneService = inject(DropZoneService);
+  private userSettingService = inject(UserSettingService);
 
   readonly draftUuid = input.required<string>();
   readonly existingAttachments = model<RemoteOrLocalAttachmentEditModel[]>();
@@ -102,6 +114,32 @@ export class EditImagesComponent implements OnInit {
   readonly onBeforeAdd = input<() => Promise<void> | void>();
   readonly attachmentType = input<AttachmentType>('Attachment');
   readonly ref = input<string>();
+  userSettings = toSignal(this.userSettingService.userSetting$);
+  selectedAspect = model<number | undefined>(undefined);
+
+  aspectOptions = computed((): SelectOption[] => {
+    const translations = this.translateService.instant([
+      'DIRECTION.N',
+      'DIRECTION.NE',
+      'DIRECTION.E',
+      'DIRECTION.SE',
+      'DIRECTION.S',
+      'DIRECTION.SW',
+      'DIRECTION.W',
+      'DIRECTION.NW',
+    ]);
+
+    return [
+      { id: 0, text: translations['DIRECTION.N'] },
+      { id: 45, text: translations['DIRECTION.NE'] },
+      { id: 90, text: translations['DIRECTION.E'] },
+      { id: 135, text: translations['DIRECTION.SE'] },
+      { id: 180, text: translations['DIRECTION.S'] },
+      { id: 225, text: translations['DIRECTION.SW'] },
+      { id: 270, text: translations['DIRECTION.W'] },
+      { id: 315, text: translations['DIRECTION.NW'] },
+    ];
+  });
 
   isHybrid?: boolean;
   accept = ALLOWED_ATTACHMENT_FILE_TYPES;
@@ -152,6 +190,37 @@ export class EditImagesComponent implements OnInit {
   setNewAttachmentComment(attachment: AttachmentUploadEditModel, comment: AttachmentUploadEditModel['Comment']) {
     this.logger.debug('Updating new attachment comment', DEBUG_TAG, { comment });
     this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Comment: comment });
+  }
+
+  addNewAttachmentAspect(attachment: AttachmentUploadEditModel, event: Event) {
+    const aspect = (event.target as HTMLSelectElement).value;
+    this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Aspect: +aspect });
+  }
+
+  addNewAttachmentPhotographer(attachment: AttachmentUploadEditModel, event: Event) {
+    const photographer = (event.target as HTMLInputElement).value;
+    this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Photographer: photographer });
+  }
+
+  updateExistingAttachmentPhotographer(attachment: RemoteOrLocalAttachmentEditModel, event: Event) {
+    const photographer = (event.target as HTMLInputElement).value;
+    this.existingAttachments.update((attachments) =>
+      (attachments || []).map((a) =>
+        a.AttachmentId === attachment.AttachmentId ? { ...a, Photographer: photographer } : a
+      )
+    );
+  }
+
+  addNewAttachmentCopyright(attachment: AttachmentUploadEditModel, event: Event) {
+    const copyRight = (event.target as HTMLInputElement).value;
+    this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Copyright: copyRight });
+  }
+
+  updateExistingAttachmentCopyright(attachment: RemoteOrLocalAttachmentEditModel, event: Event) {
+    const copyright = (event.target as HTMLInputElement).value;
+    this.existingAttachments.update((attachments) =>
+      (attachments || []).map((a) => (a.AttachmentId === attachment.AttachmentId ? { ...a, Copyright: copyright } : a))
+    );
   }
 
   async addClick() {

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, ChangeDetectionStrategy, inject, input, model, computed } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject, input, model } from '@angular/core';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 import {
   ActionSheetController,
+  InputCustomEvent,
   IonAccordion,
   IonAccordionGroup,
   IonFab,
@@ -49,6 +50,7 @@ import { SelectComponent } from '../../../shared/components/input/select/select.
 import { SelectOption } from 'src/app/modules/shared/components/input/select/select-option.model';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
+import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
 
 const DEBUG_TAG = 'AddPictureItemComponent';
 const MIME_TYPE = 'image/jpeg';
@@ -92,6 +94,7 @@ interface NewAttachment extends AttachmentUploadEditModelWithBlob, AddAttachment
 })
 export class EditImagesComponent implements OnInit {
   newAttachmentService = inject(NewAttachmentService);
+  private regobsAuthService = inject(RegobsAuthService);
   private translateService = inject(TranslateService);
   private platform = inject(Platform);
   private file = inject(File);
@@ -115,31 +118,19 @@ export class EditImagesComponent implements OnInit {
   readonly attachmentType = input<AttachmentType>('Attachment');
   readonly ref = input<string>();
   userSettings = toSignal(this.userSettingService.userSetting$);
+  myPage = toSignal(this.regobsAuthService.myPageData$);
   selectedAspect = model<number | undefined>(undefined);
 
-  aspectOptions = computed((): SelectOption[] => {
-    const translations = this.translateService.instant([
-      'DIRECTION.N',
-      'DIRECTION.NE',
-      'DIRECTION.E',
-      'DIRECTION.SE',
-      'DIRECTION.S',
-      'DIRECTION.SW',
-      'DIRECTION.W',
-      'DIRECTION.NW',
-    ]);
-
-    return [
-      { id: 0, text: translations['DIRECTION.N'] },
-      { id: 45, text: translations['DIRECTION.NE'] },
-      { id: 90, text: translations['DIRECTION.E'] },
-      { id: 135, text: translations['DIRECTION.SE'] },
-      { id: 180, text: translations['DIRECTION.S'] },
-      { id: 225, text: translations['DIRECTION.SW'] },
-      { id: 270, text: translations['DIRECTION.W'] },
-      { id: 315, text: translations['DIRECTION.NW'] },
-    ];
-  });
+  aspectOptions: SelectOption[] = [
+    { id: 0, text: this.translateService.instant('DIRECTION.N') },
+    { id: 45, text: this.translateService.instant('DIRECTION.NE') },
+    { id: 90, text: this.translateService.instant('DIRECTION.E') },
+    { id: 135, text: this.translateService.instant('DIRECTION.SE') },
+    { id: 180, text: this.translateService.instant('DIRECTION.S') },
+    { id: 225, text: this.translateService.instant('DIRECTION.SW') },
+    { id: 270, text: this.translateService.instant('DIRECTION.W') },
+    { id: 315, text: this.translateService.instant('DIRECTION.NW') },
+  ];
 
   isHybrid?: boolean;
   accept = ALLOWED_ATTACHMENT_FILE_TYPES;
@@ -194,16 +185,19 @@ export class EditImagesComponent implements OnInit {
 
   addNewAttachmentAspect(attachment: AttachmentUploadEditModel, event: Event) {
     const aspect = (event.target as HTMLSelectElement).value;
+    if (aspect == null || aspect == undefined) return;
     this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Aspect: +aspect });
   }
 
-  addNewAttachmentPhotographer(attachment: AttachmentUploadEditModel, event: Event) {
-    const photographer = (event.target as HTMLInputElement).value;
+  addNewAttachmentPhotographer(attachment: AttachmentUploadEditModel, event: InputCustomEvent) {
+    const photographer = event.detail.value;
+    if (photographer == null || photographer == undefined) return;
     this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Photographer: photographer });
   }
 
-  updateExistingAttachmentPhotographer(attachment: RemoteOrLocalAttachmentEditModel, event: Event) {
-    const photographer = (event.target as HTMLInputElement).value;
+  updateExistingAttachmentPhotographer(attachment: RemoteOrLocalAttachmentEditModel, event: InputCustomEvent) {
+    const photographer = event.detail.value;
+    if (photographer == null || photographer == undefined) return;
     this.existingAttachments.update((attachments) =>
       (attachments || []).map((a) =>
         a.AttachmentId === attachment.AttachmentId ? { ...a, Photographer: photographer } : a
@@ -211,15 +205,17 @@ export class EditImagesComponent implements OnInit {
     );
   }
 
-  addNewAttachmentCopyright(attachment: AttachmentUploadEditModel, event: Event) {
-    const copyRight = (event.target as HTMLInputElement).value;
+  addNewAttachmentCopyright(attachment: AttachmentUploadEditModel, event: InputCustomEvent) {
+    const copyRight = event.detail.value;
+    if (copyRight == null || copyRight == undefined) return;
     this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Copyright: copyRight });
   }
 
-  updateExistingAttachmentCopyright(attachment: RemoteOrLocalAttachmentEditModel, event: Event) {
-    const copyright = (event.target as HTMLInputElement).value;
+  updateExistingAttachmentCopyright(attachment: RemoteOrLocalAttachmentEditModel, event: InputCustomEvent) {
+    const copyRight = event.detail.value;
+    if (copyRight == null || copyRight == undefined) return;
     this.existingAttachments.update((attachments) =>
-      (attachments || []).map((a) => (a.AttachmentId === attachment.AttachmentId ? { ...a, Copyright: copyright } : a))
+      (attachments || []).map((a) => (a.AttachmentId === attachment.AttachmentId ? { ...a, Copyright: copyRight } : a))
     );
   }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -516,6 +516,7 @@
       }
     },
     "IMAGES": "Images",
+    "IMAGE_ASPECT": "Orientation",
     "IMAGE_DESCRIPTION": "Image description",
     "IMAGE_DESCRIPTION_PLACEHOLDER": "Add a description to the image",
     "IMAGE_ERROR": {

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -243,7 +243,7 @@
   },
   "MY_PROFILE": {
     "COMPETENCE": "<a href=\"https://varsom.no/om-varsom/regobs/kompetanse/\">Les mer om kompetanse</a>",
-    "COPYRIGHT": "Opphavsrett",
+    "COPYRIGHT": "Kilde/rettighetshaver",
     "EDIT": "Rediger",
     "MY_COMPETENCE": "Min kompetanse",
     "MY_GROUPS": "Mine grupper",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -516,6 +516,7 @@
       }
     },
     "IMAGES": "Bilder",
+    "IMAGE_ASPECT": "Himmelretning",
     "IMAGE_DESCRIPTION": "Beskrivelse av bildet",
     "IMAGE_DESCRIPTION_PLACEHOLDER": "Her kan du gi en beskrivelse av bildet",
     "IMAGE_ERROR": {


### PR DESCRIPTION
Jeg fikk ikke til å bruker two way binding på ion-input derfor lagret jeg to metoder for å legge en ny fotografer og opphavsrett, og for oppdatering.

Template i denne komponenten har en del repetisjoner men det er ikke mulig å fikse det med mindre vi lager to separate komponenter derfor valgte jeg å la den være som den er. 

Som bestemt med Jørgen, de "ekstra" under bildet vises i en akkordion. 