### PR TITLE
update ngx-markdown package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "moment-timezone": "^0.5.40",
         "ngx-file-drop": "^16.0.0",
         "ngx-logger": "^4.2.1",
-        "ngx-markdown": "^19.0.0",
+        "ngx-markdown": "^19.1.1",
         "observable-webworker": "^3.4.0",
         "pouchdb-adapter-idb": "^7.2.2",
         "rxjs": "^7.8.1",
@@ -24368,9 +24368,10 @@
       }
     },
     "node_modules/ngx-markdown": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-19.0.0.tgz",
-      "integrity": "sha512-/UDTYxK2sbG9LjeuPfqErCg9gbT1O64Rnqvs9qgvK70X//gEVCMStNUi1zYIqw/SLRk19Rk48DZMgPiFRbgb1Q==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-19.1.1.tgz",
+      "integrity": "sha512-R0SGsSa8QMLS4mXMWjB7EoK7Vab30QeGA+Y4zeeb4yb+YdAqg0hU/XFkBiQefJx/JxrtxTWJAu1b97LEGscluQ==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -24379,7 +24380,7 @@
         "emoji-toolkit": ">= 8.0.0 < 10.0.0",
         "katex": "^0.16.0",
         "mermaid": ">= 10.6.0 < 12.0.0",
-        "prismjs": "^1.28.0"
+        "prismjs": "^1.30.0"
       },
       "peerDependencies": {
         "@angular/common": "^19.0.0",
@@ -26074,9 +26075,10 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "moment-timezone": "^0.5.40",
     "ngx-file-drop": "^16.0.0",
     "ngx-logger": "^4.2.1",
-    "ngx-markdown": "^19.0.0",
+    "ngx-markdown": "^19.1.1",
     "observable-webworker": "^3.4.0",
     "pouchdb-adapter-idb": "^7.2.2",
     "rxjs": "^7.8.1",


### PR DESCRIPTION
Denne PRen løser anbefalinger fra dependabot (begge PRene ble nå lukket). Vi har kun oppdaterte ngx-markdown som igjen fikk med seg oppdaterte versjoner av prismjs.
Både dompurify og mermaid trenger vi ikke å oppdatere. 