### PR TITLE
RO-2721: fikse swiper-container-høyde

### DIFF
--- a/src/app/pages/start-wizard/start-wizard.page.html
+++ b/src/app/pages/start-wizard/start-wizard.page.html
@@ -13,68 +13,78 @@
   (swiperslidechange)="onSlideChange($event)"
 >
   <swiper-slide>
-    <img alt="" src="/assets/images/onboarding/eclipse.svg" />
-    <h2>
-      {{ "SETTINGS.LANGUAGE" | translate }}
-      @if (language() !== LangKey.en) {
-        <span> / Language</span>
-      }
-    </h2>
-    <ion-list class="language-list">
-      <ion-item class="ion-no-padding">
-        <ion-label position="stacked" color="medium">
-          {{ "START_WIZARD.CHOOSE_LANGUAGE.HEADER" | translate }}
-          @if (language() !== LangKey.en) {
-            <span> / Choose language</span>
-          }
-        </ion-label>
-        <ion-select
-          cancelText="{{ 'DIALOGS.CANCEL' | translate }}"
-          [interface]="!isDesktop ? 'action-sheet' : 'popover'"
-          (ionChange)="saveLanguage($event)"
-          [value]="language()"
-        >
-          @for (lang of supportedLanguages; track lang.langKey) {
-            <ion-select-option [value]="lang.langKey">
-              {{ lang.name }}
-            </ion-select-option>
-          }
-        </ion-select>
-      </ion-item>
-    </ion-list>
-  </swiper-slide>
-  <swiper-slide>
-    <img alt="" src="/assets/images/onboarding/line.svg" />
-    <h2>{{ "START_WIZARD.PAGE_1.HEADER" | translate }}</h2>
-    <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_1.LINE_1" | translate }}</h3>
-  </swiper-slide>
-  <swiper-slide>
-    <div style="position: relative; padding-bottom: 90px">
-      <img alt="" src="/assets/images/onboarding/danger-map.svg" />
-      <img
-        alt=""
-        style="position: absolute; left: 0; z-index: -1"
-        src="/assets/images/onboarding/steepness-background.svg"
-      />
+    <div class="text-scrollable text-scrollable--center">
+      <img alt="" src="/assets/images/onboarding/eclipse.svg" />
+      <h2>
+        {{ "SETTINGS.LANGUAGE" | translate }}
+        @if (language() !== LangKey.en) {
+          <span> / Language</span>
+        }
+      </h2>
+      <ion-list class="language-list">
+        <ion-item class="ion-no-padding">
+          <ion-label position="stacked" color="medium">
+            {{ "START_WIZARD.CHOOSE_LANGUAGE.HEADER" | translate }}
+            @if (language() !== LangKey.en) {
+              <span> / Choose language</span>
+            }
+          </ion-label>
+          <ion-select
+            cancelText="{{ 'DIALOGS.CANCEL' | translate }}"
+            [interface]="!isDesktop ? 'action-sheet' : 'popover'"
+            (ionChange)="saveLanguage($event)"
+            [value]="language()"
+          >
+            @for (lang of supportedLanguages; track lang.langKey) {
+              <ion-select-option [value]="lang.langKey">
+                {{ lang.name }}
+              </ion-select-option>
+            }
+          </ion-select>
+        </ion-item>
+      </ion-list>
     </div>
-    <h2>{{ "START_WIZARD.PAGE_2.HEADER" | translate }}</h2>
-    <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_2.LINE_1" | translate }}</h3>
   </swiper-slide>
   <swiper-slide>
-    <img alt="" src="/assets/images/onboarding/add-observation.svg" />
+    <div class="text-scrollable text-scrollable--center">
+      <img alt="" src="/assets/images/onboarding/line.svg" />
+      <h2>{{ "START_WIZARD.PAGE_1.HEADER" | translate }}</h2>
+      <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_1.LINE_1" | translate }}</h3>
+    </div>
+  </swiper-slide>
+  <swiper-slide>
+    <div class="text-scrollable text-scrollable--center">
+      <div style="position: relative; padding-bottom: 90px">
+        <img alt="" src="/assets/images/onboarding/danger-map.svg" />
+        <img
+          alt=""
+          style="position: absolute; left: 0; z-index: -1"
+          src="/assets/images/onboarding/steepness-background.svg"
+        />
+      </div>
+      <h2>{{ "START_WIZARD.PAGE_2.HEADER" | translate }}</h2>
+      <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_2.LINE_1" | translate }}</h3>
+    </div>
+  </swiper-slide>
+  <swiper-slide>
+    <div class="text-scrollable text-scrollable--center">
+      <img alt="" src="/assets/images/onboarding/add-observation.svg" />
 
