### PR TITLE
RO-2707: Vise grafikk i observasjonskort

### DIFF
--- a/src/app/components/observation/graphics/exposed-height/exposed-height.component.html
+++ b/src/app/components/observation/graphics/exposed-height/exposed-height.component.html
@@ -1,0 +1,146 @@
+@if (hasHeightValue()) {
+  <div [ngSwitch]="exposedHeightComboTid()" class="container">
+    <ng-container *ngSwitchCase="0">
+      <!-- <ng-container *ngTemplateOutlet="middle"></ng-container> -->
+    </ng-container>
+    <ng-container *ngSwitchCase="1">
+      <ng-container *ngTemplateOutlet="top"></ng-container>
+      <ng-container *ngTemplateOutlet="topHeight"></ng-container>
+    </ng-container>
+    <ng-container *ngSwitchCase="2">
+      <ng-container *ngTemplateOutlet="bottom"></ng-container>
+      <ng-container *ngTemplateOutlet="bottomHeight"></ng-container>
+    </ng-container>
+    <ng-container *ngSwitchCase="3">
+      <ng-container *ngTemplateOutlet="topBottom"></ng-container>
+      <ng-container *ngTemplateOutlet="topBottomHeight"></ng-container>
+    </ng-container>
+    <ng-container *ngSwitchCase="4">
+      <ng-container *ngTemplateOutlet="middle"></ng-container>
+      <ng-container *ngTemplateOutlet="middleHeight"></ng-container>
+    </ng-container>
+  </div>
+}
+<ng-template #middle>
+  <svg xmlns="http://www.w3.org/2000/svg" width="65" height="64">
+    <path
+      fill="#E3E3E3"
+      d="M37 12.8c-4.5 2.1-5.4.5-8-.7-3-1.8-6.6-.7-7-.7l.2-.4L26 1.8c.5-1 1.2-1.8 2-1.8s1.5.5 2.3 1.2l6.5 11.6z"
+    />
+    <path
+      fill="#D21523"
+      d="M53.1 40c0 1.4-2 2.5-2 2.5-2.6 1.8-5.8 2.3-9.9-.5-3-2-4.6-3.8-8-4.8-3.2-1-4.6.8-9.2.7-3 0-3.6-1-5.4-2 0 0-2.5-2-5.5-2.8l-.9-.2 7.7-17s5.3-1.1 8.7.6c2.8 1.6 7.3 4.1 11.2.7L53 40z"
+    />
+    <path
+      fill="#E3E3E3"
+      d="M63.8 61.7c-.6.7-1.3 2.3-2.7 2.3H3C1.7 64 .8 62.4.3 61.7c-.5-.9-.3-2.5.4-3.6l8.1-17.7h.6c5.5 0 9.2 3 9.2 3a8.7 8.7 0 006.2 1.6c4.5-.4 6-1.8 9.3-.6 3.2 1.3 5.1 3.4 8.5 4.7 4 1.6 7.5 1.6 10.2-.2 0 0 2.8-2.3 3-4.1l7.8 12.8c.5 1 .7 3.4.2 4z"
+    />
+    <path
+      fill="#fff"
+      d="M40 17.6c-4 3.2-8.6.7-11.2-.7-3.4-1.8-8.8-.7-8.8-.7l2-4.6c.5-.2 4-1.1 7 .7 2.6 1.4 3.5 3 8 .7l3 4.6zM55.8 45c-.2 1.8-3 4-3 4-2.7 1.8-6.3 1.8-10.2.2-3.2-1.2-5.3-3.2-8.5-4.6-3.2-1.4-4.8.2-9.3.6-2.4.1-4-.2-6.2-1.6 0 0-3.7-3-9.2-3h-.6l3.4-7.4 1 .2a15 15 0 015.4 2.9c1.8 1 2.3 2 5.4 2 4.6.1 6-1.9 9.2-.8 3.4 1 5 2.9 8 4.8 4.3 2.9 7.3 2.1 10 .5 0 0 2-1 2-2.4l2.6 4.6z"
+    />
+  </svg>
+</ng-template>
+
+<ng-template #bottom>
+  <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="none">
+    <path fill="#fff" d="M0 0h64v64H0z" />
+    <path
+      fill="#E3E3E3"
+      d="M50.4 41.8c-2.7 1.8-4.8 1.8-9.2-1.1-2.8-2-4.3-3.7-8-5.2-3.2-1.4-4.6 1-9.2 1-3.2 0-3.5-.6-5.3-2.2 0 0-3-3-6.7-2.9L25.6 2C26.2.7 27 .2 27.7 0c1 0 1.8.5 2.5 1.6L51.8 38c.9 2-1.6 3.8-1.4 3.8z"
+    />
+    <path
+      fill="#D21523"
+      d="M63.7 61.5c-.6.9-1.3 2.5-2.7 2.5H3C1.6 64 .7 62.4.2 61.5c-.4-1.1-.2-2.8.3-3.8L9 39c5.5 0 9.4 2.4 9.6 2.4a8.6 8.6 0 006.2 1.6c4.5-.4 6-2 9.3-.6 3.2 1.5 5.1 3.8 8.5 5.1 4 1.6 7.5 1.6 10.2-.2 0 0 3.3-2.3 3-4.3L63.5 57c.5 1.1.7 3.5.2 4.4z"
+    />
+    <path
+      fill="#fff"
+      d="M56 43.2c.3 2-3 4.4-3 4.4-2.7 1.8-6.3 1.8-10.2.2-3.3-1.5-5.4-3.7-8.6-5.1-3.2-1.5-4.8.2-9.3.5-2.5.2-4.1-.2-6.3-1.6-.1 0-4-2.4-9.6-2.4l3.2-8.2c3.8-.2 6.8 3 6.8 3 1.8 1.6 2.1 2.1 5.4 2.1 4.6 0 6-2.2 9.2-.9 3.8 1.5 5.2 3.3 8 5.3 4.6 3 6.7 3 9.4 1-.2 0 2.3-1.6 1.6-3.7l3.4 5.4z"
+    />
+  </svg>
+</ng-template>
+
+<ng-template #top>
+  <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+    <path
+      fill="#D21523"
+      d="M50.3 41.8c-2.7 1.8-4.8 1.8-9.2-1.1-2.8-2-4.2-3.7-8-5.2-3.1-1.4-4.5 1-9.1 1-3.2 0-3.5-.6-5.3-2.2 0 0-3-3-6.7-2.9L25.6 2c.5-1.1 1.2-2 2.3-2 .9 0 1.7.5 2.4 1.6L52 37.8c.7 2.4-1.8 4-1.6 4z"
+    />
+    <path
+      fill="#E3E3E3"
+      d="M63.7 61.5c-.6.9-1.3 2.5-2.7 2.5H3C1.6 64 .7 62.4.2 61.5c-.4-1.1-.2-2.7.3-3.8L9 39a20 20 0 019.6 2.5 8.6 8.6 0 006.2 1.6c4.5-.3 6-2 9.3-.5 3.2 1.4 5.1 3.6 8.5 5 4 1.7 7.5 1.7 10.2-.1 0 0 3.3-2.4 3-4.4L63.5 57c.5 1.2.7 3.6.2 4.5z"
+    />
+    <path
+      fill="#fff"
+      d="M56 43.3c.3 2-3 4.3-3 4.3-2.7 1.8-6.3 1.8-10.2.2-3.4-1.3-5.4-3.6-8.6-5-3.2-1.5-4.8.1-9.3.5-2.5.2-4.1-.2-6.3-1.6 0 0-4-2.6-9.6-2.6l3.2-8c3.8-.3 6.8 2.8 6.8 2.8 1.8 1.6 2.1 2.2 5.4 2.2 4.6 0 6-2.2 9.2-1 3.8 1.3 5.2 3.3 8 5.3 4.6 2.9 6.7 2.9 9.4 1-.2 0 2.3-1.5 1.6-3.7l3.4 5.6z"
+    />
+  </svg>
+</ng-template>
+
+<ng-template #topBottom>
+  <svg xmlns="http://www.w3.org/2000/svg" width="65" height="64">
+    <path
+      fill="#D21523"
+      d="M37 12.8c-4.5 2.1-5.4.5-8-.7-3-1.8-6.6-.7-7-.7l.2-.4L26 1.8c.5-1 1.2-1.8 2-1.8s1.5.5 2.3 1.2l6.5 11.6z"
+    />
+    <path
+      fill="#E3E3E3"
+      d="M53.1 40c0 1.4-2 2.5-2 2.5-2.6 1.8-5.8 2.3-9.9-.5-3-2-4.6-3.8-8-4.8-3.2-1-4.6.8-9.2.7-3 0-3.6-1-5.4-2 0 0-2.5-2-5.5-2.8l-.9-.2 7.7-17s5.3-1.1 8.7.6c2.8 1.6 7.3 4.1 11.2.7L53 40z"
+    />
+    <path
+      fill="#fff"
+      d="M40 17.6c-4 3.2-8.6.7-11.2-.7-3.4-1.8-8.8-.7-8.8-.7l2-4.6c.5-.2 4-1.1 7 .7 2.6 1.4 3.5 3 8 .7l3 4.6z"
+    />
+    <path
+      fill="#D21523"
+      d="M63.8 61.7c-.6.7-1.3 2.3-2.7 2.3H3C1.7 64 .8 62.4.3 61.7c-.5-.9-.3-2.5.4-3.6l8.1-17.7h.6c5.5 0 9.2 3 9.2 3a8.7 8.7 0 006.2 1.6c4.5-.4 6-1.8 9.3-.6 3.2 1.3 5.1 3.4 8.5 4.7 4 1.6 7.5 1.6 10.2-.2 0 0 2-1.8 2.8-3.4.2-.2.2-.3.2-.7l7.8 12.8c.5 1 .7 3.4.2 4z"
+    />
+    <path
+      fill="#fff"
+      d="M55.8 45l-.2.7c-.7 1.6-2.8 3.4-2.8 3.4-2.7 1.7-6.3 1.7-10.2.1-3.2-1.2-5.3-3.2-8.5-4.6-3.2-1.4-4.8.2-9.3.6-2.4.1-4-.2-6.2-1.6 0 0-3.7-3-9.2-3h-.6l3.4-7.4 1 .2a15 15 0 015.4 2.9c1.8 1 2.3 2 5.4 2 4.6.1 6-1.9 9.2-.8 3.4 1 5 2.9 8 4.8 4.3 2.9 7.3 2.1 10 .5 0 0 2-1 2-2.4l2.6 4.6z"
+    />
+  </svg>
+</ng-template>
+
+<ng-template #topHeight>
+  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="64">
+    <path fill="#fff" d="M0 0h45v64H0z" />
+    <text x=".1" y="49.4">
+      {{ exposedHeight1() !== null ? exposedHeight1() + "m" : ("Unknown" | translate) }}
+    </text>
+    <path fill="#D21523" d="M30 23h-5v10h-5V23h-5l7.5-10L30 23z" />
+  </svg>
+</ng-template>
+
+<ng-template #bottomHeight>
+  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="64">
+    <text x=".1" y="28.4">
+      {{ exposedHeight1() !== null ? exposedHeight1() + "m" : ("Unknown" | translate) }}
+    </text>
+    <path fill="#D21523" d="M15 42h5V32h5v10h5l-7.5 10L15 42z" />
+  </svg>
+</ng-template>
+
+<ng-template #middleHeight>
+  <svg xmlns="http://www.w3.org/2000/svg" width="72" height="64">
+    <text x="19" y="24.4">
+      {{ exposedHeight1() !== null ? exposedHeight1() + "m" : ("Unknown" | translate) }}
+    </text>
+    <text x="19" y="52.4">
+      {{ exposedHeight2() !== null ? exposedHeight2() + "m" : ("Unknown" | translate) }}
+    </text>
+    <path fill="#D21523" d="M0 18h5V8h5v10h5L7.5 28 0 18zM15 46h-5v10H5V46H0l7.5-10L15 46z" />
+  </svg>
+</ng-template>
+
+<ng-template #topBottomHeight>
+  <svg xmlns="http://www.w3.org/2000/svg" width="72" height="64">
+    <text x="19" y="24.4">
+      {{ exposedHeight1() !== null ? exposedHeight1() + "m" : ("Unknown" | translate) }}
+    </text>
+    <text x="19" y="52.4">
+      {{ exposedHeight2() !== null ? exposedHeight2() + "m" : ("Unknown" | translate) }}
+    </text>
+    <path fill="#D21523" d="M0 46h5V36h5v10h5L7.5 56 0 46zM15 18h-5v10H5V18H0L7.5 8 15 18z" />
+  </svg>
+</ng-template>

