### PR TITLE
RO-2727: Funksjon for å slette et islag

### DIFF
--- a/src/app/modules/registration/pages/add-web-url-modal/add-web-url-modal.page.ts
+++ b/src/app/modules/registration/pages/add-web-url-modal/add-web-url-modal.page.ts
@@ -47,7 +47,7 @@ export class AddWebUrlModalPage {
   private modalController = inject(ModalController);
 
   readonly url = input<UrlEditModel>();
-  isNew = computed(() => this.url() != null);
+  isNew = computed(() => this.url() == null);
   urlLine = linkedSignal(() => this.url()?.UrlLine);
   urlDesc = linkedSignal(() => this.url()?.UrlDescription);
 

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.html
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.html
@@ -29,11 +29,23 @@
     >
     </app-numeric-input>
   </ion-list>
-  <app-modal-save-or-delete-buttons
-    [saveDisabled]="!isValid()"
-    (saveClicked)="ok()"
-    (deleteClicked)="delete()"
-    [showDelete]="!isNew()"
-  >
-  </app-modal-save-or-delete-buttons>
+  <ion-grid class="ion-no-padding">
+    <ion-row>
+      <ion-col size="12">
+        <ion-button (click)="ok()" [disabled]="!isValid()" type="submit" expand="block" fill="solid" color="primary">
+          {{ "DIALOGS.OK_BACK" | translate }}
+        </ion-button>
+      </ion-col>
+    </ion-row>
+    @if (!isNew()) {
+      <ion-row>
+        <ion-col size="6" offset="3">
+          <ion-button (click)="delete()" size="small" fill="clear" expand="block">
+            <ion-icon slot="start" name="trash"></ion-icon>
+            {{ "DIALOGS.DELETE" | translate }}
+          </ion-button>
+        </ion-col>
+      </ion-row>
+    }
+  </ion-grid>
 </ion-content>

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.html
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.html
@@ -29,23 +29,11 @@
     >
     </app-numeric-input>
   </ion-list>
-  <ion-grid class="ion-no-padding">
-    <ion-row>
-      <ion-col size="12">
-        <ion-button (click)="ok()" [disabled]="!isValid()" type="submit" expand="block" fill="solid" color="primary">
-          {{ "DIALOGS.OK_BACK" | translate }}
-        </ion-button>
-      </ion-col>
-    </ion-row>
-    @if (!isNew()) {
-      <ion-row>
-        <ion-col size="6" offset="3">
-          <ion-button (click)="delete()" size="small" fill="clear" expand="block">
-            <ion-icon slot="start" name="trash"></ion-icon>
-            {{ "DIALOGS.DELETE" | translate }}
-          </ion-button>
-        </ion-col>
-      </ion-row>
-    }
-  </ion-grid>
+  <app-modal-save-or-delete-buttons
+    [saveDisabled]="!isValid()"
+    (saveClicked)="ok()"
+    (deleteClicked)="delete()"
+    [showDelete]="!isNew()"
+  >
+  </app-modal-save-or-delete-buttons>
 </ion-content>

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.ts
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.ts
@@ -10,15 +10,12 @@ import {
   IonTitle,
   IonToolbar,
   ModalController,
-  IonRow,
-  IonCol,
-  IonIcon,
-  IonGrid,
 } from '@ionic/angular/standalone';
 import { IceThicknessLayerEditModel } from 'src/app/modules/common-regobs-api/models';
 import { HeaderColorDirective } from '../../../../../shared/directives/header-color/header-color.directive';
 import { KdvSelectComponent } from '../../../../../../components/kdv-select/kdv-select.component';
 import { NumericInputComponent } from '../../../../components/numeric-input/numeric-input.component';
+import { ModalSaveOrDeleteButtonsComponent } from '../../../../components/modal-save-or-delete-buttons/modal-save-or-delete-buttons.component';
 import { TranslatePipe } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
 import { arrowBack, arrowForward, chevronDown, chevronUp, trash } from 'ionicons/icons';
@@ -28,10 +25,6 @@ import { arrowBack, arrowForward, chevronDown, chevronUp, trash } from 'ionicons
   templateUrl: './ice-layer.page.html',
   styleUrls: ['./ice-layer.page.scss'],
   imports: [
-    IonGrid,
-    IonIcon,
-    IonCol,
-    IonRow,
     HeaderColorDirective,
     IonButton,
     IonButtons,
@@ -43,6 +36,7 @@ import { arrowBack, arrowForward, chevronDown, chevronUp, trash } from 'ionicons
     IonTitle,
     IonToolbar,
     KdvSelectComponent,
+    ModalSaveOrDeleteButtonsComponent,
     NumericInputComponent,
     TranslatePipe,
   ],

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.ts
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-layer/ice-layer.page.ts
@@ -10,19 +10,28 @@ import {
   IonTitle,
   IonToolbar,
   ModalController,
+  IonRow,
+  IonCol,
+  IonIcon,
+  IonGrid,
 } from '@ionic/angular/standalone';
 import { IceThicknessLayerEditModel } from 'src/app/modules/common-regobs-api/models';
 import { HeaderColorDirective } from '../../../../../shared/directives/header-color/header-color.directive';
 import { KdvSelectComponent } from '../../../../../../components/kdv-select/kdv-select.component';
 import { NumericInputComponent } from '../../../../components/numeric-input/numeric-input.component';
-import { ModalSaveOrDeleteButtonsComponent } from '../../../../components/modal-save-or-delete-buttons/modal-save-or-delete-buttons.component';
 import { TranslatePipe } from '@ngx-translate/core';
+import { addIcons } from 'ionicons';
+import { arrowBack, arrowForward, chevronDown, chevronUp, trash } from 'ionicons/icons';
 
 @Component({
   selector: 'app-ice-layer',
   templateUrl: './ice-layer.page.html',
   styleUrls: ['./ice-layer.page.scss'],
   imports: [
+    IonGrid,
+    IonIcon,
+    IonCol,
+    IonRow,
     HeaderColorDirective,
     IonButton,
     IonButtons,
@@ -34,11 +43,11 @@ import { TranslatePipe } from '@ngx-translate/core';
     IonTitle,
     IonToolbar,
     KdvSelectComponent,
-    ModalSaveOrDeleteButtonsComponent,
     NumericInputComponent,
     TranslatePipe,
   ],
 })
+/** Skjema for å registrere et islag */
 export class IceLayerPage {
   private modalController = inject(ModalController);
 
@@ -46,7 +55,11 @@ export class IceLayerPage {
   layerTid = linkedSignal(() => this.iceThicknessLayer()?.IceLayerTID);
   thickness = linkedSignal(() => this.iceThicknessLayer()?.IceLayerThickness);
   isValid = computed(() => this.thickness() != null);
-  isNew = computed(() => this.iceThicknessLayer() != null);
+  isNew = computed(() => this.iceThicknessLayer() == null);
+
+  constructor() {
+    addIcons({ chevronUp, chevronDown, arrowBack, arrowForward, trash });
+  }
 
   cancel() {
     this.modalController.dismiss();

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.html
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.html
@@ -38,7 +38,7 @@
         <ion-label> {{ "REGISTRATION.ICE.ICE_THICKNESS.ICE_LAYER" | translate }} </ion-label>
       </ion-list-header>
       <ion-reorder-group disabled="false" (ionItemReorder)="onIceThicknessReorder($event)">
-        <ion-item (click)="addOrEditThicknessLayer(i)" *ngFor="let layer of layers; let i = index">
+        <ion-item (click)="addOrEditThicknessLayer(i)" *ngFor="let layer of layers; let i = index" button>
           <ion-label>
             {{ layer.IceLayerTID | kdvDescription: "Ice_IceLayerKDV" | async }} -
             {{ layer.IceLayerThickness | metersToCm }} cm</ion-label
@@ -46,16 +46,16 @@
           <ion-reorder slot="end"></ion-reorder>
         </ion-item>
       </ion-reorder-group>
-      <ion-item (click)="addOrEditThicknessLayer()">
+      <ion-item (click)="addOrEditThicknessLayer()" button>
         <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
         <ion-label>{{ "REGISTRATION.ICE.ICE_THICKNESS.ADD_ICE_LAYER" | translate }}</ion-label>
       </ion-item>
-      <ion-item>
+      <ion-item color="light">
         <ion-label color="medium" position="stacked" class="ion-text-uppercase">
           {{ "REGISTRATION.ICE.ICE_THICKNESS.ICE_THICKNESS_SUM" | translate }}</ion-label
         >
         <ion-text class="ion-align-self-start ion-text-wrap ion-margin-bottom">
-          <p class="ion-no-margin">{{ iceThickness.IceThicknessSum | metersToCm }} cm</p>
+          <p class="ion-no-margin">{{ iceThickness.IceThicknessSum || 0 | metersToCm }} cm</p>
         </ion-text>
       </ion-item>
 

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.html
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.html
@@ -50,16 +50,15 @@
         <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
         <ion-label>{{ "REGISTRATION.ICE.ICE_THICKNESS.ADD_ICE_LAYER" | translate }}</ion-label>
       </ion-item>
-      <app-numeric-input
-        [readonly]="true"
-        [(value)]="iceThickness.IceThicknessSum"
-        label="REGISTRATION.ICE.ICE_THICKNESS.ICE_THICKNESS_SUM"
-        [min]="0"
-        [max]="999"
-        [decimalPlaces]="2"
-        [convertRatio]="100"
-        suffix="cm"
-      ></app-numeric-input>
+      <ion-item>
+        <ion-label color="medium" position="stacked" class="ion-text-uppercase">
+          {{ "REGISTRATION.ICE.ICE_THICKNESS.ICE_THICKNESS_SUM" | translate }}</ion-label
+        >
+        <ion-text class="ion-align-self-start ion-text-wrap ion-margin-bottom">
+          <p class="ion-no-margin">{{ iceThickness.IceThicknessSum | metersToCm }} cm</p>
+        </ion-text>
+      </ion-item>
+
       <app-yes-no-select [(value)]="isWaterBefore" title="REGISTRATION.ICE.ICE_THICKNESS.ICE_HEIGHT_BEFORE_TOGGLE">
       </app-yes-no-select>
       <app-numeric-input

--- a/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.ts
+++ b/src/app/modules/registration/pages/ice/ice-thickness/ice-thickness.page.ts
@@ -13,6 +13,7 @@ import {
   IonListHeader,
   IonReorder,
   IonReorderGroup,
+  IonText,
   IonTitle,
   IonToolbar,
   ModalController,
@@ -37,6 +38,7 @@ import { addCircleOutline } from 'ionicons/icons';
   templateUrl: './ice-thickness.page.html',
   styleUrls: ['./ice-thickness.page.scss'],
   imports: [
+    IonText,
     AsyncPipe,
     EditImagesComponent,
     HeaderColorDirective,
@@ -64,6 +66,7 @@ import { addCircleOutline } from 'ionicons/icons';
     YesNoSelectComponent,
   ],
 })
+/** Skjema for istykkelse. Viser alle registrerte islag */
 export class IceThicknessPage extends BasePage {
   override registrationTid = RegistrationTid.IceThickness;
 


### PR DESCRIPTION
Nå kan man slette islag. Man må slette ett lag av gangen.
Saken: 
https://nveprojects.atlassian.net/browse/RO-2727

Det var samme feil i komponenten for å registrere URL'er (takk, amish1188:), fikset den også slik at vi kan slette URL'er.

Fikset også visning av total tykkelse. Dette var vist med et input-felt, nå bruker vi label i stedet, så den ikke kan "velges".



