### PR TITLE
RO-2751: fiks velg sted skjema i panoramisk visning

### DIFF
--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.html
@@ -1,6 +1,6 @@
-<div>
+<div class="set-location-in-map">
   <app-map
-    [ngClass]="geoHazard() === 60 ? 'water-simple-obs-bottom' : 'regular-bottom'"
+    [class]="geoHazard() === 60 ? 'water-simple-obs-bottom' : 'regular-bottom'"
     *ngIf="locationMarker()"
     [showSupportMaps]="false"
     (mapReady)="onMapReady($event)"

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
@@ -59,7 +59,7 @@ app-map {
 }
 
 /* Vi har ikke en bra støtte på veldig små skjermer, men dette burde holde bra nok for panoramisk viewet */
-@media screen and (max-height: 580px) and (min-width: 400px) {
+@media screen and (max-height: 650px) and (min-width: 400px) {
   .bottom-background {
     right: unset;
     top: 0;

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
@@ -63,7 +63,7 @@ app-map {
     right: unset;
     top: 0;
     .bottom-info {
-      max-width: 340px;
+      max-width: 500px;
     }
   }
 }

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
@@ -57,6 +57,14 @@ app-map {
   gap: 10px;
 }
 
+/* Vi har ikke en bra støtte på veldig små skjermer, men dette burde holde bra nok for panoramisk viewet */
+@media screen and (max-height: 580px) and (min-width: 600px) {
+  .bottom-background {
+    right: unset;
+    top: 0;
+  }
+}
+
 .flex-row {
   display: flex;
   align-items: stretch;

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
@@ -19,6 +19,7 @@ app-map {
   top: 0;
   left: 0;
   right: 0;
+  bottom: 0;
 }
 
 .bottom-background {
@@ -65,6 +66,9 @@ app-map {
     .bottom-info {
       max-width: 500px;
     }
+  }
+  .regular-bottom {
+    bottom: 0;
   }
 }
 

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
@@ -58,10 +58,13 @@ app-map {
 }
 
 /* Vi har ikke en bra støtte på veldig små skjermer, men dette burde holde bra nok for panoramisk viewet */
-@media screen and (max-height: 580px) and (min-width: 600px) {
+@media screen and (max-height: 580px) and (min-width: 400px) {
   .bottom-background {
     right: unset;
     top: 0;
+    .bottom-info {
+      max-width: 340px;
+    }
   }
 }
 

--- a/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
+++ b/src/app/modules/registration/components/set-location-in-map/set-location-in-map.component.scss
@@ -14,20 +14,13 @@ $long-map-bottom-spread: 64px;
 }
 
 app-map {
-  position: absolute;
+  width: 100%;
+  height: 100%;
   display: block;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
 }
 
 .bottom-background {
   background-color: #fff;
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
   z-index: 9999;
   justify-content: center;
   padding: 0 10px;
@@ -47,6 +40,13 @@ app-map {
       height: var(--ion-button-height);
     }
   }
+}
+
+.set-location-in-map {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
 }
 
 .flex-col {
@@ -69,6 +69,9 @@ app-map {
   }
   .regular-bottom {
     bottom: 0;
+  }
+  .set-location-in-map {
+    flex-direction: row-reverse;
   }
 }
 


### PR DESCRIPTION
Nå får vi 'velg sted' skjema ved siden i panoramisk viewet og hvis bredde på mobil er min 600px. det er for å unngå visning ved siden på veldig små skjermer. Veldig små skjermer har faktisk ikke bra støttet, men jeg vil ikke prioritere det. Tror det er ikke så mange brukere uansett. 