--- a/src/app/components/observation/graphics/exposed-height/exposed-height.component.ts
+++ b/src/app/components/observation/graphics/exposed-height/exposed-height.component.ts
@@ -1,0 +1,43 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+
+export enum ExposedHeightType {
+  NOT_GIVEN = 0,
+  TOP,
+  BOTTOM,
+  TOP_BOTTOM,
+  MIDDLE,
+}
+
+@Component({
+  selector: 'app-exposed-height',
+  imports: [CommonModule, TranslateModule],
+  templateUrl: './exposed-height.component.html',
+  styles: [
+    `
+      text {
+        fill: var(--safe-text-gray);
+        font-style: italic;
+      }
+
+      svg + svg {
+        margin-left: 8px;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+/** En figur som viser utsatt høyde over eller under en gitt grenseverdi eller mellom to grenseverdier */
+export class ExposedHeightComponent {
+  exposedHeightComboTid = input<ExposedHeightType>();
+  exposedHeight1 = input<number>();
+  exposedHeight2 = input<number>();
+
+  hasHeightValue(): boolean {
+    if ((this.exposedHeightComboTid() ?? -1) < 3) {
+      return this.exposedHeight1() !== null;
+    }
+    return this.exposedHeight1() !== null || this.exposedHeight2() !== null;
+  }
+}

--- a/src/app/components/observation/graphics/exposition/exposition.component.svg
+++ b/src/app/components/observation/graphics/exposition/exposition.component.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="90px" height="90px">
+    <title>{{ text() || '' }}</title>
+    <g>
+        <path d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z" transform="rotate(-22.5 45 45)" stroke-width="1" stroke="#c6c6c5" [attr.fill]="value()[0] === '1' ? '#d21523' : '#e3e3e3'"></path>
+        <path d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z" transform="rotate(22.5 45 45)" stroke-width="1" stroke="#c6c6c5" [attr.fill]="value()[1] === '1' ? '#d21523' : '#e3e3e3'"></path>
+        <path d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z" transform="rotate(67.5 45 45)" stroke-width="1" stroke="#c6c6c5" [attr.fill]="value()[2] === '1' ? '#d21523' : '#e3e3e3'"></path>
+        <path d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z" transform="rotate(112.5 45 45)" stroke-width="1" stroke="#c6c6c5" [attr.fill]="value()[3] === '1' ? '#d21523' : '#e3e3e3'"></path>
+        <path d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z" transform="rotate(157.5 45 45)" stroke-width="1" stroke="#c6c6c5" [attr.fill]="value()[4] === '1' ? '#d21523' : '#e3e3e3'"></path>
+        <path d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z" transform="rotate(202.5 45 45)" stroke-width="1" stroke="#c6c6c5" [attr.fill]="value()[5] === '1' ? '#d21523' : '#e3e3e3'"></path>
+        <path d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z" transform="rotate(247.5 45 45)" stroke-width="1" stroke="#c6c6c5" [attr.fill]="value()[6] === '1' ? '#d21523' : '#e3e3e3'"></path>
+        <path d="M 45 9 A 36 36 0 0 1 70.45584412271572 19.54415587728429 L 45 45 Z" transform="rotate(292.5 45 45)" stroke-width="1" stroke="#c6c6c5" [attr.fill]="value()[7] === '1' ? '#d21523' : '#e3e3e3'"></path>
+        <circle cx="45" cy="45" r="36" fill="none" stroke-width="1" class="circle-outline"></circle>
+    </g>
+    <g>
+        <circle cx="45" cy="9" r="7.2" stroke-width="1" stroke="#69797a" fill="#fff"></circle>
+        <text x="45" y="9" dy="3.1680000000000006" font-size="7.920000000000001" stroke-width="1" text-anchor="middle" fill="#6a7a7b">
+            {{ 'COMPASS_DIRECTION.NORTH_SHORT' | translate }}
+        </text>
+    </g>
+    <g>
+        <circle cx="81" cy="45" r="7.2" stroke-width="1" stroke="#69797a" fill="#fff"></circle>
+        <text x="81" y="45" dy="3.1680000000000006" font-size="7.920000000000001" stroke-width="1" text-anchor="middle" fill="#6a7a7b">
+            {{ 'COMPASS_DIRECTION.EAST_SHORT' | translate }}
+        </text>
+    </g>
+    <g>
+        <circle cx="45" cy="81" r="7.2" stroke-width="1" stroke="#69797a" fill="#fff"></circle>
+        <text x="45" y="81" dy="3.1680000000000006" font-size="7.920000000000001" stroke-width="1" text-anchor="middle" fill="#6a7a7b">
+            {{ 'COMPASS_DIRECTION.SOUTH_SHORT' | translate }}
+        </text>
+    </g>
+    <g>
+        <circle cx="9" cy="45" r="7.2" stroke-width="1" stroke="#69797a" fill="#fff"></circle>
+        <text x="9" y="45" dy="3.1680000000000006" font-size="7.920000000000001" stroke-width="1" text-anchor="middle" fill="#6a7a7b">
+            {{ 'COMPASS_DIRECTION.WEST_SHORT' | translate }}
+        </text>
+    </g>
+</svg>

--- a/src/app/components/observation/graphics/exposition/exposition.component.ts
+++ b/src/app/components/observation/graphics/exposition/exposition.component.ts
@@ -1,0 +1,24 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-exposition',
+  imports: [TranslateModule],
+  templateUrl: './exposition.component.svg',
+  styles: [
+    `
+      text {
+        font-family: 'Roboto Light', sans-serif;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+/** En figur som viser utsatt himmelretning */
+export class ExpositionComponent {
+  /** Himmelretning som flagg, f.eks. 00111110 */
+  value = input.required<string>();
+
+  /** Overskrift */
+  text = input<string>();
+}

--- a/src/app/components/observation/graphics/ice-plot.component.ts
+++ b/src/app/components/observation/graphics/ice-plot.component.ts
@@ -11,11 +11,11 @@ import { DomSanitizer } from '@angular/platform-browser';
       <ion-spinner></ion-spinner>
     }
     <iframe
-      [hidden]="loading()"
+      loading="lazy"
       title="Ice Plot"
       [attr.src]="safeUrl()"
       (load)="onLoad()"
-      (error)="onLoad()"
+      (error)="onError()"
       importance="low"
       allowfullscreen="false"
     ></iframe>
@@ -34,14 +34,19 @@ import { DomSanitizer } from '@angular/platform-browser';
 export class IcePlotComponent {
   readonly url = input.required<string>();
   private sanitizer = inject(DomSanitizer);
-  loading = signal(true);
+  failed = signal(false);
+  loadCalledCount = signal(0);
+  loading = computed(() => this.loadCalledCount() < 2 && !this.failed());
 
   safeUrl = computed(() => {
     const result = this.sanitizer.bypassSecurityTrustResourceUrl(this.url());
     return result as string;
   });
 
-  onLoad(): void {
-    this.loading.set(false);
+  onLoad() {
+    this.loadCalledCount.set(this.loadCalledCount() + 1);
+  }
+  onError() {
+    this.failed.set(true);
   }
 }

--- a/src/app/components/observation/graphics/ice-plot.component.ts
+++ b/src/app/components/observation/graphics/ice-plot.component.ts
@@ -26,8 +26,6 @@ import { DomSanitizer } from '@angular/platform-browser';
         height: 280px;
         width: 140px;
         border: none;
-        margin-right: 32px;
-        margin-top: -10px;
       }
     `,
   ],

--- a/src/app/components/observation/graphics/ice-plot.component.ts
+++ b/src/app/components/observation/graphics/ice-plot.component.ts
@@ -1,0 +1,49 @@
+import { IonSpinner } from '@ionic/angular/standalone';
+import { Component, ChangeDetectionStrategy, input, inject, computed, signal } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+
+/** Viser en figur for istykkelse */
+@Component({
+  selector: 'app-ice-plot',
+  imports: [IonSpinner],
+  template: `
+    @if (loading()) {
+      <ion-spinner></ion-spinner>
+    }
+    <iframe
+      [hidden]="loading()"
+      title="Ice Plot"
+      [attr.src]="safeUrl()"
+      (load)="onLoad()"
+      (error)="onLoad()"
+      importance="low"
+      allowfullscreen="false"
+    ></iframe>
+  `,
+  styles: [
+    `
+      iframe {
+        height: 280px;
+        width: 140px;
+        border: none;
+        margin-right: 32px;
+        margin-top: -10px;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class IcePlotComponent {
+  readonly url = input.required<string>();
+  private sanitizer = inject(DomSanitizer);
+  loading = signal(true);
+
+  safeUrl = computed(() => {
+    const result = this.sanitizer.bypassSecurityTrustResourceUrl(this.url());
+    return result as string;
+  });
+
+  onLoad(): void {
+    this.loading.set(false);
+  }
+}

--- a/src/app/components/observation/graphics/ice-plot.component.ts
+++ b/src/app/components/observation/graphics/ice-plot.component.ts
@@ -36,6 +36,8 @@ export class IcePlotComponent {
   private sanitizer = inject(DomSanitizer);
   failed = signal(false);
   loadCalledCount = signal(0);
+
+  // iFrame sender load() før den er ferdig lastet, derfor sjekker vi om den er mindre enn 2
   loading = computed(() => this.loadCalledCount() < 2 && !this.failed());
 
   safeUrl = computed(() => {

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -38,10 +38,7 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { StaticMapImageComponent } from 'src/app/modules/static-map-image/static-map-image.component';
 import { ImageLocation } from '../../img-swiper/image-location.model';
 import L from 'leaflet';
-import {
-  getAllAttachmentsFromViewModel,
-  getRegistrationTids,
-} from 'src/app/modules/common-registration/registration.helpers';
+import { getAllAttachmentsFromViewModel } from 'src/app/modules/common-registration/registration.helpers';
 import { catchError, firstValueFrom, Observable, of, switchMap, timeout, TimeoutError } from 'rxjs';
 import { Router } from '@angular/router';
 import {
@@ -294,10 +291,11 @@ function getLocation(obs: RegistrationViewModel): ImageLocation {
   };
 }
 
+/** En liste av alle skjema som skal vises for denne observasjonen  */
 function getRegistrationViews(obs: RegistrationViewModel) {
-  // Ikke ideelt hvordan konfigen itereres over, skal finne på noe bedre
-  return Object.keys(REGISTRATION_VIEW_CONFIG)
-    .map((tid) => ({ config: REGISTRATION_VIEW_CONFIG[tid as unknown as number], tid }))
-    .filter(({ config }) => !config.isEmpty(obs))
-    .map(({ config, tid }) => ({ component: config.component, inputs: config.getInputs(obs), tid }));
+  return REGISTRATION_VIEW_CONFIG.filter((config) => !config.isEmpty(obs)).map((config) => ({
+    tid: Number(config.tid),
+    component: config.component,
+    inputs: config.getInputs(obs),
+  }));
 }

--- a/src/app/components/observation/registration-view-config.model.ts
+++ b/src/app/components/observation/registration-view-config.model.ts
@@ -1,7 +1,13 @@
 import { Type } from '@angular/core';
+import { RegistrationTid } from 'src/app/modules/common-registration/models/registration-tid.enum';
 import { RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 
 export interface RegistrationViewConfig {
+  /**
+   * ID til skjemaet som skal vises
+   */
+  tid: RegistrationTid;
+
   /**
    * Hvilken komponent som skal vises
    */

--- a/src/app/components/observation/registration-view-config.ts
+++ b/src/app/components/observation/registration-view-config.ts
@@ -7,6 +7,7 @@ import { AvalancheActivitesViewComponent } from './registrations/avalanche-activ
 import { AvalancheEvaluationViewComponent } from './registrations/avalanche-evaluation-view/avalanche-evaluation-view.component';
 import { AbalancheProblemsViewComponent } from './registrations/avalanche-problem-view/avalanche-problems-view.component';
 import { isEmpty } from 'src/app/modules/common-core/helpers';
+import { IceThicknessViewComponent } from './registrations/ice-thickness-view/ice-thickness-view.component';
 /**
  * Konfig for hvilke komponenter som skal vises for skjemaer i en registrering.
  *
@@ -119,9 +120,13 @@ export const REGISTRATION_VIEW_CONFIG: RegistrationViewConfig[] = [
   },
   {
     tid: RegistrationTid.IceThickness,
-    component: SummaryComponent,
+    component: IceThicknessViewComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.IceThickness),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.IceThickness),
+    getInputs: (reg) => ({
+      regId: reg.RegId,
+      data: reg.IceThickness,
+      summaries: getSummaryInputs(reg, RegistrationTid.IceThickness),
+    }),
   },
   {
     tid: RegistrationTid.WaterLevel,

--- a/src/app/components/observation/registration-view-config.ts
+++ b/src/app/components/observation/registration-view-config.ts
@@ -14,115 +14,137 @@ import { isEmpty } from 'src/app/modules/common-core/helpers';
  * Et alternativ hadde vært å feks falle tilbake på en Summary-baserte visning hvis
  * ikke det fantes en konfigurasjon for den registreringstypen.
  */
-export const REGISTRATION_VIEW_CONFIG: Record<number, RegistrationViewConfig> = {
-  [RegistrationTid.GeneralObservation]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.GeneralObservation),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.GeneralObservation),
-  },
-  [RegistrationTid.Incident]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.Incident),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.Incident),
-  },
-  [RegistrationTid.DangerObs]: {
+export const REGISTRATION_VIEW_CONFIG: RegistrationViewConfig[] = [
+  {
+    tid: RegistrationTid.DangerObs,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.DangerObs),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.DangerObs),
   },
-  [RegistrationTid.DamageObs]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.DamageObs),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.DamageObs),
-  },
-  [RegistrationTid.WeatherObservation]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.WeatherObservation),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.WeatherObservation),
-  },
-  [RegistrationTid.SnowSurfaceObservation]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.SnowSurfaceObservation),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.SnowSurfaceObservation),
-  },
-  [RegistrationTid.SnowCoverObs]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.SnowCoverObs),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.SnowCoverObs),
-  },
-  [RegistrationTid.AvalancheDangerObs]: {
+  {
+    tid: RegistrationTid.AvalancheDangerObs,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.AvalancheDangerObs),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheDangerObs),
   },
