### PR TITLE
RO-2601 og RO-2743: Mer brukervennlig redigering av standard copyright og fotograf

### DIFF
--- a/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.html
+++ b/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.html
@@ -5,13 +5,21 @@
   </ion-item>
   <ion-item>
     <div class="flexContainer margin-mobile">
-      <ion-input [(ngModel)]="copyright" placeholder="copyright">
+      <ion-input
+        [(ngModel)]="copyright"
+        [label]="('MY_PROFILE.COPYRIGHT' | translate).toUpperCase()"
+        labelPlacement="stacked"
+      >
         <strong>{{ "MY_PROFILE.COPYRIGHT" | translate }}:</strong>
       </ion-input>
     </div>
   </ion-item>
   <ion-item>
-    <ion-input [(ngModel)]="photographer" placeholder="photographer">
+    <ion-input
+      [(ngModel)]="photographer"
+      [label]="('MY_PROFILE.PHOTOGRAPHER' | translate).toUpperCase()"
+      labelPlacement="stacked"
+    >
       <strong>{{ "MY_PROFILE.PHOTOGRAPHER" | translate }}:</strong>
     </ion-input>
   </ion-item>

--- a/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.html
+++ b/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.html
@@ -1,8 +1,8 @@
 <ion-list>
-  <ion-item>
+  <div class="header">
     <h2>{{ "MY_PROFILE.MY_PICTURES" | translate }}</h2>
     <ion-icon name="close" size="large" slot="end" (click)="close()"></ion-icon>
-  </ion-item>
+  </div>
   <ion-item>
     <div class="flexContainer margin-mobile">
       <ion-input
@@ -23,5 +23,6 @@
       <strong>{{ "MY_PROFILE.PHOTOGRAPHER" | translate }}:</strong>
     </ion-input>
   </ion-item>
+  <p class="info-text ion-padding-top" [innerHTML]="'MY_PROFILE.PUBLISH_PHOTOS' | translate"></p>
   <ion-button class="saveButton" (click)="save()">{{ "MY_PROFILE.SAVE" | translate }}</ion-button>
 </ion-list>

--- a/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.html
+++ b/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.html
@@ -1,28 +1,34 @@
-<ion-list>
-  <div class="header">
-    <h2>{{ "MY_PROFILE.MY_PICTURES" | translate }}</h2>
-    <ion-icon name="close" size="large" slot="end" (click)="close()"></ion-icon>
-  </div>
-  <ion-item>
-    <div class="flexContainer margin-mobile">
+<ion-header>
+  <ion-toolbar>
+    <ion-title>{{ "MY_PROFILE.MY_PICTURES" | translate }}</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="close()">{{ "CLOSE" | translate }}</ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+<ion-content>
+  <ion-list>
+    <ion-item>
+      <div class="flexContainer margin-mobile">
+        <ion-input
+          [(ngModel)]="copyright"
+          [label]="('MY_PROFILE.COPYRIGHT' | translate).toUpperCase()"
+          labelPlacement="stacked"
+        >
+          <strong>{{ "MY_PROFILE.COPYRIGHT" | translate }}:</strong>
+        </ion-input>
+      </div>
+    </ion-item>
+    <ion-item>
       <ion-input
-        [(ngModel)]="copyright"
-        [label]="('MY_PROFILE.COPYRIGHT' | translate).toUpperCase()"
+        [(ngModel)]="photographer"
+        [label]="('MY_PROFILE.PHOTOGRAPHER' | translate).toUpperCase()"
         labelPlacement="stacked"
       >
-        <strong>{{ "MY_PROFILE.COPYRIGHT" | translate }}:</strong>
+        <strong>{{ "MY_PROFILE.PHOTOGRAPHER" | translate }}:</strong>
       </ion-input>