-    <h2>{{ "START_WIZARD.PAGE_3.HEADER" | translate }}</h2>
-    <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_3.LINE_1" | translate }}</h3>
+      <h2>{{ "START_WIZARD.PAGE_3.HEADER" | translate }}</h2>
+      <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_3.LINE_1" | translate }}</h3>
+    </div>
   </swiper-slide>
   <swiper-slide>
-    <img src="/assets/images/onboarding/competence-finger.svg" />
-    <h2>{{ "START_WIZARD.COMPETENCE_PAGE.HEADER" | translate }}</h2>
-    <h3 class="ion-text-wrap">{{ "START_WIZARD.COMPETENCE_PAGE.LINE_1" | translate }}</h3>
+    <div class="text-scrollable text-scrollable--center">
+      <img src="/assets/images/onboarding/competence-finger.svg" />
+      <h2>{{ "START_WIZARD.COMPETENCE_PAGE.HEADER" | translate }}</h2>
+      <h3 class="ion-text-wrap">{{ "START_WIZARD.COMPETENCE_PAGE.LINE_1" | translate }}</h3>
+    </div>
   </swiper-slide>
   <swiper-slide>
-    <img alt="" class="legal__icon" src="/assets/images/onboarding/legal.svg" />
-    <h2>{{ "LEGAL_TERMS.HEADER" | translate }}</h2>
-    <h3 class="ion-no-padding ion-text-wrap">
+    <div class="text-scrollable">
+      <img alt="" class="legal__icon" src="/assets/images/onboarding/legal.svg" />
+      <h2>{{ "LEGAL_TERMS.HEADER" | translate }}</h2>
       <ul class="legal-text">
         <li>{{ "LEGAL_TERMS.LINE_1" | translate }}</li>
         <li>{{ "LEGAL_TERMS.LINE_2" | translate }}</li>
@@ -89,7 +99,7 @@
           <span [innerHtml]="'LEGAL_TERMS.LINE_6' | translate: { legalUrl: legalUrl }"></span>
         </li>
       </ul>
-    </h3>
+    </div>
   </swiper-slide>
 </swiper-container>
 <ion-footer>

--- a/src/app/pages/start-wizard/start-wizard.page.html
+++ b/src/app/pages/start-wizard/start-wizard.page.html
@@ -13,93 +13,81 @@
   (swiperslidechange)="onSlideChange($event)"
 >
   <swiper-slide>
-    <div class="text-scrollable text-scrollable--center">
-      <img alt="" src="/assets/images/onboarding/eclipse.svg" />
-      <h2>
-        {{ "SETTINGS.LANGUAGE" | translate }}
-        @if (language() !== LangKey.en) {
-          <span> / Language</span>
-        }
-      </h2>
-      <ion-list class="language-list">
-        <ion-item class="ion-no-padding">
-          <ion-label position="stacked" color="medium">
-            {{ "START_WIZARD.CHOOSE_LANGUAGE.HEADER" | translate }}
-            @if (language() !== LangKey.en) {
-              <span> / Choose language</span>
-            }
-          </ion-label>
-          <ion-select
-            cancelText="{{ 'DIALOGS.CANCEL' | translate }}"
-            [interface]="!isDesktop ? 'action-sheet' : 'popover'"
-            (ionChange)="saveLanguage($event)"
-            [value]="language()"
-          >
-            @for (lang of supportedLanguages; track lang.langKey) {
-              <ion-select-option [value]="lang.langKey">
-                {{ lang.name }}
-              </ion-select-option>
-            }
-          </ion-select>
-        </ion-item>
-      </ion-list>
-    </div>
+    <img alt="" src="/assets/images/onboarding/eclipse.svg" />
+    <h2>
+      {{ "SETTINGS.LANGUAGE" | translate }}
+      @if (language() !== LangKey.en) {
+        <span> / Language</span>
+      }
+    </h2>
+    <ion-list class="language-list">
+      <ion-item class="ion-no-padding">
+        <ion-label position="stacked" color="medium">
+          {{ "START_WIZARD.CHOOSE_LANGUAGE.HEADER" | translate }}
+          @if (language() !== LangKey.en) {
+            <span> / Choose language</span>
+          }
+        </ion-label>
+        <ion-select
+          cancelText="{{ 'DIALOGS.CANCEL' | translate }}"
+          [interface]="!isDesktop ? 'action-sheet' : 'popover'"
+          (ionChange)="saveLanguage($event)"
+          [value]="language()"
+        >
+          @for (lang of supportedLanguages; track lang.langKey) {
+            <ion-select-option [value]="lang.langKey">
+              {{ lang.name }}
+            </ion-select-option>
+          }
+        </ion-select>
+      </ion-item>
+    </ion-list>
   </swiper-slide>
   <swiper-slide>