-  [RegistrationTid.CompressionTest]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.CompressionTest),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.CompressionTest),
-  },
-  [RegistrationTid.AvalancheObs]: {
+  {
+    tid: RegistrationTid.AvalancheObs,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.AvalancheObs),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheObs),
   },
-  [RegistrationTid.AvalancheActivityObs]: {
+  {
+    tid: RegistrationTid.Incident,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.Incident),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.Incident),
+  },
+  {
+    tid: RegistrationTid.DamageObs,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.DamageObs),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.DamageObs),
+  },
+  {
+    tid: RegistrationTid.AvalancheActivityObs,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.AvalancheActivityObs),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheActivityObs),
   },
-  [RegistrationTid.AvalancheEvaluation]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.AvalancheEvaluation),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheEvaluation),
-  },
-  [RegistrationTid.AvalancheEvaluation2]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.AvalancheEvaluation2),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheEvaluation2),
-  },
-  [RegistrationTid.AvalancheEvaluation3]: {
-    component: AvalancheEvaluationViewComponent,
-    isEmpty: (reg) => isEmpty(reg.AvalancheEvaluation3),
-    getInputs: (reg) => ({ data: reg.AvalancheEvaluation3 }),
-  },
-  [RegistrationTid.AvalancheEvalProblem2]: {
-    component: AbalancheProblemsViewComponent,
-    isEmpty: (reg) => isEmpty(reg.AvalancheEvalProblem2),
-    getInputs: (reg) => ({ data: reg.AvalancheEvalProblem2 }),
-  },
-  [RegistrationTid.AvalancheActivityObs2]: {
+  {
+    tid: RegistrationTid.AvalancheActivityObs2,
     component: AvalancheActivitesViewComponent,
     isEmpty: (reg) => isEmpty(reg.AvalancheActivityObs2),
     getInputs: (reg) => ({ data: reg.AvalancheActivityObs2 }),
   },
-  [RegistrationTid.SnowProfile2]: {
+  {
+    tid: RegistrationTid.WeatherObservation,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.WeatherObservation),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.WeatherObservation),
+  },
+  {
+    tid: RegistrationTid.SnowSurfaceObservation,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.SnowSurfaceObservation),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.SnowSurfaceObservation),
+  },
+  {
+    tid: RegistrationTid.SnowCoverObs,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.SnowCoverObs),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.SnowCoverObs),
+  },
+  {
+    tid: RegistrationTid.CompressionTest,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.CompressionTest),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.CompressionTest),
+  },
+  {
+    tid: RegistrationTid.SnowProfile2,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.SnowProfile2),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.SnowProfile2),
   },
