### PR TITLE
RO-2734: Fiks av tilbakestilling av filter på en observasjonstype

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -175,6 +175,22 @@ describe('SearchCriteriaService', () => {
     expect(url.searchParams.get('type')).toEqual('81.13');
   }));
 
+  it('det skal gå an å fjerne samme observasjonstype som vi nettopp la til i filteret (ro-2734)', fakeAsync(async () => {
+    let criteria: any;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    const obsType = { Id: 80, SubTypes: [26] };
+    tick(500);
+    await service.setObservationType(obsType);
+    tick(500);
+    await service.removeObservationType(obsType);
+    tick(500);
+    //check that criteria contains only obsType2
+    expect(criteria.SelectedRegistrationTypes.length).toEqual(0);
+    await service.applyQueryParams();
+    const url = new URL(document.location.href);
+    expect(url.searchParams.has('type')).toBeFalse();
+  }));
+
   it('remove observation type with wrong parameter, should return the same object', fakeAsync(async () => {
     let criteria: any;
     service.searchCriteria$.subscribe((c) => (criteria = c));

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -529,15 +529,17 @@ export class SearchCriteriaService {
     this.removeSlushFlowFilterIfFilterByAvalancheIsRemoved(typeToRemove);
     const { SelectedRegistrationTypes: currentTypesCriteria } = await firstValueFrom(this.searchCriteria$);
     if (currentTypesCriteria) {
-      const update = {
-        SelectedRegistrationTypes: currentTypesCriteria.map((regType) => {
-          return {
-            ...regType,
-            SubTypes: regType.SubTypes?.filter((subType) => !typeToRemove.SubTypes?.includes(subType)),
-          };
-        }),
-      };
-      this.searchCriteriaChanges.next(update);
+      const newCriteria = currentTypesCriteria
+        .map((type) => {
+          if (type.Id === typeToRemove.Id) {
+            const subtypesLeft = type.SubTypes?.filter((subType) => !typeToRemove.SubTypes?.includes(subType)) || [];
+            return subtypesLeft.length > 0 ? { Id: type.Id, SubTypes: subtypesLeft } : null;
+          }
+          return { Id: type.Id, SubTypes: type.SubTypes ? [...type.SubTypes] : [] };
+        })
+        .filter(Boolean) as RegistrationTypeCriteriaDto[];
+
+      this.searchCriteriaChanges.next({ SelectedRegistrationTypes: newCriteria });
     }
   }
 

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -529,12 +529,18 @@ export class SearchCriteriaService {
     this.removeSlushFlowFilterIfFilterByAvalancheIsRemoved(typeToRemove);
     const { SelectedRegistrationTypes: currentTypesCriteria } = await firstValueFrom(this.searchCriteria$);
     if (currentTypesCriteria) {
+      // vi har filter på type, som vi da må oppdatere
       const newCriteria = currentTypesCriteria
         .map((type) => {
           if (type.Id === typeToRemove.Id) {
+            // det kan være typen har noen under-typer som fortsatt skal være med
             const subtypesLeft = type.SubTypes?.filter((subType) => !typeToRemove.SubTypes?.includes(subType)) || [];
-            return subtypesLeft.length > 0 ? { Id: type.Id, SubTypes: subtypesLeft } : null;
+            if (subtypesLeft.length > 0) {
+              return { Id: type.Id, SubTypes: subtypesLeft };
+            }
+            return null; // vi fjerner hele typen hvis det ikke er noen under-typer igjen
           }
+          // denne typen skal ikke fjernes, så vi returnerer den uendret
           return { Id: type.Id, SubTypes: type.SubTypes ? [...type.SubTypes] : [] };
         })
         .filter(Boolean) as RegistrationTypeCriteriaDto[];


### PR DESCRIPTION
Nå fjerner vi valgt observasjonstype fullstendig om vi skrur av et filter på type.
Se https://nveprojects.atlassian.net/browse/RO-2734

Skrev også en ny test som feilet før jeg fikset koden.