-    </div>
-  </ion-item>
-  <ion-item>
-    <ion-input
-      [(ngModel)]="photographer"
-      [label]="('MY_PROFILE.PHOTOGRAPHER' | translate).toUpperCase()"
-      labelPlacement="stacked"
-    >
-      <strong>{{ "MY_PROFILE.PHOTOGRAPHER" | translate }}:</strong>
-    </ion-input>
-  </ion-item>
-  <p class="info-text ion-padding-top" [innerHTML]="'MY_PROFILE.PUBLISH_PHOTOS' | translate"></p>
-  <ion-button class="saveButton" (click)="save()">{{ "MY_PROFILE.SAVE" | translate }}</ion-button>
-</ion-list>
+    </ion-item>
+    <p class="info-text ion-padding-top" [innerHTML]="'MY_PROFILE.PUBLISH_PHOTOS' | translate"></p>
+    <ion-button class="saveButton" (click)="save()">{{ "MY_PROFILE.SAVE" | translate }}</ion-button>
+  </ion-list>
+</ion-content>

--- a/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.scss
+++ b/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.scss
@@ -1,12 +1,3 @@
-.header {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 0;
-  h2 {
-    margin-top: 0.5rem;
-  }
-}
-
 .saveButton {
   width: 100%;
   min-height: 44px;
@@ -15,8 +6,4 @@
 
 ion-list {
   padding: 16px;
-}
-
-ion-icon {
-  float: right;
 }

--- a/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.scss
+++ b/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.scss
@@ -1,3 +1,12 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0;
+  h2 {
+    margin-top: 0.5rem;
+  }
+}
+
 .saveButton {
   width: 100%;
   min-height: 44px;

--- a/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.ts
+++ b/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.ts
@@ -1,5 +1,16 @@
 import { Component, inject, model } from '@angular/core';
-import { IonButton, IonIcon, IonInput, IonItem, IonList, ModalController } from '@ionic/angular/standalone';
+import {
+  IonButton,
+  IonInput,
+  IonItem,
+  IonList,
+  ModalController,
+  IonToolbar,
+  IonTitle,
+  IonHeader,
+  IonContent,
+  IonButtons,
+} from '@ionic/angular/standalone';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
@@ -9,7 +20,19 @@ import { close } from 'ionicons/icons';
   selector: 'app-edit-picture-info-modal',
   templateUrl: './edit-picture-info-modal.component.html',
   styleUrls: ['./edit-picture-info-modal.component.scss'],
-  imports: [FormsModule, IonButton, IonIcon, IonInput, IonItem, IonList, TranslatePipe],
+  imports: [
+    IonButtons,
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    FormsModule,
+    IonButton,
+    IonInput,
+    IonItem,
+    IonList,
+    TranslatePipe,
+  ],
 })
 /** Brukes til å endre standard rettighetshaver og fotograf for bilder */
 export class EditPictureInfoModalComponent {

--- a/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.ts
+++ b/src/app/modules/edit-picture-info-modal/edit-picture-info-modal.component.ts
@@ -11,6 +11,7 @@ import { close } from 'ionicons/icons';
   styleUrls: ['./edit-picture-info-modal.component.scss'],
   imports: [FormsModule, IonButton, IonIcon, IonInput, IonItem, IonList, TranslatePipe],
 })