-    <div class="text-scrollable text-scrollable--center">
-      <img alt="" src="/assets/images/onboarding/line.svg" />
-      <h2>{{ "START_WIZARD.PAGE_1.HEADER" | translate }}</h2>
-      <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_1.LINE_1" | translate }}</h3>
-    </div>
+    <img alt="" src="/assets/images/onboarding/line.svg" />
+    <h2>{{ "START_WIZARD.PAGE_1.HEADER" | translate }}</h2>
+    <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_1.LINE_1" | translate }}</h3>
   </swiper-slide>
   <swiper-slide>
-    <div class="text-scrollable text-scrollable--center">
-      <div style="position: relative; padding-bottom: 90px">
-        <img alt="" src="/assets/images/onboarding/danger-map.svg" />
-        <img
-          alt=""
-          style="position: absolute; left: 0; z-index: -1"
-          src="/assets/images/onboarding/steepness-background.svg"
-        />
-      </div>
-      <h2>{{ "START_WIZARD.PAGE_2.HEADER" | translate }}</h2>
-      <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_2.LINE_1" | translate }}</h3>
+    <div style="position: relative; padding-bottom: 90px">
+      <img alt="" src="/assets/images/onboarding/danger-map.svg" />
+      <img
+        alt=""
+        style="position: absolute; left: 0; z-index: -1"
+        src="/assets/images/onboarding/steepness-background.svg"
+      />
     </div>
+    <h2>{{ "START_WIZARD.PAGE_2.HEADER" | translate }}</h2>
+    <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_2.LINE_1" | translate }}</h3>
   </swiper-slide>
   <swiper-slide>
-    <div class="text-scrollable text-scrollable--center">
-      <img alt="" src="/assets/images/onboarding/add-observation.svg" />
+    <img alt="" src="/assets/images/onboarding/add-observation.svg" />
 
-      <h2>{{ "START_WIZARD.PAGE_3.HEADER" | translate }}</h2>
-      <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_3.LINE_1" | translate }}</h3>
-    </div>
+    <h2>{{ "START_WIZARD.PAGE_3.HEADER" | translate }}</h2>
+    <h3 class="ion-text-wrap">{{ "START_WIZARD.PAGE_3.LINE_1" | translate }}</h3>
   </swiper-slide>
   <swiper-slide>
-    <div class="text-scrollable text-scrollable--center">
-      <img src="/assets/images/onboarding/competence-finger.svg" />
-      <h2>{{ "START_WIZARD.COMPETENCE_PAGE.HEADER" | translate }}</h2>
-      <h3 class="ion-text-wrap">{{ "START_WIZARD.COMPETENCE_PAGE.LINE_1" | translate }}</h3>
-    </div>
+    <img src="/assets/images/onboarding/competence-finger.svg" />
+    <h2>{{ "START_WIZARD.COMPETENCE_PAGE.HEADER" | translate }}</h2>
+    <h3 class="ion-text-wrap">{{ "START_WIZARD.COMPETENCE_PAGE.LINE_1" | translate }}</h3>
   </swiper-slide>
   <swiper-slide>
-    <div class="text-scrollable">
-      <img alt="" class="legal__icon" src="/assets/images/onboarding/legal.svg" />
-      <h2>{{ "LEGAL_TERMS.HEADER" | translate }}</h2>
-      <ul class="legal-text">
-        <li>{{ "LEGAL_TERMS.LINE_1" | translate }}</li>
-        <li>{{ "LEGAL_TERMS.LINE_2" | translate }}</li>
-        <li>{{ "LEGAL_TERMS.LINE_3" | translate }}</li>
-        <li>
-          <span [innerHtml]="'LEGAL_TERMS.LINE_4' | translate"></span>
-        </li>
-        <li>
-          <span [innerHtml]="'LEGAL_TERMS.LINE_5' | translate"></span>
-        </li>
-        <li>
-          <span [innerHtml]="'LEGAL_TERMS.LINE_6' | translate: { legalUrl: legalUrl }"></span>
-        </li>
-      </ul>
-    </div>
+    <img alt="" class="legal__icon" src="/assets/images/onboarding/legal.svg" />
+    <h2>{{ "LEGAL_TERMS.HEADER" | translate }}</h2>
+    <ul class="legal-text">
+      <li>{{ "LEGAL_TERMS.LINE_1" | translate }}</li>
+      <li>{{ "LEGAL_TERMS.LINE_2" | translate }}</li>
+      <li>{{ "LEGAL_TERMS.LINE_3" | translate }}</li>
+      <li>
+        <span [innerHtml]="'LEGAL_TERMS.LINE_4' | translate"></span>
+      </li>
+      <li>
+        <span [innerHtml]="'LEGAL_TERMS.LINE_5' | translate"></span>
+      </li>
+      <li>
+        <span [innerHtml]="'LEGAL_TERMS.LINE_6' | translate: { legalUrl: legalUrl }"></span>
+      </li>
+    </ul>
   </swiper-slide>
 </swiper-container>
 <ion-footer>

