### PR TITLE
RO-2770: Alltid vise filtermeny hvis skjermen er stor nok

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,18 +4,6 @@
       <app-side-menu></app-side-menu>
     }
   </ion-menu>
-  <ion-menu
-    maxEdgeStart="0"
-    side="start"
-    menuId="filter"
-    contentId="main-content"
-    style="--background: #fff"
-    (ionWillOpen)="filterMenuWillOpen()"
-  >
-    @defer {
-      <app-filter-menu *ngIf="filterMenuOpened$ | async"></app-filter-menu>
-    }
-  </ion-menu>
   <ion-router-outlet id="main-content" [swipeGesture]="(swipeBackEnabled$ | async)!"></ion-router-outlet>
   <!-- TODO: Ikke rendre gps debug default -->
   <app-gps-debug></app-gps-debug>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,8 +16,7 @@ import { BreakpointService } from './core/services/breakpoint.service';
 import { Keyboard } from '@capacitor/keyboard';
 import { SqliteService } from './core/services/sqlite/sqlite.service';
 import { SideMenuComponent } from './modules/side-menu/components/side-menu.component';
-import { NgIf, AsyncPipe } from '@angular/common';
-import { FilterMenuComponent } from './modules/side-menu/components/filter-menu/filter-menu.component';
+import { AsyncPipe } from '@angular/common';
 import { GpsDebugComponent } from './modules/gps-debug/components/gps-debug/gps-debug.component';
 
 const DEBUG_TAG = 'AppComponent';