-  [RegistrationTid.IceThickness]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.IceThickness),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.IceThickness),
+  {
+    tid: RegistrationTid.AvalancheEvalProblem2,
+    component: AbalancheProblemsViewComponent,
+    isEmpty: (reg) => isEmpty(reg.AvalancheEvalProblem2),
+    getInputs: (reg) => ({ data: reg.AvalancheEvalProblem2 }),
   },
-  [RegistrationTid.IceCoverObs]: {
+  {
+    tid: RegistrationTid.AvalancheEvaluation,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.AvalancheEvaluation),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheEvaluation),
+  },
+  {
+    tid: RegistrationTid.AvalancheEvaluation2,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.AvalancheEvaluation2),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheEvaluation2),
+  },
+  {
+    tid: RegistrationTid.AvalancheEvaluation3,
+    component: AvalancheEvaluationViewComponent,
+    isEmpty: (reg) => isEmpty(reg.AvalancheEvaluation3),
+    getInputs: (reg) => ({ data: reg.AvalancheEvaluation3 }),
+  },
+  {
+    tid: RegistrationTid.IceCoverObs,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.IceCoverObs),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.IceCoverObs),
   },
-  [RegistrationTid.WaterLevel]: {
+  {
+    tid: RegistrationTid.IceThickness,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.IceThickness),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.IceThickness),
+  },
+  {
+    tid: RegistrationTid.WaterLevel,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.WaterLevel),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.WaterLevel),
   },