--- a/src/app/pages/start-wizard/start-wizard.page.scss
+++ b/src/app/pages/start-wizard/start-wizard.page.scss
@@ -27,7 +27,7 @@ h3 {
 }
 
 swiper-container {
-  height: 100%;
+  height: calc(100% - 53px);
   width: 100%;
   background-color: #fff;
 }

--- a/src/app/pages/start-wizard/start-wizard.page.scss
+++ b/src/app/pages/start-wizard/start-wizard.page.scss
@@ -1,5 +1,4 @@
 /* Dette burde være globalt men jeg vil ikke ødelegge eksisterende komponenter */
-ul,
 h2,
 h3 {
   margin: 0;
@@ -17,6 +16,7 @@ h2 {
 @media screen and (max-width: 768px) {
   h2 {
     font-size: 20px;
+    word-break: break-word;
   }
 }
 
@@ -24,6 +24,10 @@ h3 {
   font-size: 18px;
   transform-origin: bottom;
   margin: 0px;
+}
+
+ul {
+  padding: 0 15px;
 }
 
 swiper-container {
@@ -35,15 +39,8 @@ swiper-container {
 swiper-slide {
   display: flex;
   flex-direction: column;
-  height: 90%;
-  width: 100%;
-  align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 0px 120px;
-  img:last-of-type {
-    margin-bottom: 30px;
-  }
+  align-items: center;
 }
 
 @media screen and (max-width: 768px) {
@@ -84,4 +81,25 @@ swiper-slide {
 
 ion-list.list-md {
   padding: 0px;
+}
+
+.text-scrollable {
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 20px 0px;
+  width: 90%;
+}
+
+@media screen and (min-width: 600px) {
+  .text-scrollable {
+    height: 100%;
+    justify-content: center; /* sentrerer alltid på stor skjerm*/
+  }
+}
+
+.text-scrollable--center {
+  justify-content: center; /* sentrerer valgte på liten skjerm */
 }

--- a/src/app/pages/start-wizard/start-wizard.page.scss
+++ b/src/app/pages/start-wizard/start-wizard.page.scss
@@ -37,15 +37,28 @@ swiper-container {
 }
 
 swiper-slide {
+  overflow: auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
+  gap: 10px;
+  padding: 20px 0px;
+}
+
+@media screen and (max-width: 600px) {
+  swiper-slide:not(:last-of-type) {
+    justify-content: center;
+  }
+}
+@media screen and (min-width: 600px) {
+  swiper-slide {
+    justify-content: center;
+  }
 }
 
 @media screen and (max-width: 768px) {
   swiper-slide {
-    padding: 0px 50px;
+    padding: 10px 50px;
   }
 }
 
@@ -81,25 +94,4 @@ swiper-slide {
 
 ion-list.list-md {
   padding: 0px;
-}
-
-.text-scrollable {
-  overflow: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  padding: 20px 0px;
-  width: 90%;
-}
-
-@media screen and (min-width: 600px) {
-  .text-scrollable {
-    height: 100%;
-    justify-content: center; /* sentrerer alltid på stor skjerm*/
-  }
-}
-
-.text-scrollable--center {
-  justify-content: center; /* sentrerer valgte på liten skjerm */
 }


### PR DESCRIPTION
Problemet oppstår når man velger stor skriftstørrelse på mobil. swiper-container tar over hele skjermen og skyver ion-footer med knappen ut av visningen. Derfor beregner vi høyden ved å trekke fra høyden på footeren.

jeg vet tanken var å ikke bruke så mange tekst kontainere men det var umulig å sette overflow:auto uten en hoved div wrapper. selve swiper-slide kunne ikke justeres bra nok. 