+/** Brukes til å endre standard rettighetshaver og fotograf for bilder */
 export class EditPictureInfoModalComponent {
   modalController = inject(ModalController);
 

--- a/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.html
+++ b/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.html
@@ -1,19 +1,25 @@
-<ion-list>
-  <div class="header">
-    <h2>{{ "MY_PROFILE.MY_NICKNAME" | translate }}</h2>
-    <ion-icon name="close" size="large" slot="end" (click)="close()"></ion-icon>
-  </div>
-  <ion-item>
-    <ion-input
-      [(ngModel)]="nickName"
-      [label]="('MY_PROFILE.NICKNAME' | translate).toUpperCase()"
-      labelPlacement="stacked"
-    >
-      <strong>{{ "MY_PROFILE.NICKNAME" | translate }}:</strong>
-    </ion-input>
-  </ion-item>
-  @if (!nickName()) {
-    <p>{{ "MY_PROFILE.INVALID_NICKNAME" | translate }}</p>
-  }
-  <ion-button class="saveButton" (click)="save()">{{ "MY_PROFILE.SAVE" | translate }}</ion-button>
-</ion-list>
+<ion-header>
+  <ion-toolbar>
+    <ion-title>{{ "MY_PROFILE.MY_NICKNAME" | translate }}</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="close()">{{ "CLOSE" | translate }}</ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+<ion-content>
+  <ion-list>
+    <ion-item>
+      <ion-input
+        [(ngModel)]="nickName"
+        [label]="('MY_PROFILE.NICKNAME' | translate).toUpperCase()"
+        labelPlacement="stacked"
+      >
+        <strong>{{ "MY_PROFILE.NICKNAME" | translate }}:</strong>
+      </ion-input>
+    </ion-item>
+    @if (!nickName()) {
+      <p>{{ "MY_PROFILE.INVALID_NICKNAME" | translate }}</p>
+    }
+    <ion-button class="saveButton" (click)="save()">{{ "MY_PROFILE.SAVE" | translate }}</ion-button>
+  </ion-list>
+</ion-content>

--- a/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.html
+++ b/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.html
@@ -1,14 +1,16 @@
 <ion-list>
-  <ion-item>
+  <div class="header">
     <h2>{{ "MY_PROFILE.MY_NICKNAME" | translate }}</h2>
     <ion-icon name="close" size="large" slot="end" (click)="close()"></ion-icon>
-  </ion-item>
+  </div>
   <ion-item>
-    <div class="flexContainer margin-mobile">
-      <ion-input [(ngModel)]="nickName" [placeholder]="'MY_PROFILE.NICKNAME' | translate">
-        <strong>{{ "MY_PROFILE.NICKNAME" | translate }}:</strong>
-      </ion-input>
-    </div>
+    <ion-input
+      [(ngModel)]="nickName"
+      [label]="('MY_PROFILE.NICKNAME' | translate).toUpperCase()"
+      labelPlacement="stacked"
+    >
+      <strong>{{ "MY_PROFILE.NICKNAME" | translate }}:</strong>
+    </ion-input>
   </ion-item>
   @if (!nickName()) {
     <p>{{ "MY_PROFILE.INVALID_NICKNAME" | translate }}</p>

--- a/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.scss
+++ b/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.scss
@@ -1,3 +1,12 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0;
+  h2 {
+    margin-top: 0.5rem;
+  }
+}
+
 .saveButton {
   width: 100%;
   min-height: 44px;

--- a/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.scss
+++ b/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.scss
@@ -1,12 +1,3 @@
-.header {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 0;
-  h2 {
-    margin-top: 0.5rem;
-  }
-}
-
 .saveButton {
   width: 100%;
   min-height: 44px;
@@ -15,10 +6,6 @@
 
 ion-list {
   padding: 16px;
-}
-
-ion-icon {
-  float: right;
 }
 
 p {

--- a/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.ts
+++ b/src/app/modules/edit-user-nickname-modal/edit-user-nickname-modal.component.ts
@@ -1,6 +1,17 @@
 import { Component, inject, model, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { IonButton, IonIcon, IonInput, IonItem, IonList, ModalController } from '@ionic/angular/standalone';
+import {
+  IonButton,
+  IonInput,
+  IonItem,
+  IonList,
+  ModalController,
+  IonContent,
+  IonButtons,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 import { TranslatePipe } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
 import { close } from 'ionicons/icons';
@@ -9,7 +20,19 @@ import { close } from 'ionicons/icons';
   selector: 'app-edit-user-nickname-modal',
   templateUrl: './edit-user-nickname-modal.component.html',
   styleUrls: ['./edit-user-nickname-modal.component.scss'],
-  imports: [FormsModule, IonButton, IonIcon, IonInput, IonItem, IonList, TranslatePipe],
+  imports: [
+    IonHeader,
+    IonButtons,
+    IonContent,
+    FormsModule,
+    IonButton,
+    IonInput,
+    IonItem,
+    IonList,
+    IonToolbar,
+    IonTitle,
+    TranslatePipe,
+  ],
 })
 export class EditUserNicknameModalComponent {
   modalController = inject(ModalController);

--- a/src/app/modules/login/pages/user-information/user-information.page.html
+++ b/src/app/modules/login/pages/user-information/user-information.page.html
@@ -96,7 +96,8 @@
             class="button ion-padding-start ion-text-uppercase edit-button"
             fill="clear"
             expand="block"
-            >Rediger <ion-icon class="padding-medium" src="./assets/icon/pencil.svg"> </ion-icon>
+            >{{ "MY_PROFILE.EDIT" | translate }}
+            <ion-icon class="padding-medium" src="./assets/icon/pencil.svg"> </ion-icon>
           </ion-button>
         </div>
       </ion-col>
@@ -105,12 +106,12 @@
       <ion-col>
         <div class="flexContainer max-div-height margin-mobile">
           <p class="ion-align-self-center no-margin">
-            <strong>{{ "MY_PROFILE.COPYRIGHT" | translate }}:</strong> {{ copyright$ | async }}
+            <strong>{{ "MY_PROFILE.COPYRIGHT" | translate }}:</strong> {{ copyright() }}
           </p>
         </div>
         <div class="flexContainer max-div-height">
           <p class="ion-align-self-center no-margin">
-            <strong>{{ "MY_PROFILE.PHOTOGRAPHER" | translate }}:</strong> {{ photographer$ | async }}
+            <strong>{{ "MY_PROFILE.PHOTOGRAPHER" | translate }}:</strong> {{ photographer() }}
           </p>
         </div>
       </ion-col>

--- a/src/app/modules/login/pages/user-information/user-information.page.ts
+++ b/src/app/modules/login/pages/user-information/user-information.page.ts
@@ -74,6 +74,14 @@ export class UserInformation implements OnInit {
   loggedInUser$!: Observable<LoggedInUser>;
   userGroups$!: Observable<ObserverGroupDto[]>;
   myPage = toSignal(this.regobsAuthService.myPageData$);
+  private savedCopyright = toSignal(
+    this.userSettingService.userSetting$.pipe(map((userSetting) => userSetting.copyright))
+  );
+  copyright = computed(() => this.savedCopyright() || this.myPage()?.NickName);
+  private savedPhotographer = toSignal(
+    this.userSettingService.userSetting$.pipe(map((userSetting) => userSetting.photographer))
+  );
+  photographer = computed(() => this.savedPhotographer() || '');
 
   myPageSampleData: MyPageData = {
     Competence: [
@@ -198,13 +206,11 @@ export class UserInformation implements OnInit {
   }
 
   async presentModalForCopyRightUpdate() {
-    const copyright = await firstValueFrom(this.copyright$);
-    const photographer = await firstValueFrom(this.photographer$);
     const modal = await this.modalController.create({
       component: EditPictureInfoModalComponent,
       componentProps: {
-        copyright: copyright,
-        photographer: photographer,
+        copyright: this.copyright(),
+        photographer: this.photographer(),
       },
       cssClass: 'editCopyrightModal',
     });

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -249,7 +249,7 @@
     "MY_GROUPS": "My groups",
     "MY_GROUPS_TEXT": "You can edit observations in a group for up to 48 hours after registration. <a href=\"mailto:regobs@nve.no\">Please contact us</a> to change group name, group description and members",
     "MY_NVE_ACCOUNT": "My NVE account",
-    "MY_PICTURES": "My photos",
+    "MY_PICTURES": "Default photo settings",
     "MY_NICKNAME": "My nickname",
     "NICKNAME": "Nickname",
     "INVALID_NICKNAME": "Nickname can't be empty!",
@@ -257,7 +257,7 @@
     "NICKNAME_UPDATE_ERROR": "Your nickname hasn't been updated. Check if you have internet connection and try again later.",
     "NO_GROUPS": "You are not part of any groups",
     "PHOTOGRAPHER": "Photographer",
-    "PUBLISH_PHOTOS": "All published photos are licensed under NLOD and can be reused. <a href=\"https://data.norge.no/nlod/en/\">Read more about data</a>",
+    "PUBLISH_PHOTOS": "Yoy can specify this individually for each photo you publish. I you don't set a default copyright we will show your nickname. All published photos are licensed under NLOD and can be reused. <a href=\"https://data.norge.no/nlod/en/\">Read more about data</a>",
     "SAVE": "Save",
     "TITLE": "My profile",
     "USER": "User"

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -249,7 +249,7 @@
     "MY_GROUPS": "Mine grupper",
     "MY_GROUPS_TEXT": "Du kan redigere en observasjon i en gruppe inntil 48 timer etter den er sendt inn.<br/>For å endre gruppenavn, gruppebeskrivelse og medlemmer, <a href=\"mailto:regobs@nve.no\">ta kontakt</a>.",
     "MY_NVE_ACCOUNT": "Min NVE-konto",
-    "MY_PICTURES": "Mine bilder",
+    "MY_PICTURES": "Standard-innstillinger for bildene mine",
     "MY_NICKNAME": "Mitt kallenavn",
     "INVALID_NICKNAME": "Du må ha et kallenavn!",
     "NICKNAME": "Kallenavn",
@@ -257,7 +257,7 @@
     "NICKNAME_UPDATE_ERROR": "Kallenavnet ditt ble ikke oppdatert. Sjekk om du har nettverk og prøv igjen senere.",
     "NO_GROUPS": "Du er ikke medlem av noen grupper",
     "PHOTOGRAPHER": "Fotograf",
-    "PUBLISH_PHOTOS": "Når du publiserer bilder på observasjoner aksepterer du at de er lisensiert under NLOD og kan gjenbrukes. <a href=\"https://data.norge.no/nlod/no/\">Les mer om data</a>",
+    "PUBLISH_PHOTOS": "Dette kan overstyres for hvert bilde du publiserer. Hvis du ikke spesifiserer rettighetshaver, viser vi kallenavnet. Når du publiserer bilder på observasjoner aksepterer du at de er lisensiert under NLOD og kan gjenbrukes. <a href=\"https://data.norge.no/nlod/no/\">Les mer om data</a>",
     "SAVE": "Lagre",
     "TITLE": "Min side",
     "USER": "Bruker"


### PR DESCRIPTION
Sakene det gjelder:
https://nveprojects.atlassian.net/browse/RO-2601
https://nveprojects.atlassian.net/browse/RO-2743

Før ble brukernavnet ditt vist både under "Fotograf" og "Kilde/rettighetshaver" under "Min side - Mine bilder". Jeg synes ikke det gir noen mening, siden vi aldri viser brukernavnet for andre. 
Nå viser vi hva som faktisk vises under bildene dine når de publiseres.
Har også endret overskrift og lagt inn en forklaring av hva vi viser i beskrivelsen nederst.
![image](https://github.com/user-attachments/assets/f4121713-aaca-4598-8bf5-fc8211573456)

I modalen har jeg fjernet hardkodet placeholder og lagt inn ledetekst i stedet.
Modalen ser nå slik ut:
![image](https://github.com/user-attachments/assets/00bbb815-7711-4b27-a28d-af94692fc642)

NB! Husk at du ikke kan teste dette i PR-bygget, da det ikke går an å logge inn her.