-  [RegistrationTid.WaterLevel2]: {
+  {
+    tid: RegistrationTid.WaterLevel2,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.WaterLevel2),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.WaterLevel2),
   },
-  [RegistrationTid.LandSlideObs]: {
+  {
+    tid: RegistrationTid.LandSlideObs,
     component: SummaryComponent,
     isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.LandSlideObs),
     getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.LandSlideObs),
   },
-};
+  {
+    tid: RegistrationTid.GeneralObservation,
+    component: SummaryComponent,
+    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.GeneralObservation),
+    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.GeneralObservation),
+  },
+];

--- a/src/app/components/observation/registration-view-config.ts
+++ b/src/app/components/observation/registration-view-config.ts
@@ -3,10 +3,10 @@ import { RegistrationViewConfig } from './registration-view-config.model';
 import { SummaryComponent } from './summary/summary.component';
 import { getSummaryInputs } from './summary/get-summary-input';
 import { isObservationModelEmptyForRegistrationTid } from 'src/app/modules/common-registration/registration.helpers';
+import { AvalancheActivitesViewComponent } from './registrations/avalanche-activity-view/avalanche-activities-view.component';
 import { AvalancheEvaluationViewComponent } from './registrations/avalanche-evaluation-view/avalanche-evaluation-view.component';
 import { AbalancheProblemsViewComponent } from './registrations/avalanche-problem-view/avalanche-problems-view.component';
 import { isEmpty } from 'src/app/modules/common-core/helpers';
