### PR TITLE
RO-1767: støtte '-' med tastatur i numeric input

### DIFF
--- a/src/app/modules/registration/pages/modal-pages/numeric-input-modal/numeric-input-modal.page.ts
+++ b/src/app/modules/registration/pages/modal-pages/numeric-input-modal/numeric-input-modal.page.ts
@@ -79,6 +79,12 @@ export class NumericInputModalPage {
     if (event.key.match('[,.]')) {
       this.pushDecimalSeparator();
     }
+    if (event.key.match('[-]')) {
+      this.toggleNegative();
+    }
+    if (event.key.match('[+]')) {
+      this.isNegative.set(false);
+    }
     if (event.keyCode === 13) {
       // Enter click
       this.done();

--- a/src/app/modules/registration/pages/modal-pages/numeric-input-modal/numeric-input-modal.page.ts
+++ b/src/app/modules/registration/pages/modal-pages/numeric-input-modal/numeric-input-modal.page.ts
@@ -79,10 +79,10 @@ export class NumericInputModalPage {
     if (event.key.match('[,.]')) {
       this.pushDecimalSeparator();
     }
-    if (event.key.match('[-]')) {
+    if (event.key.match('[-]') && this.min() < 0) {
       this.toggleNegative();
     }
-    if (event.key.match('[+]')) {
+    if (event.key.match('[+]') && this.min() < 0) {
       this.isNegative.set(false);
     }
     if (event.keyCode === 13) {


### PR DESCRIPTION
[Lenke til saken](https://nveprojects.atlassian.net/browse/RO-1767)

For å teste åpen Vær skjema under Snøskred for eksempel. Prøv med '-' tegn på tastaturen. Den burde toggle mellom positive og negative tall. Når man trykker på '+' så skal den bare endre til positiv tall. Si fra hva dere syns om denne løsningen. 