### PR TITLE
RO-2748: Link til norsk tekst for "Om data og tilgjengelighet"

### DIFF
--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -103,13 +103,12 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
     return this.userSetting$.pipe(map((us) => this.getSupportTilesOptions(us, false)));
   }
 
-  get legalUrl() {
-    const language = this.userSettingInMemory.value?.language;
-    if (language == LangKey.nb || language == LangKey.nn) {
-      return settings.legalUrl.nb;
-    } else {
-      return settings.legalUrl.en;
-    }
+  get legalUrl$() {
+    return this.language$.pipe(
+      map((language) =>
+        language === LangKey.nb || language === LangKey.nn ? settings.legalUrl.nb : settings.legalUrl.en
+      )
+    );
   }
 
   constructor() {

--- a/src/app/modules/side-menu/components/side-menu.component.html
+++ b/src/app/modules/side-menu/components/side-menu.component.html
@@ -106,7 +106,7 @@
   </ion-list-header>
 
   <ion-menu-toggle auto-hide="false">
-    <ion-item [href]="legalTermsUrl()" detail="true" button color="light">
+    <ion-item [href]="legalUrl()" detail="true" button color="light">
       <ion-icon slot="start" name="information-circle-outline" color="primary"></ion-icon>
       <ion-label>{{ "MENU.ABOUT_REGOBS" | translate }}</ion-label>
     </ion-item>

--- a/src/app/modules/side-menu/components/side-menu.component.ts
+++ b/src/app/modules/side-menu/components/side-menu.component.ts
@@ -42,6 +42,7 @@ import {
   bugOutline,
   mailOutline,
 } from 'ionicons/icons';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-side-menu',
@@ -78,7 +79,7 @@ export class SideMenuComponent implements OnInit, OnDestroy {
   private ngZone = inject(NgZone);
   private externalLinkService = inject(ExternalLinkService);
   private fileLoggingService = inject(FileLoggingService);
-
+  legalUrl = toSignal(this.userSettingService.legalUrl$, { initialValue: '' });
   userSettings?: UserSetting;
   settings = settings;
   TopoMap = TopoMap;
@@ -118,8 +119,6 @@ export class SideMenuComponent implements OnInit, OnDestroy {
       mailOutline,
     });
   }
-
-  legalTermsUrl = computed(() => this.userSettingService.legalUrl);
 
   async ngOnInit() {
     this.userSettingSubscription = this.userSettingService.userSetting$.subscribe((val) => {

--- a/src/app/pages/start-wizard/start-wizard.page.html
+++ b/src/app/pages/start-wizard/start-wizard.page.html
@@ -85,7 +85,7 @@
         <span [innerHtml]="'LEGAL_TERMS.LINE_5' | translate"></span>
       </li>
       <li>
-        <span [innerHtml]="'LEGAL_TERMS.LINE_6' | translate: { legalUrl: legalUrl }"></span>
+        <span [innerHtml]="'LEGAL_TERMS.LINE_6' | translate: { legalUrl: legalUrl() }"></span>
       </li>
     </ul>
   </swiper-slide>

--- a/src/app/pages/start-wizard/start-wizard.page.ts
+++ b/src/app/pages/start-wizard/start-wizard.page.ts
@@ -35,7 +35,7 @@ export class StartWizardPage {
   LangKey = LangKey;
   currentSlideIndex = 0;
   language = toSignal(this.userSettingService.language$, { initialValue: LangKey.nb });
-  legalUrl = this.userSettingService.legalUrl;
+  legalUrl = toSignal(this.userSettingService.legalUrl$);
   userSettings = toSignal(this.userSettingService.userSetting$);
   supportedLanguages: {
     lang: string;


### PR DESCRIPTION
Ser ut at this.userSettingInMemory.value?.language i user-setting.service pleide å returnere undefined. Har brukt language$ istedenfor. Så gjort jeg legalUrl til en signal i både start-wizard og side-menu.

Når man bytter språk burde man få riktig lenke av Om data og tilgjengelighet. Skal jeg legge til dansk og svensk og, akkurat som med Varsom?