### PR TITLE
RO-2740: Fiks av abonnement på GPS-data i app

### DIFF
--- a/src/app/core/services/geo-position/geo-position.service.ts
+++ b/src/app/core/services/geo-position/geo-position.service.ts
@@ -111,7 +111,7 @@ export class GeoPositionService implements OnDestroy {
       // for å unngå at popup om lokasjon dukker opp for tidlig.
       this.userSettings.userSetting$.pipe(
         // showGeoSelectInfo er om coach marks er ferdig
-        map((userSettings) => userSettings.completedStartWizard && !userSettings.showGeoSelectInfo),
+        map((userSettings) => userSettings.completedStartWizard), // TODO: Ta inn resten av denne linja når coachmarks er på plass igjen: && !userSettings.showGeoSelectInfo),
         skipWhile((startWizardCompleted) => startWizardCompleted === false),
         take(1)
       ),


### PR DESCRIPTION
Feilen skyldtes at vi aldri abonnerte på GPS-signal, fordi vi ventet på at coach-marks skulle bli vist først.
Siden coach-marks midlertidig er kommentert ut ifm. oppgradering av Angular og Ionic, startet vi ikke å abonnere på GPS-signalet.
Er testet på Android og web. Aktuell kode påvirker kun app, så denne må testes i app.
Takk til jolokv for hjelp til feilsøking!
Jeg har laget en [egen sak i Jira](https://nveprojects.atlassian.net/browse/RO-2755) på å ta inn coach-marks igjen.