@@ -25,16 +24,7 @@ const DEBUG_TAG = 'AppComponent';
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
-  imports: [
-    AsyncPipe,
-    FilterMenuComponent,
-    GpsDebugComponent,
-    IonApp,
-    IonMenu,
-    IonRouterOutlet,
-    NgIf,
-    SideMenuComponent,
-  ],
+  imports: [AsyncPipe, GpsDebugComponent, IonApp, IonMenu, IonRouterOutlet, SideMenuComponent],
 })
 export class AppComponent {
   private platform = inject(Platform);
@@ -52,9 +42,6 @@ export class AppComponent {
   private injector = inject(Injector);
 
   swipeBackEnabled$: Observable<boolean>;
-
-  private filterMenuOpened = new Subject<boolean>();
-  filterMenuOpened$ = this.filterMenuOpened.asObservable();
 
   constructor() {
     this.swipeBackEnabled$ = this.swipeBackService.swipeBackEnabled$;
@@ -78,10 +65,6 @@ export class AppComponent {
     this.breakpointService.onResize(this.platform.width());
 
     this.afterAppInitialized();
-  }
-
-  filterMenuWillOpen() {
-    this.filterMenuOpened.next(true);
   }
 
   private afterAppInitialized() {

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -1,7 +1,9 @@
 <ion-list class="ion-no-margin main-list filtermenu-scrollfix">
-  <ion-list-header color="primary" class="ion-no-margin">
-    <ion-label>{{ "OBSERVATION_FILTER.TITLE" | translate }}</ion-label>
-  </ion-list-header>
+  <ion-header color="primary" class="ion-no-margin">
+    <ion-toolbar appHeaderColor>
+      <ion-title>{{ "OBSERVATION_FILTER.TITLE" | translate }}</ion-title>
+    </ion-toolbar>
+  </ion-header>
   <ion-item lines="full" color="light" button detail="false">
     <ion-toggle [checked]="showObservations$ | async" (ionChange)="saveShowObservation($event)">
       {{ "MENU.SHOW_OBSERVATIONS" | translate }}

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -1,142 +1,145 @@
-<ion-list class="ion-no-margin main-list filtermenu-scrollfix">
-  <ion-header color="primary" class="ion-no-margin">
-    <ion-toolbar appHeaderColor>
-      <ion-title>{{ "OBSERVATION_FILTER.TITLE" | translate }}</ion-title>
-    </ion-toolbar>
-  </ion-header>
-  <ion-item lines="full" color="light" button detail="false">
-    <ion-toggle [checked]="showObservations$ | async" (ionChange)="saveShowObservation($event)">
-      {{ "MENU.SHOW_OBSERVATIONS" | translate }}
-    </ion-toggle>
-  </ion-item>
+<ion-header color="primary" class="ion-no-margin">
+  <ion-toolbar appHeaderColor>
+    <ion-title>{{ "OBSERVATION_FILTER.TITLE" | translate }}</ion-title>
+  </ion-toolbar>
+</ion-header>
 
-  <ng-container *ngIf="showObservations$ | async">
-    <app-update-observations></app-update-observations>
-    <ion-item lines="full" button (click)="onResetFilters()" detail="false" color="light">
-      {{ "OBSERVATION_FILTER.RESET_FILTER_BUTTON_TITLE" | translate }}
-      <ion-icon slot="end" name="close-circle-outline"></ion-icon>
+<ion-content>
+  <ion-list class="ion-no-margin main-list filtermenu-scrollfix">
+    <ion-item lines="full" color="light" button detail="false">
+      <ion-toggle [checked]="showObservations$ | async" (ionChange)="saveShowObservation($event)">
+        {{ "MENU.SHOW_OBSERVATIONS" | translate }}
+      </ion-toggle>
     </ion-item>
-    <app-observations-days-back *ngIf="isIosOrAndroid"></app-observations-days-back>
-    <app-date-range *ngIf="!isIosOrAndroid"></app-date-range>
 
-    <ion-accordion-group>
-      <ion-accordion *ngIf="isSupported('observationType')">
-        <ion-item slot="header" color="light">
-          <app-selected-items-counter-label
-            [selectedItemsCount]="slushFlowFilterIsActive ? 1 : (nTypesSelected$ | async)"
-          >
-            {{ "OBSERVATION_FILTER.OBSERVATION_TYPE_FILTER.TITLE" | translate }}
-          </app-selected-items-counter-label>
-        </ion-item>
-        <div slot="content">
-          <ion-list lines="none">
-            <!--if slush flow filter is set, disable filter by observation type because it cannot be combined -->
-            <ion-item *ngFor="let type of observationTypes$ | async; trackBy: obsTypeTrackById">
-              <ion-checkbox
-                [checked]="!slushFlowFilterIsActive && type.isChecked"
-                (click)="setNewType($event, type.parentId, type.id)"
-                [disabled]="slushFlowFilterIsActive"
-                labelPlacement="end"
-                justify="start"
-                >{{ type.name }}
-              </ion-checkbox>
-            </ion-item>
-            <app-slush-flow-filter> </app-slush-flow-filter>
-          </ion-list>
-        </div>
-      </ion-accordion>
+    <ng-container *ngIf="showObservations$ | async">
+      <app-update-observations></app-update-observations>
+      <ion-item lines="full" button (click)="onResetFilters()" detail="false" color="light">
+        {{ "OBSERVATION_FILTER.RESET_FILTER_BUTTON_TITLE" | translate }}
+        <ion-icon slot="end" name="close-circle-outline"></ion-icon>
+      </ion-item>
+      <app-observations-days-back *ngIf="isIosOrAndroid"></app-observations-days-back>
+      <app-date-range *ngIf="!isIosOrAndroid"></app-date-range>
 
-      <!-- Snøskredregioner -->
-      <div *ngIf="isSupported('region')">
-        <div *ngIf="regions$ | async as regions" slot="content">
-          <ion-accordion *ngIf="isSupported('region')" value="a-regions">
-            <ion-item slot="header" color="light">
-              <app-selected-items-counter-label [selectedItemsCount]="nRegionsSelected$ | async">
-                {{ "OBSERVATION_FILTER.REGION_FILTER_TITLE_SNOW" | translate }}
-              </app-selected-items-counter-label>
-            </ion-item>
-            <div slot="content">
-              <ion-list lines="none">
-                <ion-item *ngFor="let region of regions.a; trackBy: avalancheRegionTrackById">
-                  <ion-checkbox
-                    [value]="region"
-                    [checked]="region.checked"
-                    (ionChange)="regionCheckBoxChanged($event)"
-                    labelPlacement="end"
-                    justify="start"
-                  >
-                    {{ region.name }}
-                  </ion-checkbox>
-                </ion-item>
-              </ion-list>
-            </div>
-          </ion-accordion>
-          <ion-accordion value="b-regions">
-            <ion-item slot="header" color="light">
-              <app-selected-items-counter-label [selectedItemsCount]="nRegionsSelected$ | async">
-                {{ "OBSERVATION_FILTER.REGION_FILTER_B_REGIONS_TITLE" | translate }}
-              </app-selected-items-counter-label>
-            </ion-item>
-            <div slot="content">
-              <ion-list lines="none">
-                <ion-item *ngFor="let region of regions.b; trackBy: avalancheRegionTrackById">
-                  <ion-checkbox
-                    [value]="region"
-                    [checked]="region.checked"
-                    (ionChange)="regionCheckBoxChanged($event)"
-                    labelPlacement="end"
-                    justify="start"
-                  >
-                    {{ region.name }}
-                  </ion-checkbox>
-                </ion-item>
-              </ion-list>
-            </div>
-          </ion-accordion>
-        </div>
-      </div>
-      <ion-accordion *ngIf="isSupported('competence')" value="competence">
-        <ion-item slot="header" color="light">
-          <ion-label>
-            {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.TITLE" | translate }}
-          </ion-label>
-        </ion-item>
-
-        <ion-item slot="content" lines="none">
-          <ion-label position="stacked" class="margin-bottom">
-            {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.LABEL" | translate }}
-            <span *ngIf="noCompetenceFilterActive$ | async">
-              &nbsp;({{ "OBSERVATION_FILTER.MULTISELECT_SHOW_NO_COUNT" | translate }})
-            </span>
-          </ion-label>
-          <ion-list lines="none">
-            <ion-item *ngFor="let competence of competenceItems$ | async; trackBy: competenceOptionTrackById">
-              <ion-checkbox
-                [value]="competence"
-                [checked]="competence.checked"
-                (ionChange)="competenceCheckboxChanged($event)"
-                [title]="competence.descriptions.join('<br />')"
-                labelPlacement="end"
-                justify="start"
-                >{{ competence.name }}</ion-checkbox
-              ></ion-item
+      <ion-accordion-group>
+        <ion-accordion *ngIf="isSupported('observationType')">
+          <ion-item slot="header" color="light">
+            <app-selected-items-counter-label
+              [selectedItemsCount]="slushFlowFilterIsActive ? 1 : (nTypesSelected$ | async)"
             >
-          </ion-list>
-          <div *ngIf="isSupported('nickName')">
-            <ion-label class="margin-bottom" position="stacked">{{
-              "OBSERVATION_FILTER.NICK_FILTER.TITLE" | translate
-            }}</ion-label>
-            <ion-searchbar
-              [value]="nickName"
-              [debounce]="1000"
-              class="ion-no-padding"
-              [placeholder]="'OBSERVATION_FILTER.NICK_FILTER.PLACEHOLDER' | translate"
-              (ionChange)="setNickName($event)"
-            >
-            </ion-searchbar>
+              {{ "OBSERVATION_FILTER.OBSERVATION_TYPE_FILTER.TITLE" | translate }}
+            </app-selected-items-counter-label>
+          </ion-item>
+          <div slot="content">
+            <ion-list lines="none">
+              <!--if slush flow filter is set, disable filter by observation type because it cannot be combined -->
+              <ion-item *ngFor="let type of observationTypes$ | async; trackBy: obsTypeTrackById">
+                <ion-checkbox
+                  [checked]="!slushFlowFilterIsActive && type.isChecked"
+                  (click)="setNewType($event, type.parentId, type.id)"
+                  [disabled]="slushFlowFilterIsActive"
+                  labelPlacement="end"
+                  justify="start"
+                  >{{ type.name }}
+                </ion-checkbox>
+              </ion-item>
+              <app-slush-flow-filter> </app-slush-flow-filter>
+            </ion-list>
           </div>
-        </ion-item>
-      </ion-accordion>
-    </ion-accordion-group>
-  </ng-container>
-</ion-list>
+        </ion-accordion>
+
+        <!-- Snøskredregioner -->
+        <div *ngIf="isSupported('region')">
+          <div *ngIf="regions$ | async as regions" slot="content">
+            <ion-accordion *ngIf="isSupported('region')" value="a-regions">
+              <ion-item slot="header" color="light">
+                <app-selected-items-counter-label [selectedItemsCount]="nRegionsSelected$ | async">
+                  {{ "OBSERVATION_FILTER.REGION_FILTER_TITLE_SNOW" | translate }}
+                </app-selected-items-counter-label>
+              </ion-item>
+              <div slot="content">
+                <ion-list lines="none">
+                  <ion-item *ngFor="let region of regions.a; trackBy: avalancheRegionTrackById">
+                    <ion-checkbox
+                      [value]="region"
+                      [checked]="region.checked"
+                      (ionChange)="regionCheckBoxChanged($event)"
+                      labelPlacement="end"
+                      justify="start"
+                    >
+                      {{ region.name }}
+                    </ion-checkbox>
+                  </ion-item>
+                </ion-list>
+              </div>
+            </ion-accordion>
+            <ion-accordion value="b-regions">
+              <ion-item slot="header" color="light">
+                <app-selected-items-counter-label [selectedItemsCount]="nRegionsSelected$ | async">
+                  {{ "OBSERVATION_FILTER.REGION_FILTER_B_REGIONS_TITLE" | translate }}
+                </app-selected-items-counter-label>
+              </ion-item>
+              <div slot="content">
+                <ion-list lines="none">
+                  <ion-item *ngFor="let region of regions.b; trackBy: avalancheRegionTrackById">
+                    <ion-checkbox
+                      [value]="region"
+                      [checked]="region.checked"
+                      (ionChange)="regionCheckBoxChanged($event)"
+                      labelPlacement="end"
+                      justify="start"
+                    >
+                      {{ region.name }}
+                    </ion-checkbox>
+                  </ion-item>
+                </ion-list>
+              </div>
+            </ion-accordion>
+          </div>
+        </div>
+        <ion-accordion *ngIf="isSupported('competence')" value="competence">
+          <ion-item slot="header" color="light">
+            <ion-label>
+              {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.TITLE" | translate }}
+            </ion-label>
+          </ion-item>
+
+          <ion-item slot="content" lines="none">
+            <ion-label position="stacked" class="margin-bottom">
+              {{ "OBSERVATION_FILTER.COMPETANCE_FILTER.LABEL" | translate }}
+              <span *ngIf="noCompetenceFilterActive$ | async">
+                &nbsp;({{ "OBSERVATION_FILTER.MULTISELECT_SHOW_NO_COUNT" | translate }})
+              </span>
+            </ion-label>
+            <ion-list lines="none">
+              <ion-item *ngFor="let competence of competenceItems$ | async; trackBy: competenceOptionTrackById">
+                <ion-checkbox
+                  [value]="competence"
+                  [checked]="competence.checked"
+                  (ionChange)="competenceCheckboxChanged($event)"
+                  [title]="competence.descriptions.join('<br />')"
+                  labelPlacement="end"
+                  justify="start"
+                  >{{ competence.name }}</ion-checkbox
+                ></ion-item
+              >
+            </ion-list>
+            <div *ngIf="isSupported('nickName')">
+              <ion-label class="margin-bottom" position="stacked">{{
+                "OBSERVATION_FILTER.NICK_FILTER.TITLE" | translate
+              }}</ion-label>
+              <ion-searchbar
+                [value]="nickName"
+                [debounce]="1000"
+                class="ion-no-padding"
+                [placeholder]="'OBSERVATION_FILTER.NICK_FILTER.PLACEHOLDER' | translate"
+                (ionChange)="setNickName($event)"
+              >
+              </ion-searchbar>
+            </div>
+          </ion-item>
+        </ion-accordion>
+      </ion-accordion-group>
+    </ng-container>
+  </ion-list>
+</ion-content>

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -1,6 +1,6 @@
 <ion-header color="primary" class="ion-no-margin">
   <ion-toolbar appHeaderColor>
-    <ion-title>{{ "OBSERVATION_FILTER.TITLE" | translate }}</ion-title>
+    <ion-title size="small">{{ "OBSERVATION_FILTER.TITLE" | translate }}</ion-title>
   </ion-toolbar>
 </ion-header>
 

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
@@ -18,13 +18,6 @@ ion-list {
 }
 
 ion-list.main-list {
-  overflow: auto;
-  max-height: 100vh;
-  padding-top: env(safe-area-inset-top);
-
-  // For å sørge for at det er lett å klikke på ting på mobil nederst i lista
-  padding-bottom: 100px;
-
   .item-height {
     max-height: 40px;
     display: flex;

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
@@ -1,3 +1,9 @@
+:host {
+  height: 100%;
+  --background-color: #fff;
+  background-color: var(--background-color);
+}
+
 .resetFiltersButton {
   font-size: 17px;
 }
@@ -8,7 +14,7 @@
 
 ion-list {
   width: 100%;
-  background: #fff;
+  background: var(--background-color);
 }
 
 ion-list.main-list {

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
@@ -4,6 +4,10 @@
   background-color: var(--background-color);
 }
 
+ion-title.title-small {
+  padding-bottom: 0;
+}
+
 .resetFiltersButton {
   font-size: 17px;
 }

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -3,13 +3,16 @@ import {
   IonAccordion,
   IonAccordionGroup,
   IonCheckbox,
+  IonHeader,
   IonIcon,
   IonItem,
   IonLabel,
   IonList,
   IonListHeader,
   IonSearchbar,
+  IonTitle,
   IonToggle,
+  IonToolbar,
   Platform,
   SearchbarCustomEvent,
   ToggleCustomEvent,
@@ -40,6 +43,7 @@ import { SlushFlowFilterComponent } from '../slush-flow-filter/slush-flow-filter
 import { TranslatePipe } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
 import { closeCircleOutline } from 'ionicons/icons';
+import { HeaderColorDirective } from 'src/app/modules/shared/directives/header-color/header-color.directive';
 
 type PlatformType = 'app' | 'web';
 type FilterType = 'observationType' | 'competence' | 'nickName' | 'region';
@@ -87,6 +91,9 @@ export function arrayHasNotChanged<T>(prev: Immutable<Array<T>>, curr: Immutable
   styleUrls: ['./filter-menu.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    IonTitle,
+    IonToolbar,
+    IonHeader,
     AsyncPipe,
     DateRangeComponent,
     IonAccordion,
@@ -106,6 +113,7 @@ export function arrayHasNotChanged<T>(prev: Immutable<Array<T>>, curr: Immutable
     SlushFlowFilterComponent,
     TranslatePipe,
     UpdateObservationsComponent,
+    HeaderColorDirective,
   ],
 })
 export class FilterMenuComponent extends NgDestoryBase implements OnInit {

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -16,6 +16,7 @@ import {
   Platform,
   SearchbarCustomEvent,
   ToggleCustomEvent,
+  IonContent,
 } from '@ionic/angular/standalone';
 import { ChangeDetectionStrategy, Component, OnInit, TrackByFunction, inject } from '@angular/core';
 import { SelectInterface } from '@ionic/core';
@@ -91,6 +92,7 @@ export function arrayHasNotChanged<T>(prev: Immutable<Array<T>>, curr: Immutable
   styleUrls: ['./filter-menu.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    IonContent,
     IonTitle,
     IonToolbar,
     IonHeader,

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -1,7 +1,8 @@
 <ion-split-pane contentId="main-content-home-page">
   <ion-menu side="start" menuId="filter" contentId="main-content-home-page">
-    @defer {}
-    <app-filter-menu></app-filter-menu>
+    @defer {
+      <app-filter-menu></app-filter-menu>
+    }
   </ion-menu>
 
   <div id="main-content-home-page" class="ion-page">

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -1,29 +1,38 @@
-<app-header title="{{ appname }}" [fullscreenSupport]="true"></app-header>
-<ion-content>
-  <app-map
-    (mapReady)="onMapReady($event)"
-    [autoActivate]="false"
-    [geoTag]="'HomePage'"
-    [showObserverTrips]="true"
-    [activateFollowModeOnStartup]="activateFollowModeInMapOnStartup"
-    [updateMapViewOnExtentChange]="true"
-  ></app-map>
+<ion-split-pane contentId="main-content-home-page">
+  <ion-menu side="start" menuId="filter" contentId="main-content-home-page">
+    @defer {}
+    <app-filter-menu></app-filter-menu>
+  </ion-menu>
 
-  @defer {
-    <app-map-center-info *ngIf="userSettingService.showMapCenter$ | async"></app-map-center-info>
+  <div id="main-content-home-page" class="ion-page">
+    <app-header title="{{ appname }}" [fullscreenSupport]="true"></app-header>
+    <ion-content>
+      <app-map
+        (mapReady)="onMapReady($event)"
+        [autoActivate]="false"
+        [geoTag]="'HomePage'"
+        [showObserverTrips]="true"
+        [activateFollowModeOnStartup]="activateFollowModeInMapOnStartup"
+        [updateMapViewOnExtentChange]="true"
+      ></app-map>
 
-    <app-map-item-bar></app-map-item-bar>
+      @defer {
+        <app-map-center-info *ngIf="userSettingService.showMapCenter$ | async"></app-map-center-info>
 
-    <!-- TODO sett tilbake etter at veilederen er fiksa  -->
-    <!-- <app-geo-fab slot="fixed" *ngIf="showGeoSelectInfo === false"></app-geo-fab> -->
-    <app-geo-fab></app-geo-fab>
+        <app-map-item-bar></app-map-item-bar>
 
-    @if (isDesktop()) {
-      <app-show-filter-criteria slot="fixed"></app-show-filter-criteria>
-    }
+        <!-- TODO sett tilbake etter at veilederen er fiksa  -->
+        <!-- <app-geo-fab slot="fixed" *ngIf="showGeoSelectInfo === false"></app-geo-fab> -->
+        <app-geo-fab></app-geo-fab>
 
-    <app-add-menu></app-add-menu>
+        @if (isDesktop()) {
+          <app-show-filter-criteria slot="fixed"></app-show-filter-criteria>
+        }
 
-    <app-data-load [show]="isFetchingObservations$ | async" [label]="spinnerLabel"></app-data-load>
-  }
-</ion-content>
+        <app-add-menu></app-add-menu>
+
+        <app-data-load [show]="isFetchingObservations$ | async" [label]="spinnerLabel"></app-data-load>
+      }
+    </ion-content>
+  </div>
+</ion-split-pane>

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -7,7 +7,3 @@ app-show-filter-criteria {
   margin-left: 80px;
   margin-top: 10px;
 }
-
-ion-split-pane {
-  --side-max-width: 300px;
-}

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -7,3 +7,7 @@ app-show-filter-criteria {
   margin-left: 80px;
   margin-top: 10px;
 }
+
+ion-split-pane {
+  --side-max-width: 300px;
+}

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -2,7 +2,7 @@ import { DOCUMENT, NgIf, AsyncPipe } from '@angular/common';
 import { AfterViewChecked, Component, NgZone, OnDestroy, OnInit, inject, viewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Capacitor } from '@capacitor/core';
-import { AlertController, IonContent, ToastController } from '@ionic/angular/standalone';
+import { AlertController, IonContent, ToastController, IonSplitPane, IonMenu } from '@ionic/angular/standalone';
 import { TranslateService } from '@ngx-translate/core';
 import { Feature, Point } from 'geojson';
 import L from 'leaflet';
@@ -55,6 +55,7 @@ import { ShowFilterCriteriaComponent } from '../../modules/side-menu/components/
 import { AddMenuComponent } from '../../modules/shared/components/add-menu/add-menu.component';
 import { DataLoadComponent } from '../../modules/data-load/components/data-load/data-load.component';
 import { BreakpointService } from 'src/app/core/services/breakpoint.service';
+import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter-menu/filter-menu.component';
 
 const DEBUG_TAG = 'HomePage';
 
@@ -79,9 +80,12 @@ function positionDtoToLatLng(position: PositionDto): L.LatLng {
     AddMenuComponent,
     AsyncPipe,
     DataLoadComponent,
+    FilterMenuComponent,
     GeoFabComponent,
     HeaderComponent,
     IonContent,
+    IonMenu,
+    IonSplitPane,
     MapCenterInfoComponent_1,
     MapComponent,
     MapItemBarComponent,

--- a/src/app/pages/observation-list/list.page.ts
+++ b/src/app/pages/observation-list/list.page.ts
@@ -15,7 +15,9 @@ import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter
   template: `
     <ion-split-pane contentId="main-content-list-page">
       <ion-menu side="start" menuId="filter" contentId="main-content-list-page">
-        <app-filter-menu></app-filter-menu>
+        @defer {
+          <app-filter-menu></app-filter-menu>
+        }
       </ion-menu>
 
       <div id="main-content-list-page" class="ion-page">

--- a/src/app/pages/observation-list/list.page.ts
+++ b/src/app/pages/observation-list/list.page.ts
@@ -3,7 +3,8 @@ import { HeaderComponent } from '../../modules/shared/components/header/header.c
 import { AddMenuComponent } from '../../modules/shared/components/add-menu/add-menu.component';
 import { RouterOutlet } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
-import { IonTitle } from '@ionic/angular/standalone';
+import { IonMenu, IonSplitPane, IonTitle } from '@ionic/angular/standalone';
+import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter-menu/filter-menu.component';
 
 /**
  * Show a list of observation data that meets current search filter.
@@ -12,13 +13,35 @@ import { IonTitle } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-list-page',
   template: `
-    <app-header>
-      <ion-title>{{ 'OBSERVATION_LIST.TITLE' | translate }}</ion-title>
-    </app-header>
-    <router-outlet></router-outlet>
-    <app-add-menu></app-add-menu>
+    <ion-split-pane contentId="main-content-list-page">
+      <ion-menu side="start" menuId="filter" contentId="main-content-list-page">
+        <app-filter-menu></app-filter-menu>
+      </ion-menu>
+
+      <div id="main-content-list-page" class="ion-page">
+        <app-header>
+          <ion-title>{{ 'OBSERVATION_LIST.TITLE' | translate }}</ion-title>
+        </app-header>
+        <router-outlet></router-outlet>
+        <app-add-menu></app-add-menu>
+      </div>
+    </ion-split-pane>
+  `,
+  styles: `
+    ion-split-pane {
+      --side-max-width: 300px;
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [AddMenuComponent, HeaderComponent, RouterOutlet, TranslatePipe, IonTitle],
+  imports: [
+    AddMenuComponent,
+    FilterMenuComponent,
+    HeaderComponent,
+    IonMenu,
+    IonSplitPane,
+    IonTitle,
+    RouterOutlet,
+    TranslatePipe,
+  ],
 })
 export class ObservationListPage {}

--- a/src/app/pages/observation-list/list.page.ts
+++ b/src/app/pages/observation-list/list.page.ts
@@ -27,11 +27,6 @@ import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter
       </div>
     </ion-split-pane>
   `,
-  styles: `
-    ion-split-pane {
-      --side-max-width: 300px;
-    }
-  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AddMenuComponent,

--- a/src/global.scss
+++ b/src/global.scss
@@ -956,3 +956,19 @@ swiper-container::part(button-prev),
 swiper-container::part(button-next) {
   color: var(--ion-color-primary);
 }
+
+/**
+ * Styling for filtermenyen, som skal vises hele tiden på store skjermer.
+ * Reglene ligger globalt siden menyen vises både i kartet og listevisninga.
+ * https://ionicframework.com/docs/api/split-pane#css-custom-properties-1
+ */
+ion-split-pane {
+  --side-max-width: 300px;
+  --border: none;
+}
+
+@media (min-width: 2000px) {
+  ion-split-pane {
+    --side-max-width: 400px;
+  }
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -966,9 +966,3 @@ ion-split-pane {
   --side-max-width: 300px;
   --border: none;
 }
-
-@media (min-width: 2000px) {
-  ion-split-pane {
-    --side-max-width: 400px;
-  }
-}


### PR DESCRIPTION
Ionic-måten å få dette til på er med en split pane.

Kanskje vanskelig å se siden det ble en del endringer, men dette flytter menyen fra ett sted i appen til to, til kartet og listevisninga. Så de har ikke helt lik tilstand lenger, selv om filtrene som vises er like. Det fungerer greit, men er ikke helt optimalt.

Måtte også endre litt på strukturen i filtermenyen for å få scrollbar osv til å fungere bra. Bruker nå strukturen Ionic bruker i dokumentasjonen.