-
 /**
  * Konfig for hvilke komponenter som skal vises for skjemaer i en registrering.
  *
@@ -91,9 +91,9 @@ export const REGISTRATION_VIEW_CONFIG: Record<number, RegistrationViewConfig> = 
     getInputs: (reg) => ({ data: reg.AvalancheEvalProblem2 }),
   },
   [RegistrationTid.AvalancheActivityObs2]: {
-    component: SummaryComponent,
-    isEmpty: (reg) => isObservationModelEmptyForRegistrationTid(reg, RegistrationTid.AvalancheActivityObs2),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheActivityObs2),
+    component: AvalancheActivitesViewComponent,
+    isEmpty: (reg) => isEmpty(reg.AvalancheActivityObs2),
+    getInputs: (reg) => ({ data: reg.AvalancheActivityObs2 }),
   },
   [RegistrationTid.SnowProfile2]: {
     component: SummaryComponent,

--- a/src/app/components/observation/registration-view-config.ts
+++ b/src/app/components/observation/registration-view-config.ts
@@ -4,8 +4,8 @@ import { SummaryComponent } from './summary/summary.component';
 import { getSummaryInputs } from './summary/get-summary-input';
 import { isObservationModelEmptyForRegistrationTid } from 'src/app/modules/common-registration/registration.helpers';
 import { AvalancheEvaluationViewComponent } from './registrations/avalanche-evaluation-view/avalanche-evaluation-view.component';
+import { AbalancheProblemsViewComponent } from './registrations/avalanche-problem-view/avalanche-problems-view.component';
 import { isEmpty } from 'src/app/modules/common-core/helpers';
-import { AvalancheProblemViewComponent } from './registrations/avalanche-problem-view/avalanche-problem-view.component';
 
 /**
  * Konfig for hvilke komponenter som skal vises for skjemaer i en registrering.
@@ -86,11 +86,9 @@ export const REGISTRATION_VIEW_CONFIG: Record<number, RegistrationViewConfig> = 
     getInputs: (reg) => ({ data: reg.AvalancheEvaluation3 }),
   },
   [RegistrationTid.AvalancheEvalProblem2]: {
-    // TODO
-    // component: AvalancheProblemViewComponent,
-    component: SummaryComponent,
+    component: AbalancheProblemsViewComponent,
     isEmpty: (reg) => isEmpty(reg.AvalancheEvalProblem2),
-    getInputs: (reg) => getSummaryInputs(reg, RegistrationTid.AvalancheEvalProblem2),
+    getInputs: (reg) => ({ data: reg.AvalancheEvalProblem2 }),
   },
   [RegistrationTid.AvalancheActivityObs2]: {
     component: SummaryComponent,

--- a/src/app/components/observation/registration-view-config.ts
+++ b/src/app/components/observation/registration-view-config.ts
@@ -1,7 +1,7 @@
 import { RegistrationTid } from 'src/app/modules/common-registration/registration.models';
 import { RegistrationViewConfig } from './registration-view-config.model';
 import { SummaryComponent } from './summary/summary.component';
-import { getSummaryInputs } from './summary/get-summary-input';
+import { getSummaries, getSummaryInputs } from './summary/get-summary-input';
 import { isObservationModelEmptyForRegistrationTid } from 'src/app/modules/common-registration/registration.helpers';
 import { AvalancheActivitesViewComponent } from './registrations/avalanche-activity-view/avalanche-activities-view.component';
 import { AvalancheEvaluationViewComponent } from './registrations/avalanche-evaluation-view/avalanche-evaluation-view.component';
@@ -125,7 +125,7 @@ export const REGISTRATION_VIEW_CONFIG: RegistrationViewConfig[] = [
     getInputs: (reg) => ({
       regId: reg.RegId,
       data: reg.IceThickness,
-      summaries: getSummaryInputs(reg, RegistrationTid.IceThickness),
+      summaries: getSummaries(reg, RegistrationTid.IceThickness),
     }),
   },
   {

--- a/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activities-view.component.ts
+++ b/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activities-view.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+import { TranslatePipe } from '@ngx-translate/core';
+import { AvalancheActivityObs2ViewModel } from 'src/app/modules/common-regobs-api';
+import { RegistrationHeaderComponent } from '../../registration-header/registration-header.component';
+import { AvalancheActivityViewComponent } from './avalanche-activity-view.component';
+
+/**
+ * Brukes i observasjonskort for å vise en liste av registreringer av skredaktivitet
+ */
+@Component({
+  selector: 'app-avalanche-activities-view',
+  imports: [TranslatePipe, RegistrationHeaderComponent, AvalancheActivityViewComponent],
+  template: `
+    <app-registration-header>{{ 'REGISTRATION.SNOW.AVALANCHE_ACTIVITY.TITLE' | translate }}</app-registration-header>
+    @for (activity of data(); track $index) {
+      <app-avalanche-activity-view [data]="activity"></app-avalanche-activity-view>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AvalancheActivitesViewComponent {
+  readonly data = input.required<AvalancheActivityObs2ViewModel[]>();
+  count = computed(() => this.data().length);
+}

--- a/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.css
+++ b/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.css
@@ -1,0 +1,26 @@
+:host {
+  font-size: var(--observation-font-size, 1rem);
+  margin-top: 0.5rem;
+  display: block;
+}
+
+h4 {
+  font-size: var(--registration-subheader-font-size, 1.1rem);
+  font-weight: var(--registration-subheader-font-weight, 600);
+  color: var(--ion-text-color-heading);
+}
+
+app-key-value {
+  display: block;
+}
+
+.body-text {
+  font-style: var(--key-value-font-style, italic);
+}
+
+.exposition-graphics {
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  gap: 1rem;
+}

--- a/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.html
+++ b/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.html
@@ -1,0 +1,44 @@
+<!-- Visning av en registrering av skredaktivitet -->
+
+@if (title()) {
+  <h4 class="title">{{ title() }}</h4>
+}
+@if (comment()) {
+  <ion-text color="dark" class="body-text">{{ comment() }}</ion-text>
+}
+@if (formatTime()) {
+  <app-key-value
+    [key]="'REGISTRATION.SNOW.AVALANCHE_ACTIVITY.ESTIMATED_TIME' | translate"
+    [value]="formatTime().toLowerCase()"
+  />
+}
+@if (!noActivity && estimatedNum()) {
+  <app-key-value
+    [key]="'REGISTRATION.SNOW.AVALANCHE_ACTIVITY.HOW_MANY_AVALANCHES' | translate"
+    [value]="estimatedNum()"
+  />
+}
+@if (size()) {
+  <app-key-value [key]="'REGISTRATION.SNOW.AVALANCHE_OBS.DESTRUCTIVE_SIZE' | translate" [value]="size()" />
+}
+@if (triggerProbability()) {
+  <app-key-value
+    [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TRIGGER_PROBABILITY' | translate"
+    [value]="triggerProbability()"
+  />
+}
+@if (propagation()) {
+  <app-key-value [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION' | translate" [value]="propagation()" />
+}
+<div class="exposition-graphics">
+  @if (exposition()) {
+    <app-exposition [value]="exposition()" text="test:)" />
+  }
+  @if (exposedHeightComboTid()) {
+    <app-exposed-height
+      [exposedHeightComboTid]="exposedHeightComboTid()"
+      [exposedHeight1]="exposedHeight1()"
+      [exposedHeight2]="exposedHeight2()"
+    />
+  }
+</div>

--- a/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.ts
+++ b/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.ts
@@ -1,0 +1,73 @@
+import { ChangeDetectionStrategy, Component, computed, input, inject } from '@angular/core';
+import { TranslateService, TranslatePipe } from '@ngx-translate/core';
+import { injectKdv } from 'src/app/modules/common-registration/services/kdv/inject-kdv';
+import { AvalancheActivityObs2ViewModel } from 'src/app/modules/common-regobs-api';
+import { KeyValueComponent } from '../../key-value/key-value.component';
+import { ExposedHeightComponent } from '../../graphics/exposed-height/exposed-height.component';
+import { ExpositionComponent } from '../../graphics/exposition/exposition.component';
+import { IonText } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-avalanche-activity-view',
+  imports: [TranslatePipe, KeyValueComponent, ExposedHeightComponent, ExpositionComponent, IonText],
+  templateUrl: './avalanche-activity-view.component.html',
+  styleUrl: './avalanche-activity-view.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+/** Brukes i observasjonskort for å vise en registrering av skredaktivitet */
+export class AvalancheActivityViewComponent {
+  data = input.required<AvalancheActivityObs2ViewModel>();
+  private translateService = inject(TranslateService);
+
+  private estimatedNumKdv = injectKdv('Snow_EstimatedNumKDV');
+  private avalancheTypeKdv = injectKdv('Snow_AvalancheExtKDV');
+  private avalancheTriggerKdv = injectKdv('Snow_AvalTriggerSimpleKDV');
+  private sizeKdv = injectKdv('Snow_DestructiveSizeKDV');
+  private propagationKdv = injectKdv('Snow_AvalPropagationKDV');
+
+  private estimatedNumTid = computed(() => this.data().EstimatedNumTID);
+  private typeTid = computed(() => this.data().AvalancheExtTID);
+  private triggerSimpleTid = computed(() => this.data().AvalTriggerSimpleTID);
+  private sizeTid = computed(() => this.data().DestructiveSizeTID);
+  private propagationTid = computed(() => this.data().AvalPropagationTID);
+
+  estimatedNum = this.estimatedNumKdv.getName(this.estimatedNumTid);
+  noActivity = computed(() => this.estimatedNumTid() === 1); // 0 skred / ingen skredaktivitet
+
+  // vi viser skredtype hvis hvis antall skred er > 0, ellers viser vi "Ingen skredaktivitet"
+  title = computed(() => (this.noActivity() ? this.estimatedNum() : this.avalancheTypeKdv.getName(this.typeTid)()));
+
+  triggerProbability = this.avalancheTriggerKdv.getName(this.triggerSimpleTid);
+  propagation = this.propagationKdv.getName(this.propagationTid);
+  size = this.sizeKdv.getName(this.sizeTid);
+  exposedHeightComboTid = computed(() => this.data().ExposedHeightComboTID);
+  exposedHeight1 = computed(() => this.data().ExposedHeight1);
+  exposedHeight2 = computed(() => this.data().ExposedHeight2);
+  exposition = computed(() => this.data().ValidExposition || '');
+  comment = computed(() => this.data().Comment);
+
+  private duringTheDay = this.translateService.instant('REGISTRATION.SNOW.AVALANCHE_ACTIVITY.DURING_THE_DAY');
+
+  formatTime = computed(() => {
+    const startTime = this.parseDate(this.data().DtStart);
+    const endTime = this.parseDate(this.data().DtEnd);
+
+    if (startTime && endTime) {
+      const day = startTime.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+      const startHour = startTime.getHours();
+      const endHour = endTime.getHours();
+      if (startHour === 0 && endHour === 23) {
+        return `${day}, ${this.duringTheDay}`; // 23 er 23:59, som vi tolker som "ut dagen"
+      }
+      return `${day}, ${startHour}-${endHour}`;
+    }
+    return '';
+  });
+
+  private parseDate = (date: string | undefined): Date | undefined => {
+    if (date) {
+      return new Date(date as string);
+    }
+    return undefined;
+  };
+}

--- a/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.css
+++ b/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.css
@@ -1,3 +1,26 @@
 :host {
+  font-size: var(--observation-font-size, 1rem);
+  margin-top: 0.5rem;
   display: block;
+}
+
+h4 {
+  font-size: var(--registration-subheader-font-size, 1.1rem);
+  font-weight: var(--registration-subheader-font-weight, 600);
+  color: var(--ion-text-color-heading);
+}
+
+app-key-value {
+  display: block;
+}
+
+.soft-layer-attributes {
+  font-style: var(--key-value-font-style, italic);
+}
+
+.exposition-graphics {
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  gap: 1rem;
 }

--- a/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.html
+++ b/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.html
@@ -1,1 +1,55 @@
-<p>Skredproblem - TODO</p>
+<!-- Visning av ett skredproblem -->
+
+@if (cause()) {
+  <h4 class="title">{{ cause() }}</h4>
+}
+@if (comment()) {
+  <ion-text color="dark" class="soft-layer-attributes">{{ comment() }}</ion-text>
+}
+@if (type()) {
+  <app-key-value [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE' | translate" [value]="type()" />
+}
+@if (causeDepth()) {
+  <app-key-value [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER_DEPTH' | translate" [value]="causeDepth()" />
+}
+<ion-text color="dark" class="soft-layer-attributes">
+  @if (easyCollapseLabel()) {
+    {{ easyCollapseLabel() }}
+  }
+  @if (softLayerLabel()) {
+    {{ softLayerLabel() }}
+  }
+  @if (largeCrystalLabel()) {
+    {{ largeCrystalLabel() }}
+  }
+</ion-text>
+@if (triggerProbability()) {
+  <app-key-value
+    [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TRIGGER_PROBABILITY' | translate"
+    [value]="triggerProbability()"
+  />
+}
+@if (size()) {
+  <app-key-value
+    [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_DESTRUCTIVE_SIZE' | translate"
+    [value]="size()"
+  />
+}
+@if (probability()) {
+  <app-key-value [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVAL_PROBABILITY' | translate" [value]="probability()" />
+}
+@if (propagation()) {
+  <app-key-value [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.PROPAGATION' | translate" [value]="propagation()" />
+}
+<div class="exposition-graphics">
+  @if (exposition()) {
+    <app-exposition [value]="exposition()" text="test:)" />
+  }
+  @if (exposedHeightComboTid()) {
+    <app-exposed-height
+      [exposedHeightComboTid]="exposedHeightComboTid()"
+      [exposedHeight1]="exposedHeight1()"
+      [exposedHeight2]="exposedHeight2()"
+    />
+  }
+</div>

--- a/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.ts
+++ b/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.ts
@@ -1,10 +1,56 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { injectKdv } from 'src/app/modules/common-registration/services/kdv/inject-kdv';
+import { AvalancheEvalProblem2ViewModel } from 'src/app/modules/common-regobs-api';
+import { KeyValueComponent } from '../../key-value/key-value.component';
+import { ExposedHeightComponent } from '../../graphics/exposed-height/exposed-height.component';
+import { ExpositionComponent } from '../../graphics/exposition/exposition.component';
+import { IonText } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-avalanche-problem-view',
-  imports: [],
+  imports: [TranslatePipe, KeyValueComponent, ExposedHeightComponent, ExpositionComponent, IonText],
   templateUrl: './avalanche-problem-view.component.html',
   styleUrl: './avalanche-problem-view.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AvalancheProblemViewComponent { }
+/** Brukes i observasjonskort for å vise ett skredproblem */
+export class AvalancheProblemViewComponent {
+  data = input.required<AvalancheEvalProblem2ViewModel>();
+
+  private avalancheCauseDepthKdv = injectKdv('Snow_AvalCauseDepthKDV');
+  private avalancheCauseKdv = injectKdv('Snow_AvalCauseKDV');
+  private avalancheTypeKdv = injectKdv('Snow_AvalancheExtKDV');
+  private avalancheTriggerKdv = injectKdv('Snow_AvalTriggerSimpleKDV');
+  private attributeFlagsKdv = injectKdv('Snow_AvalCauseAttributeFlags');
+  private avalancheProbabilityKdv = injectKdv('Snow_AvalProbabilityKDV');
+  private sizeKdv = injectKdv('Snow_DestructiveSizeKDV');
+  private propagationKdv = injectKdv('Snow_AvalPropagationKDV');
+
+  private causeTid = computed(() => this.data().AvalCauseTID);
+  private causeDepthTid = computed(() => this.data().AvalCauseDepthTID);
+  private typeTid = computed(() => this.data().AvalancheExtTID);
+  private triggerSimpleTid = computed(() => this.data().AvalTriggerSimpleTID);
+  private causeLightTid = computed(() => this.data().AvalCauseAttributeLightTID);
+  private causeSoftTid = computed(() => this.data().AvalCauseAttributeSoftTID);
+  private causeCrystalTid = computed(() => this.data().AvalCauseAttributeCrystalTID);
+  private probabilityTid = computed(() => this.data().AvalProbabilityTID);
+  private sizeTid = computed(() => this.data().DestructiveSizeTID);
+  private propagationTid = computed(() => this.data().AvalPropagationTID);
+
+  cause = this.avalancheCauseKdv.getName(this.causeTid);
+  causeDepth = this.avalancheCauseDepthKdv.getName(this.causeDepthTid);
+  type = this.avalancheTypeKdv.getName(this.typeTid);
+  triggerProbability = this.avalancheTriggerKdv.getName(this.triggerSimpleTid);
+  probability = this.avalancheProbabilityKdv.getName(this.probabilityTid);
+  easyCollapseLabel = this.attributeFlagsKdv.getName(this.causeLightTid);
+  softLayerLabel = this.attributeFlagsKdv.getName(this.causeSoftTid);
+  largeCrystalLabel = this.attributeFlagsKdv.getName(this.causeCrystalTid);
+  propagation = this.propagationKdv.getName(this.propagationTid);
+  size = this.sizeKdv.getName(this.sizeTid);
+  exposedHeightComboTid = computed(() => this.data().ExposedHeightComboTID);
+  exposedHeight1 = computed(() => this.data().ExposedHeight1);
+  exposedHeight2 = computed(() => this.data().ExposedHeight2);
+  exposition = computed(() => this.data().ValidExposition || '');
+  comment = computed(() => this.data().Comment);
+}

--- a/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problems-view.component.ts
+++ b/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problems-view.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+import { TranslatePipe } from '@ngx-translate/core';
+import { AvalancheEvalProblem2ViewModel } from 'src/app/modules/common-regobs-api';
+import { RegistrationHeaderComponent } from '../../registration-header/registration-header.component';
+import { AvalancheProblemViewComponent } from './avalanche-problem-view.component';
+
+/**
+ * Brukes i observasjonskort for å vise en liste av skredproblemer
+ */
+@Component({
+  selector: 'app-avalanche-problems-view',
+  imports: [TranslatePipe, RegistrationHeaderComponent, AvalancheProblemViewComponent],
+  template: `
+    <app-registration-header>{{ 'REGISTRATION.SNOW.AVALANCHE_PROBLEM.TITLE' | translate }}</app-registration-header>
+    @for (singleProblem of data(); track $index) {
+      <app-avalanche-problem-view [data]="singleProblem"></app-avalanche-problem-view>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AbalancheProblemsViewComponent {
+  readonly data = input.required<AvalancheEvalProblem2ViewModel[]>();
+  count = computed(() => this.data().length);
+}

--- a/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.css
+++ b/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.css
@@ -1,0 +1,4 @@
+:host {
+  display: flex;
+  gap: 1rem;
+}

--- a/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.html
+++ b/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.html
@@ -1,0 +1,3 @@
+<!-- Visning av istykkelse -->
+<app-summary [summaries]="rawSummaries()"></app-summary>
+<app-ice-plot [url]="plotUrl()"></app-ice-plot>

--- a/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.html
+++ b/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.html
@@ -1,3 +1,3 @@
 <!-- Visning av istykkelse -->
-<app-summary [summaries]="rawSummaries()"></app-summary>
+<app-summary [summaries]="summaries()"></app-summary>
 <app-ice-plot [url]="plotUrl()"></app-ice-plot>

--- a/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.ts
+++ b/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { IceThicknessViewModel } from 'src/app/modules/common-regobs-api';
+import { SummaryComponent } from '../../summary/summary.component';
+import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { AppMode } from 'src/app/modules/common-core/models/app-mode.enum';
+import { settings } from 'src/settings';
+import { IcePlotComponent } from '../../graphics/ice-plot.component';
+
+@Component({
+  selector: 'app-avalanche-problem-view',
+  imports: [SummaryComponent, IcePlotComponent],
+  templateUrl: './ice-thickness-view.component.html',
+  styleUrls: ['./ice-thickness-view.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+/** Brukes i observasjonskort for å vise istykkelse */
+export class IceThicknessViewComponent {
+  readonly regId = input.required<number>();
+  readonly data = input.required<IceThicknessViewModel>();
+  readonly summaries = input.required<any>();
+  private userSettingsService = inject(UserSettingService);
+
+  // fordi getSummaryInputs() returnerer { summaries: Summary[] }, må vi pakke det ut, vi trenger bare Summary[]
+  rawSummaries = computed(() => this.summaries().summaries);
+
+  private appMode = toSignal(this.userSettingsService.appMode$, { initialValue: AppMode.Prod });
+  private plotBaseUrl = settings.iceThicknessPlotUrl[this.appMode()];
+  readonly plotUrl = computed(() => `${this.plotBaseUrl}${this.regId().toString()}`);
+}

--- a/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.ts
+++ b/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.ts
@@ -19,10 +19,8 @@ export class IceThicknessViewComponent {
   readonly regId = input.required<number>();
   readonly data = input.required<IceThicknessViewModel>();
   readonly summaries = input.required<any>();
-  private userSettingsService = inject(UserSettingService);
 
-  // fordi getSummaryInputs() returnerer { summaries: Summary[] }, må vi pakke det ut, vi trenger bare Summary[]
-  rawSummaries = computed(() => this.summaries().summaries);
+  private userSettingsService = inject(UserSettingService);
 
   private appMode = toSignal(this.userSettingsService.appMode$, { initialValue: AppMode.Prod });
   private plotBaseUrl = settings.iceThicknessPlotUrl[this.appMode()];

--- a/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.ts
+++ b/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.ts
@@ -8,7 +8,7 @@ import { settings } from 'src/settings';
 import { IcePlotComponent } from '../../graphics/ice-plot.component';
 
 @Component({
-  selector: 'app-avalanche-problem-view',
+  selector: 'app-ice-thickness-view',
   imports: [SummaryComponent, IcePlotComponent],
   templateUrl: './ice-thickness-view.component.html',
   styleUrls: ['./ice-thickness-view.component.css'],

--- a/src/app/components/observation/summary/get-summary-input.ts
+++ b/src/app/components/observation/summary/get-summary-input.ts
@@ -1,8 +1,14 @@
 import { RegistrationTid } from 'src/app/modules/common-registration/registration.models';
-import { RegistrationViewModel } from 'src/app/modules/common-regobs-api';
+import { RegistrationViewModel, Summary } from 'src/app/modules/common-regobs-api';
 
+/** Plukker ut summaries for angitt skjematype */
+export function getSummaries(registration: RegistrationViewModel, tid: RegistrationTid): Summary[] {
+  return (registration.Summaries || []).filter((s) => s.RegistrationTID === tid);
+}
+
+/** Plukker ut summaries for angitt skjematype og putter dette i et objekt som er tilpasset SummaryComponent */
 export function getSummaryInputs(registration: RegistrationViewModel, tid: RegistrationTid) {
   return {
-    summaries: (registration.Summaries || []).filter((s) => s.RegistrationTID === tid),
+    summaries: getSummaries(registration, tid),
   };
 }

--- a/src/app/modules/common-registration/services/kdv/inject-kdv.ts
+++ b/src/app/modules/common-registration/services/kdv/inject-kdv.ts
@@ -18,11 +18,16 @@ export function injectKdv(key: KdvKey) {
 
     /**
      * Returnerer en computed som henter navnet / teksten til en type id (Tid).
+     * Verdier med TID = 0 eller x00 betyr vanligvis "ikke gitt" e.l., så de filtrerer vi vekk ved å returnere undefined
+     * @param showAlsoNotGiven Sett denne til true for å ta med verdier med TID = 0 eller x00 (100, 200 osv.)
      */
-    getName: (tid: Signal<number | undefined>) =>
+    getName: (tid: Signal<number | undefined>, showAlsoNotGiven = false) =>
       computed(() => {
         const table = kdv();
         const typeId = tid();
+        if (typeId === undefined || (!showAlsoNotGiven && (typeId === 0 || typeId % 100 === 0))) {
+          return undefined; // filtrer vekk verdier som ikke skal vises
+        }
         return table.find((v) => v.Id === typeId)?.Name ?? typeId?.toString();
       }),
   };

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -37,6 +37,24 @@
     "TOGGLE_OBSERVATION_EXTRA_INFO": "Toggle on to send observations at your position - simple and fast. This is extremely useful for the warning services and for other users.\n \n Toggle off to submit a more advanced observation - just like before.",
     "VIEW_WARNINGS": "View warnings from varsom.no"
   },
+  "COMPASS_DIRECTION": {
+    "EAST": "East",
+    "EAST_SHORT": "E",
+    "NORTH": "North",
+    "NORTH_EAST": "North-East",
+    "NORTH_EAST_SHORT": "NE",
+    "NORTH_SHORT": "N",
+    "NORTH_WEST": "North-West",
+    "NORTH_WEST_SHORT": "NW",
+    "SOUTH": "South",
+    "SOUTH_EAST": "South-East",
+    "SOUTH_EAST_SHORT": "SE",
+    "SOUTH_SHORT": "S",
+    "SOUTH_WEST": "South-West",
+    "SOUTH_WEST_SHORT": "SW",
+    "WEST": "West",
+    "WEST_SHORT": "W"
+  },
   "COMPETENCE": {
     "UNKNOWN": "Competence unknown"
   },

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -37,6 +37,24 @@
     "TOGGLE_OBSERVATION_EXTRA_INFO": "Slå på for å sende inn observasjoner av situasjonen der du er – enkelt og raskt. Dette er supernyttige data for varslingen og andre brukere.\n \n Slå av for å få alle valgene for innsending av observasjoner – som før.",
     "VIEW_WARNINGS": "Se varsler fra varsom.no"
   },
+  "COMPASS_DIRECTION": {
+    "EAST": "Øst",
+    "EAST_SHORT": "Ø",
+    "NORTH": "Nord",
+    "NORTH_EAST": "Nord-Øst",
+    "NORTH_EAST_SHORT": "NØ",
+    "NORTH_SHORT": "N",
+    "NORTH_WEST": "Nord-Vest",
+    "NORTH_WEST_SHORT": "NV",
+    "SOUTH": "Sør",
+    "SOUTH_EAST": "Sør-Øst",
+    "SOUTH_EAST_SHORT": "SØ",
+    "SOUTH_SHORT": "S",
+    "SOUTH_WEST": "Sør-Vest",
+    "SOUTH_WEST_SHORT": "SV",
+    "WEST": "Vest",
+    "WEST_SHORT": "V"
+  },
   "COMPETENCE": {
     "UNKNOWN": "Ukjent kompetanse"
   },

--- a/src/settings.model.ts
+++ b/src/settings.model.ts
@@ -114,4 +114,10 @@ export interface ISettings {
     en: string;
   };
   feedbackWebUrl: string;
+
+  /**
+   * URL til tjenesten som plotter istykkelse. Legg til reg-ID på slutten av URL.
+   * Eksempel: https://test-plot.regobs.no/v1/IceThickness/265830/
+   */
+  iceThicknessPlotUrl: any;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -434,4 +434,9 @@ export const settings: ISettings = {
   },
   feedbackWebUrl:
     'https://forms.office.com/Pages/ResponsePage.aspx?id=DYSNvMlgC0G0-xG4aAZ4DNWEVVcEorZHtmeqQxJTsoVUQ001UkpYUlU0SEwySEpQRkdZMVJDUU1VOCQlQCN0PWcu',
+  iceThicknessPlotUrl: {
+    TEST: 'https://test-plot.regobs.no/v1/IceThickness/',
+    DEMO: 'https://demo-plot.regobs.no/v1/IceThickness/',
+    PROD: 'https://plot.regobs.no/v1/IceThickness/',
+  },
 };


### PR DESCRIPTION
Disse skjema har fått grafikk: Skredproblem, skredaktivitet og istykkelse, i tillegg til skredfarevurdering, som hadde det fra før.
Dette var mer jobb enn jeg trodde. Mye kløning i starten, så det vil nok gå raskere etterhvert.
Se også #697, som sier noe om tankene bak strukturen på koden.

Jeg har kopiert komponentene som viser grafikken fra gamle regobs.no og fjernet alt som har med AdaptiveCards å gjøre. Kult å se hvor fleksibelt man kan lage grafikk med svg, jeg hadde ikke sett denne koden før.
Tekstene for kompassretninger stjal jeg fra https://github.com/NVE/Varsom-Regobs-Translations/tree/master/web

Jeg viser kun felter som man kan fylle ut i dagens versjon av appen, så noen gamle observasjoner blir kanskje noe mangelfulle. For skredproblem og skredaktivitet valgte jeg å legge kommentar-feltet øverst, så det ikke ble liggende for seg selv under grafikken.

For istykkelse valgte jeg å bruke summaries-komponenten for å teste ut hvordan vi kan kombinere å vise grafikk samtidig som vi baserer oss på summaries.

- [ ] Spinneren som skal vises når man laster istykkelse-plot funker ikke. Kom gjerne med tips til hva jeg har gjort feil!

Her er to observasjoner hvor jeg har fylt ut alle felter for aktuelle skjema, som man kan bruke som "fasit" å sjekke mot:
- Snø: https://test.regobs.no/Registration/265825
- Is: https://test.regobs.no/Registration/265830

Takk for hjelp til sortering og å vise summaries i istykkelse!