### PR TITLE
RO-1872: Lese gamle url-parametre som brukes i regobs.no

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -476,11 +476,9 @@ describe('SearchCriteriaService url parsing', () => {
     expect(criteria!.OrderBy).toEqual('DtObsTime');
   }));
 
-  ['hazard=70', 'GeoHazards=70'].forEach((queryPath) => {
-    it('geo hazard url filter should work', fakeAsync(() => {
-      expect(applyUrlQueryPath(queryPath).SelectedGeoHazards).toEqual([70]);
-    }));
-  });
+  it('geo hazard url filter should work', fakeAsync(() => {
+    expect(applyUrlQueryPath('hazard=70').SelectedGeoHazards).toEqual([70]);
+  }));
 
   it('illegal geo hazard in url should return 10', fakeAsync(() => {
     setUrlQueryPath('hazard=illegal');
@@ -493,23 +491,21 @@ describe('SearchCriteriaService url parsing', () => {
     expect(criteria!.SelectedGeoHazards).toEqual([10]);
   }));
 
-  ['daysBack=1', 'SelectedNumberOfDays=1'].forEach((queryPath) => {
-    it('days back url filter should work', fakeAsync(() => {
-      jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
-      setUrlQueryPath(queryPath);
+  it('days back url filter should work', fakeAsync(() => {
+    const queryPath = 'daysBack=1';
+    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
+    setUrlQueryPath(queryPath);
 
-      //check that criteria contains correct from time. Should be 1 day earlier at midnight
-      expect(applyUrlQueryPath(queryPath).FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
-    }));
-  });
+    //check that criteria contains correct from time. Should be 1 day earlier at midnight
+    expect(applyUrlQueryPath(queryPath).FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
+  }));
 
-  ['fromDate=2020-12-24&toDate=2022-12-24', 'FromDate=2020-12-24&ToDate=2022-12-24'].forEach((queryPath) => {
-    it('toDate and fromDate filter should work', fakeAsync(() => {
-      const criteria = applyUrlQueryPath(queryPath);
-      expect(criteria!.FromDtObsTime).toEqual('2020-12-24T00:00:00.000+01:00');
-      expect(criteria!.ToDtObsTime).toEqual('2022-12-24T23:59:59.999+01:00');
-    }));
-  });
+  it('toDate and fromDate filter should work', fakeAsync(() => {
+    const queryPath = 'fromDate=2020-12-24&toDate=2022-12-24';
+    const criteria = applyUrlQueryPath(queryPath);
+    expect(criteria!.FromDtObsTime).toEqual('2020-12-24T00:00:00.000+01:00');
+    expect(criteria!.ToDtObsTime).toEqual('2022-12-24T23:59:59.999+01:00');
+  }));
 
   it('slush flow filter should be activated by url', fakeAsync(() => {
     setUrlQueryPath('slushFlow=true');

--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -358,6 +358,15 @@ describe('SearchCriteriaService url parsing', () => {
     return TestBed.inject(SearchCriteriaService);
   };
 
+  /**
+   * Bruk denne til å fake at vi har satt en eller flere url-parametre
+   * Eksempel: setUrlQueryPath('hazard=10&nick=Oluf')
+   */
+  const setUrlQueryPath = (queryPath: string) => {
+    const newRelativePathQuery = `${window.location.pathname}?${queryPath}`;
+    history.pushState(null, '', newRelativePathQuery);
+  };
+
   beforeEach(() => {
     jasmine.clock().install();
     moment.tz.setDefault('Europe/Oslo');
@@ -381,7 +390,7 @@ describe('SearchCriteriaService url parsing', () => {
   });
 
   it('competence url filter works properly', fakeAsync(() => {
-    new UrlParams().set('competence', '150~105').apply();
+    setUrlQueryPath('competence=150~105');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -390,7 +399,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('type wrong hazard should search for 10 as default', fakeAsync(() => {
-    new UrlParams().set('hazard', '140').apply();
+    setUrlQueryPath('hazard=140');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -399,7 +408,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('competence url filter with wrong params', fakeAsync(() => {
-    new UrlParams().set('competence', '150~string').apply();
+    setUrlQueryPath('competence=150~string');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -408,7 +417,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('nick name url filter should work', fakeAsync(() => {
-    new UrlParams().set('nick', 'Oluf').apply();
+    setUrlQueryPath('nick=Oluf');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -418,7 +427,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('type url should work', fakeAsync(() => {
-    new UrlParams().set('type', '81.13~81.26~10').apply();
+    setUrlQueryPath('type=81.13~81.26~10');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -431,7 +440,7 @@ describe('SearchCriteriaService url parsing', () => {
 
   wrongObservationTypeUrl.forEach((test) => {
     it('type url wrong format, set undefined in criteria', fakeAsync(() => {
-      new UrlParams().set('type', test).apply();
+      setUrlQueryPath('type=test');
       const service = getService();
       let criteria;
       service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -441,7 +450,7 @@ describe('SearchCriteriaService url parsing', () => {
   });
 
   it('orderBy url filter should work', fakeAsync(() => {
-    new UrlParams().set('orderBy', 'changeTime').apply();
+    setUrlQueryPath('orderBy=changeTime');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -452,7 +461,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('orderBy url filter should work', fakeAsync(() => {
-    new UrlParams().set('orderBy', 'obsTime').apply();
+    setUrlQueryPath('orderBy=obsTime');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -462,7 +471,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('geo hazard url filter should work', fakeAsync(() => {
-    new UrlParams().set('hazard', '70').apply();
+    setUrlQueryPath('hazard=70');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -472,7 +481,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('illegal geo hazard in url should reuturn 10', fakeAsync(() => {
-    new UrlParams().set('hazard', 'illegal').apply();
+    setUrlQueryPath('hazard=illegal');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -484,22 +493,45 @@ describe('SearchCriteriaService url parsing', () => {
 
   it('days back url filter should work', fakeAsync(() => {
     jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
-    new UrlParams().set('daysBack', 1).apply();
+    setUrlQueryPath('daysBack=1');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
     tick(100);
 
     //check that criteria contains correct from time. Should be 1 day earlier at midnight
+    expect(criteria!.FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
+  }));
 
+  it('old days back url filter should work', fakeAsync(() => {
+    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
+    setUrlQueryPath('SelectedNumberOfDays=1');
+    const service = getService();
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
+
+    //check that criteria contains correct from time. Should be 1 day earlier at midnight
     expect(criteria!.FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
   }));
 
   it('toDate and fromDate filter should work', fakeAsync(() => {
     jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
 
-    new UrlParams().set('fromDate', '2020-12-24').apply();
-    new UrlParams().set('toDate', '2022-12-24').apply();
+    setUrlQueryPath('fromDate=2020-12-24&toDate=2022-12-24');
+    const service = getService();
+    let criteria;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
+
+    expect(criteria!.FromDtObsTime).toEqual('2020-12-24T00:00:00.000+01:00');
+    expect(criteria!.ToDtObsTime).toEqual('2022-12-24T23:59:59.999+01:00');
+  }));
+
+  it('old toDate and fromDate filter should work', fakeAsync(() => {
+    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
+
+    setUrlQueryPath('FromDate=2020-12-24&ToDate=2022-12-24');
     const service = getService();
     let criteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -510,7 +542,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('slush flow filter should be activated by url', fakeAsync(() => {
-    new UrlParams().set('slushFlow', true).apply();
+    setUrlQueryPath('slushFlow=true');
     const service = getService();
     let criteria: SearchCriteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -524,7 +556,7 @@ describe('SearchCriteriaService url parsing', () => {
   }));
 
   it('slush flow filter should be deactivated by url', fakeAsync(() => {
-    new UrlParams().set('slushFlow', false).apply();
+    setUrlQueryPath('slushFlow=false');
     const service = getService();
     let criteria: SearchCriteria;
     service.searchCriteria$.subscribe((c) => (criteria = c));

--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -426,11 +426,9 @@ describe('SearchCriteriaService url parsing', () => {
     expect(criteria!.ObserverCompetence).toEqual(undefined);
   }));
 
-  ['nick=Oluf', 'ObserverNickName=Oluf'].forEach((queryPath) => {
-    it('nick name url filter should work', fakeAsync(() => {
-      expect(applyUrlQueryPath(queryPath).ObserverNickName).toEqual('Oluf');
-    }));
-  });
+  it('nick name url filter should work', fakeAsync(() => {
+    expect(applyUrlQueryPath('nick=Oluf').ObserverNickName).toEqual('Oluf');
+  }));
 
   it('type url should work', fakeAsync(() => {
     setUrlQueryPath('type=81.13~81.26~10');

--- a/src/app/core/services/search-criteria/search-criteria.service.spec.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.spec.ts
@@ -9,9 +9,10 @@ import { provideTestLogger } from 'src/app/modules/shared/services/logging/test-
 import { SearchCriteria } from '../../models/search-criteria';
 import { UserSettingService } from '../user-setting/user-setting.service';
 import { SearchCriteriaOrderBy, SearchCriteriaService } from './search-criteria.service';
-import { separatedStringToNumberArray, UrlParams } from './url-params';
+import { separatedStringToNumberArray } from './url-params';
 import { provideTranslateService } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { SearchCriteriaRequestDto } from 'src/app/modules/common-regobs-api';
 
 export class TestMapService {
   mapView$!: BehaviorSubject<IMapView>;
@@ -38,6 +39,7 @@ describe('SearchCriteriaService', () => {
     { apiValue: 'DtObsTime', urlValue: 'obsTime' },
   ];
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const expectQueryParameterToHaveBeenApplied = (key: string, value: any) => {
     const url = new URL(document.location.href + router.url);
     if (!value) {
@@ -186,6 +188,7 @@ describe('SearchCriteriaService', () => {
   }));
 
   it('det skal gå an å fjerne samme observasjonstype som vi nettopp la til i filteret (ro-2734)', fakeAsync(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let criteria: any;
     service.searchCriteria$.subscribe((c) => (criteria = c));
     const obsType = { Id: 80, SubTypes: [26] };
@@ -367,6 +370,22 @@ describe('SearchCriteriaService url parsing', () => {
     history.pushState(null, '', newRelativePathQuery);
   };
 
+  /**
+   * Bruk denne til å sjekke at vi har fått riktige kriteria basert på angitte url-parametre
+   * @param queryPath url-parameterne som skal brukes
+   * @returns søkekriteria som skal være i henhold til url-parametrene
+   * @example applyUrlParameter('nick=Oluf').ObserverNickName === 'Oluf'
+   */
+  const applyUrlQueryPath = (queryPath: string): SearchCriteriaRequestDto => {
+    setUrlQueryPath(queryPath);
+    const service = getService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let criteria: any;
+    service.searchCriteria$.subscribe((c) => (criteria = c));
+    tick(100);
+    return criteria as SearchCriteriaRequestDto;
+  };
+
   beforeEach(() => {
     jasmine.clock().install();
     moment.tz.setDefault('Europe/Oslo');
@@ -398,15 +417,6 @@ describe('SearchCriteriaService url parsing', () => {
     expect(criteria!.ObserverCompetence).toEqual([150, 105]);
   }));
 
-  it('type wrong hazard should search for 10 as default', fakeAsync(() => {
-    setUrlQueryPath('hazard=140');
-    const service = getService();
-    let criteria;
-    service.searchCriteria$.subscribe((c) => (criteria = c));
-    tick(100);
-    expect(criteria!.SelectedGeoHazards).toEqual([10]);
-  }));
-
   it('competence url filter with wrong params', fakeAsync(() => {
     setUrlQueryPath('competence=150~string');
     const service = getService();
@@ -416,15 +426,11 @@ describe('SearchCriteriaService url parsing', () => {
     expect(criteria!.ObserverCompetence).toEqual(undefined);
   }));
 
-  it('nick name url filter should work', fakeAsync(() => {
-    setUrlQueryPath('nick=Oluf');
-    const service = getService();
-    let criteria;
-    service.searchCriteria$.subscribe((c) => (criteria = c));
-    tick(100);
-    //check that current criteria contains expected nick name
-    expect(criteria!.ObserverNickName).toEqual('Oluf');
-  }));
+  ['nick=Oluf', 'ObserverNickName=Oluf'].forEach((queryPath) => {
+    it('nick name url filter should work', fakeAsync(() => {
+      expect(applyUrlQueryPath(queryPath).ObserverNickName).toEqual('Oluf');
+    }));
+  });
 
   it('type url should work', fakeAsync(() => {
     setUrlQueryPath('type=81.13~81.26~10');
@@ -440,7 +446,7 @@ describe('SearchCriteriaService url parsing', () => {
 
   wrongObservationTypeUrl.forEach((test) => {
     it('type url wrong format, set undefined in criteria', fakeAsync(() => {
-      setUrlQueryPath('type=test');
+      setUrlQueryPath(`type=${test}`);
       const service = getService();
       let criteria;
       service.searchCriteria$.subscribe((c) => (criteria = c));
@@ -470,17 +476,13 @@ describe('SearchCriteriaService url parsing', () => {
     expect(criteria!.OrderBy).toEqual('DtObsTime');
   }));
 
-  it('geo hazard url filter should work', fakeAsync(() => {
-    setUrlQueryPath('hazard=70');
-    const service = getService();
-    let criteria;
-    service.searchCriteria$.subscribe((c) => (criteria = c));
-    tick(100);
-    //check that current criteria contains expected geo hazard
-    expect(criteria!.SelectedGeoHazards).toEqual([70]);
-  }));
+  ['hazard=70', 'GeoHazards=70'].forEach((queryPath) => {
+    it('geo hazard url filter should work', fakeAsync(() => {
+      expect(applyUrlQueryPath(queryPath).SelectedGeoHazards).toEqual([70]);
+    }));
+  });
 
-  it('illegal geo hazard in url should reuturn 10', fakeAsync(() => {
+  it('illegal geo hazard in url should return 10', fakeAsync(() => {
     setUrlQueryPath('hazard=illegal');
     const service = getService();
     let criteria;
@@ -491,55 +493,23 @@ describe('SearchCriteriaService url parsing', () => {
     expect(criteria!.SelectedGeoHazards).toEqual([10]);
   }));
 
-  it('days back url filter should work', fakeAsync(() => {
-    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
-    setUrlQueryPath('daysBack=1');
-    const service = getService();
-    let criteria;
-    service.searchCriteria$.subscribe((c) => (criteria = c));
-    tick(100);
+  ['daysBack=1', 'SelectedNumberOfDays=1'].forEach((queryPath) => {
+    it('days back url filter should work', fakeAsync(() => {
+      jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
+      setUrlQueryPath(queryPath);
 
-    //check that criteria contains correct from time. Should be 1 day earlier at midnight
-    expect(criteria!.FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
-  }));
+      //check that criteria contains correct from time. Should be 1 day earlier at midnight
+      expect(applyUrlQueryPath(queryPath).FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
+    }));
+  });
 
-  it('old days back url filter should work', fakeAsync(() => {
-    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
-    setUrlQueryPath('SelectedNumberOfDays=1');
-    const service = getService();
-    let criteria;
-    service.searchCriteria$.subscribe((c) => (criteria = c));
-    tick(100);
-
-    //check that criteria contains correct from time. Should be 1 day earlier at midnight
-    expect(criteria!.FromDtObsTime).toEqual('2000-12-23T00:00:00.000+01:00');
-  }));
-
-  it('toDate and fromDate filter should work', fakeAsync(() => {
-    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
-
-    setUrlQueryPath('fromDate=2020-12-24&toDate=2022-12-24');
-    const service = getService();
-    let criteria;
-    service.searchCriteria$.subscribe((c) => (criteria = c));
-    tick(100);
-
-    expect(criteria!.FromDtObsTime).toEqual('2020-12-24T00:00:00.000+01:00');
-    expect(criteria!.ToDtObsTime).toEqual('2022-12-24T23:59:59.999+01:00');
-  }));
-
-  it('old toDate and fromDate filter should work', fakeAsync(() => {
-    jasmine.clock().mockDate(moment.tz('2000-12-24 08:00:00', 'Europe/Oslo').toDate());
-
-    setUrlQueryPath('FromDate=2020-12-24&ToDate=2022-12-24');
-    const service = getService();
-    let criteria;
-    service.searchCriteria$.subscribe((c) => (criteria = c));
-    tick(100);
-
-    expect(criteria!.FromDtObsTime).toEqual('2020-12-24T00:00:00.000+01:00');
-    expect(criteria!.ToDtObsTime).toEqual('2022-12-24T23:59:59.999+01:00');
-  }));
+  ['fromDate=2020-12-24&toDate=2022-12-24', 'FromDate=2020-12-24&ToDate=2022-12-24'].forEach((queryPath) => {
+    it('toDate and fromDate filter should work', fakeAsync(() => {
+      const criteria = applyUrlQueryPath(queryPath);
+      expect(criteria!.FromDtObsTime).toEqual('2020-12-24T00:00:00.000+01:00');
+      expect(criteria!.ToDtObsTime).toEqual('2022-12-24T23:59:59.999+01:00');
+    }));
+  });
 
   it('slush flow filter should be activated by url', fakeAsync(() => {
     setUrlQueryPath('slushFlow=true');

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -36,6 +36,7 @@ import {
   URL_PARAM_COMPETENCE,
   URL_PARAM_DAYSBACK,
   URL_PARAM_FROMDATE,
+  URL_PARAM_FROMDATE_OLD,
   URL_PARAM_GEOHAZARD,
   URL_PARAM_NICKNAME,
   URL_PARAM_NW_LAT,
@@ -47,6 +48,7 @@ import {
   URL_PARAM_SE_LON,
   URL_PARAM_SLUSH_FLOW,
   URL_PARAM_TODATE,
+  URL_PARAM_TODATE_OLD,
   UrlParams,
 } from './url-params';
 import { isoDateTimeToLocalDate, convertToIsoDateTime } from '../../../modules/common-core/helpers/date-converters';
@@ -333,12 +335,17 @@ export class SearchCriteriaService {
     let fromObsTime: string | undefined;
     let toObsTime: string | undefined;
 
-    if (url.searchParams.get(URL_PARAM_FROMDATE)) {
-      fromObsTime = convertToIsoDateTime(url.searchParams.get(URL_PARAM_FROMDATE));
+    if (url.searchParams.get(URL_PARAM_FROMDATE) || url.searchParams.get(URL_PARAM_FROMDATE_OLD)) {
+      fromObsTime = convertToIsoDateTime(
+        url.searchParams.get(URL_PARAM_FROMDATE) || url.searchParams.get(URL_PARAM_FROMDATE_OLD)
+      );
     }
 
-    if (url.searchParams.get(URL_PARAM_TODATE)) {
-      toObsTime = convertToIsoDateTime(url.searchParams.get(URL_PARAM_TODATE), 'end');
+    if (url.searchParams.get(URL_PARAM_TODATE) || url.searchParams.get(URL_PARAM_TODATE_OLD)) {
+      toObsTime = convertToIsoDateTime(
+        url.searchParams.get(URL_PARAM_TODATE) || url.searchParams.get(URL_PARAM_TODATE_OLD),
+        'end'
+      );
     }
 
     this.setUseDaysBack(!fromObsTime);

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -39,6 +39,7 @@ import {
   URL_PARAM_FROMDATE_OLD,
   URL_PARAM_GEOHAZARD,
   URL_PARAM_NICKNAME,
+  URL_PARAM_NICKNAME_OLD,
   URL_PARAM_NW_LAT,
   URL_PARAM_NW_LON,
   URL_PARAM_ORDER_BY,
@@ -350,7 +351,7 @@ export class SearchCriteriaService {
 
     this.setUseDaysBack(!fromObsTime);
 
-    const nickName = url.searchParams.get(URL_PARAM_NICKNAME);
+    const nickName = url.searchParams.get(URL_PARAM_NICKNAME) || url.searchParams.get(URL_PARAM_NICKNAME_OLD);
     const observerCompetence = competenceFromUrlToDto(url.searchParams.get(URL_PARAM_COMPETENCE));
     const regTypesRaw = url.searchParams.get(URL_PARAM_REGISTRATION_TYPE);
     const regTypes = regTypesRaw != null ? convertRegTypeFromUrlToDto(regTypesRaw) : [];

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -31,15 +31,15 @@ import { MapService } from 'src/app/modules/map/services/map/map.service';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { UserSettingService } from '../user-setting/user-setting.service';
 import {
+  arrayToSeparatedString,
+  convertRegTypeDtoToUrl,
   separatedStringToNumberArray,
   URL_PARAM_ARRAY_DELIMITER,
   URL_PARAM_COMPETENCE,
   URL_PARAM_DAYSBACK,
   URL_PARAM_FROMDATE,
-  URL_PARAM_FROMDATE_OLD,
   URL_PARAM_GEOHAZARD,
   URL_PARAM_NICKNAME,
-  URL_PARAM_NICKNAME_OLD,
   URL_PARAM_NW_LAT,
   URL_PARAM_NW_LON,
   URL_PARAM_ORDER_BY,
@@ -49,7 +49,6 @@ import {
   URL_PARAM_SE_LON,
   URL_PARAM_SLUSH_FLOW,
   URL_PARAM_TODATE,
-  URL_PARAM_TODATE_OLD,
   UrlParams,
 } from './url-params';
 import { isoDateTimeToLocalDate, convertToIsoDateTime } from '../../../modules/common-core/helpers/date-converters';
@@ -107,13 +106,6 @@ function convertApiOrderByToUrl(value: SearchCriteriaOrderBy): string | undefine
   return;
 }
 
-function numberArrayToSeparatedString(numbers: number[] | undefined): string | undefined {
-  if (numbers?.length) {
-    return numbers.join(URL_PARAM_ARRAY_DELIMITER);
-  }
-  return;
-}
-
 function isCompetenceUrlValid(competence: string): RegExpMatchArray | null {
   //check if its a sequence of numbers to max 3 digits with optional tilde as param
   const regex = /^(\b\d{0,3}\b~?)*$/g;
@@ -146,23 +138,6 @@ function convertRegTypeFromUrlToDto(type: string): RegistrationTypeCriteriaDto[]
       {} as { [key: number]: RegistrationTypeCriteriaDto }
     );
   return Object.values(regTypeCriteriaDto);
-}
-
-//[{Id: 80, SubTypes: [26,11]}] => 80.11~80.26
-function convertRegTypeDtoToUrl(types?: RegistrationTypeCriteriaDto[]) {
-  if (types != null) {
-    const url = [] as string[];
-    types.forEach((type) => {
-      const parentId = type.Id;
-      if (type.SubTypes && type.SubTypes.length > 0) {
-        type.SubTypes.forEach((subtype) => url.push(`${parentId}.${subtype}`));
-      } else {
-        url.push(parentId.toString());
-      }
-    });
-    return url.join('~');
-  }
-  return;
 }
 
 const DEFAULT_SEARCH_CRITERIA: SearchCriteriaRequestDto = {
@@ -336,22 +311,17 @@ export class SearchCriteriaService {
     let fromObsTime: string | undefined;
     let toObsTime: string | undefined;
 
-    if (url.searchParams.get(URL_PARAM_FROMDATE) || url.searchParams.get(URL_PARAM_FROMDATE_OLD)) {
-      fromObsTime = convertToIsoDateTime(
-        url.searchParams.get(URL_PARAM_FROMDATE) || url.searchParams.get(URL_PARAM_FROMDATE_OLD)
-      );
+    if (url.searchParams.get(URL_PARAM_FROMDATE)) {
+      fromObsTime = convertToIsoDateTime(url.searchParams.get(URL_PARAM_FROMDATE));
     }
 
-    if (url.searchParams.get(URL_PARAM_TODATE) || url.searchParams.get(URL_PARAM_TODATE_OLD)) {
-      toObsTime = convertToIsoDateTime(
-        url.searchParams.get(URL_PARAM_TODATE) || url.searchParams.get(URL_PARAM_TODATE_OLD),
-        'end'
-      );
+    if (url.searchParams.get(URL_PARAM_TODATE)) {
+      toObsTime = convertToIsoDateTime(url.searchParams.get(URL_PARAM_TODATE), 'end');
     }
 
     this.setUseDaysBack(!fromObsTime);
 
-    const nickName = url.searchParams.get(URL_PARAM_NICKNAME) || url.searchParams.get(URL_PARAM_NICKNAME_OLD);
+    const nickName = url.searchParams.get(URL_PARAM_NICKNAME);
     const observerCompetence = competenceFromUrlToDto(url.searchParams.get(URL_PARAM_COMPETENCE));
     const regTypesRaw = url.searchParams.get(URL_PARAM_REGISTRATION_TYPE);
     const regTypes = regTypesRaw != null ? convertRegTypeFromUrlToDto(regTypesRaw) : [];
@@ -419,7 +389,7 @@ export class SearchCriteriaService {
 
   private toUrlParams(criteria: SearchCriteriaRequestDto, daysBack: number | null): UrlParams {
     const params = new UrlParams();
-    params.set(URL_PARAM_GEOHAZARD, numberArrayToSeparatedString(criteria.SelectedGeoHazards));
+    params.set(URL_PARAM_GEOHAZARD, arrayToSeparatedString(criteria.SelectedGeoHazards));
     if (daysBack != null) {
       params.set(URL_PARAM_DAYSBACK, daysBack.toString()); // Convert to string so that 0 is accepted as a value
       params.delete(URL_PARAM_FROMDATE);
@@ -433,7 +403,7 @@ export class SearchCriteriaService {
     params.set(URL_PARAM_COMPETENCE, competenceFromDtoToUrl(criteria.ObserverCompetence));
     params.set(URL_PARAM_REGISTRATION_TYPE, convertRegTypeDtoToUrl(criteria.SelectedRegistrationTypes));
     params.set(URL_PARAM_ORDER_BY, convertApiOrderByToUrl(criteria.OrderBy as SearchCriteriaOrderBy));
-    params.set(URL_PARAM_REGION, numberArrayToSeparatedString(criteria.SelectedRegions));
+    params.set(URL_PARAM_REGION, arrayToSeparatedString(criteria.SelectedRegions));
 
     if (this.isSlushFlow(criteria)) {
       params.set(URL_PARAM_SLUSH_FLOW, true);

--- a/src/app/core/services/search-criteria/url-params.ts
+++ b/src/app/core/services/search-criteria/url-params.ts
@@ -1,3 +1,5 @@
+import { RegistrationTypeCriteriaDto } from 'src/app/modules/common-regobs-api';
+
 export const URL_PARAM_NW_LAT = 'nwLat';
 export const URL_PARAM_NW_LON = 'nwLon';
 export const URL_PARAM_SE_LAT = 'seLat';
@@ -15,17 +17,74 @@ export const URL_PARAM_REGION = 'regions';
 export const URL_PARAM_ARRAY_DELIMITER = '~'; //https://www.rfc-editor.org/rfc/rfc3986#section-2.3
 
 // gamle url-parametre som ble brukt av regobs.no fram til mai 2025, som vi fortsatt støtter
-export const URL_PARAM_NW_LAT_OLD = 'NWLat';
-export const URL_PARAM_NW_LON_OLD = 'NWLon';
-export const URL_PARAM_SE_LAT_OLD = 'SELat';
-export const URL_PARAM_SE_LON_OLD = 'SELon';
-export const URL_PARAM_GEOHAZARD_OLD = 'GeoHazards';
-export const URL_PARAM_DAYSBACK_OLD = 'SelectedNumberOfDays';
-export const URL_PARAM_FROMDATE_OLD = 'FromDate';
-export const URL_PARAM_TODATE_OLD = 'ToDate';
-export const URL_PARAM_NICKNAME_OLD = 'ObserverNickName';
+type OldParamMapper = (params: URLSearchParams, oldKey: string, newKey: string) => string | undefined;
+
+interface OldParamConfig {
+  oldKey: string;
+  newKey: string;
+  mapper?: OldParamMapper;
+}
+
+const OLD_PARAM_CONFIG: OldParamConfig[] = [
+  { oldKey: 'NWLat', newKey: URL_PARAM_NW_LAT },
+  { oldKey: 'NWLon', newKey: URL_PARAM_NW_LON },
+  { oldKey: 'SELat', newKey: URL_PARAM_SE_LAT },
+  { oldKey: 'SELon', newKey: URL_PARAM_SE_LON },
+  { oldKey: 'GeoHazards', newKey: URL_PARAM_GEOHAZARD },
+  { oldKey: 'SelectedNumberOfDays', newKey: URL_PARAM_DAYSBACK },
+  { oldKey: 'FromDate', newKey: URL_PARAM_FROMDATE },
+  { oldKey: 'ToDate', newKey: URL_PARAM_TODATE },
+  { oldKey: 'ObserverNickName', newKey: URL_PARAM_NICKNAME },
+  {
+    oldKey: 'SelectedRegistrationTypes',
+    newKey: URL_PARAM_REGISTRATION_TYPE,
+    mapper: (params, oldKey) => {
+      const values = params.getAll(oldKey);
+      const parsedValues = values
+        .map((v) => {
+          try {
+            return JSON.parse(v);
+          } catch (error) {
+            return undefined;
+          }
+        })
+        .filter((v) => v !== undefined);
+      return convertRegTypeDtoToUrl(parsedValues);
+    },
+  },
+  {
+    oldKey: 'SelectedRegions',
+    newKey: URL_PARAM_REGION,
+    mapper: (params, oldKey) => {
+      const values = params.getAll(oldKey);
+      const unique = values.filter((v, i, arr) => arr.indexOf(v) === i);
+      return arrayToSeparatedString(unique);
+    },
+  },
+];
 
 const VALID_GEO_HAZARDS = new Set([[60, 20], [70], [10]]);
+
+function defaultMapper(params: URLSearchParams, oldKey: string) {
+  return params.get(oldKey);
+}
+
+/**
+ * NB: Modifies passed in params
+ */
+export function mapOldParamsToNew(params: URLSearchParams): void {
+  for (const config of OLD_PARAM_CONFIG) {
+    const { oldKey, newKey } = config;
+    if (!params.has(oldKey)) continue;
+
+    const mapper = config.mapper || defaultMapper;
+    const value = mapper(params, oldKey, newKey);
+    if (value != undefined && value !== '') {
+      params.set(newKey, value);
+    }
+    params.delete(oldKey);
+  }
+}
 
 export function isGeoHazardValid(hazards: number[]): boolean {
   hazards.sort((a, b) => b - a);
@@ -91,4 +150,28 @@ export class UrlParams {
   entries() {
     return Object.fromEntries(this.params.entries());
   }
+}
+
+//[{Id: 80, SubTypes: [26,11]}] => 80.11~80.26
+export function convertRegTypeDtoToUrl(types?: RegistrationTypeCriteriaDto[]) {
+  if (types != null) {
+    const url = [] as string[];
+    types.forEach((type) => {
+      const parentId = type.Id;
+      if (type.SubTypes && type.SubTypes.length > 0) {
+        type.SubTypes.forEach((subtype) => url.push(`${parentId}.${subtype}`));
+      } else {
+        url.push(parentId.toString());
+      }
+    });
+    return url.join('~');
+  }
+  return;
+}
+
+export function arrayToSeparatedString<T extends number | string>(values: T[] | undefined): string | undefined {
+  if (values?.length) {
+    return values.join(URL_PARAM_ARRAY_DELIMITER);
+  }
+  return;
 }

--- a/src/app/core/services/search-criteria/url-params.ts
+++ b/src/app/core/services/search-criteria/url-params.ts
@@ -5,8 +5,11 @@ export const URL_PARAM_SE_LON = 'seLon';
 export const URL_PARAM_GEOHAZARD = 'hazard';
 export const URL_PARAM_GEOHAZARDS_OLD = 'GeoHazards';
 export const URL_PARAM_DAYSBACK = 'daysBack';
+export const URL_PARAM_DAYSBACK_OLD = 'SelectedNumberOfDays';
 export const URL_PARAM_FROMDATE = 'fromDate';
+export const URL_PARAM_FROMDATE_OLD = 'FromDate';
 export const URL_PARAM_TODATE = 'toDate';
+export const URL_PARAM_TODATE_OLD = 'ToDate';
 export const URL_PARAM_NICKNAME = 'nick';
 export const URL_PARAM_COMPETENCE = 'competence';
 export const URL_PARAM_REGISTRATION_TYPE = 'type';
@@ -47,8 +50,8 @@ export function separatedStringToNumberArray(separatedString: string): number[] 
 }
 
 /**
- * A helper class to change url query parameters.
- * Usage: new UrlParams.set('hazard', 10).set('nick', 'siggen').apply()
+ * Bruk denne til å sette eller fjerne url-parametre.
+ * Eksempel: new UrlParams.set('hazard', 10).set('nick', 'siggen')
  */
 export class UrlParams {
   private params = new URLSearchParams(document.location.search);
@@ -74,15 +77,6 @@ export class UrlParams {
 
   delete(key: string): UrlParams {
     this.params.delete(key);
-    return this;
-  }
-
-  /**
-   * @deprecated Metoden eksisterer fortsatt kun for å tilrettelegge for testing. Testene bør skrives om.
-   */
-  apply(): UrlParams {
-    const newRelativePathQuery = window.location.pathname + '?' + this.params.toString();
-    history.pushState(null, '', newRelativePathQuery);
     return this;
   }
 

--- a/src/app/core/services/search-criteria/url-params.ts
+++ b/src/app/core/services/search-criteria/url-params.ts
@@ -3,13 +3,9 @@ export const URL_PARAM_NW_LON = 'nwLon';
 export const URL_PARAM_SE_LAT = 'seLat';
 export const URL_PARAM_SE_LON = 'seLon';
 export const URL_PARAM_GEOHAZARD = 'hazard';
-export const URL_PARAM_GEOHAZARDS_OLD = 'GeoHazards';
 export const URL_PARAM_DAYSBACK = 'daysBack';
-export const URL_PARAM_DAYSBACK_OLD = 'SelectedNumberOfDays';
 export const URL_PARAM_FROMDATE = 'fromDate';
-export const URL_PARAM_FROMDATE_OLD = 'FromDate';
 export const URL_PARAM_TODATE = 'toDate';
-export const URL_PARAM_TODATE_OLD = 'ToDate';
 export const URL_PARAM_NICKNAME = 'nick';
 export const URL_PARAM_COMPETENCE = 'competence';
 export const URL_PARAM_REGISTRATION_TYPE = 'type';
@@ -17,6 +13,18 @@ export const URL_PARAM_SLUSH_FLOW = 'slushFlow';
 export const URL_PARAM_ORDER_BY = 'orderBy';
 export const URL_PARAM_REGION = 'regions';
 export const URL_PARAM_ARRAY_DELIMITER = '~'; //https://www.rfc-editor.org/rfc/rfc3986#section-2.3
+
+// gamle url-parametre som ble brukt av regobs.no fram til mai 2025, som vi fortsatt støtter
+export const URL_PARAM_NW_LAT_OLD = 'NWLat';
+export const URL_PARAM_NW_LON_OLD = 'NWLon';
+export const URL_PARAM_SE_LAT_OLD = 'SELat';
+export const URL_PARAM_SE_LON_OLD = 'SELon';
+export const URL_PARAM_GEOHAZARD_OLD = 'GeoHazards';
+export const URL_PARAM_DAYSBACK_OLD = 'SelectedNumberOfDays';
+export const URL_PARAM_FROMDATE_OLD = 'FromDate';
+export const URL_PARAM_TODATE_OLD = 'ToDate';
+export const URL_PARAM_NICKNAME_OLD = 'ObserverNickName';
+
 const VALID_GEO_HAZARDS = new Set([[60, 20], [70], [10]]);
 
 export function isGeoHazardValid(hazards: number[]): boolean {

--- a/src/app/core/services/search-criteria/url-params.ts
+++ b/src/app/core/services/search-criteria/url-params.ts
@@ -16,15 +16,15 @@ export const URL_PARAM_ORDER_BY = 'orderBy';
 export const URL_PARAM_REGION = 'regions';
 export const URL_PARAM_ARRAY_DELIMITER = '~'; //https://www.rfc-editor.org/rfc/rfc3986#section-2.3
 
-// gamle url-parametre som ble brukt av regobs.no fram til mai 2025, som vi fortsatt støtter
 type OldParamMapper = (params: URLSearchParams, oldKey: string, newKey: string) => string | undefined;
 
 interface OldParamConfig {
   oldKey: string;
-  newKey: string;
+  newKey?: string;
   mapper?: OldParamMapper;
 }
 
+// gamle url-parametre som ble brukt av regobs.no fram til mai 2025
 const OLD_PARAM_CONFIG: OldParamConfig[] = [
   { oldKey: 'NWLat', newKey: URL_PARAM_NW_LAT },
   { oldKey: 'NWLon', newKey: URL_PARAM_NW_LON },
@@ -61,6 +61,19 @@ const OLD_PARAM_CONFIG: OldParamConfig[] = [
       return arrayToSeparatedString(unique);
     },
   },
+
+  {
+    oldKey: 'ObserverCompetence',
+    newKey: URL_PARAM_COMPETENCE,
+    mapper: (params, oldKey) => {
+      const values = params.getAll(oldKey);
+      return arrayToSeparatedString(values);
+    },
+  },
+
+  // Entries without newKey will be deleted
+  { oldKey: 'Countries' },
+  { oldKey: 'SupportMaps' },
 ];
 
 const VALID_GEO_HAZARDS = new Set([[60, 20], [70], [10]]);
@@ -75,13 +88,19 @@ function defaultMapper(params: URLSearchParams, oldKey: string) {
 export function mapOldParamsToNew(params: URLSearchParams): void {
   for (const config of OLD_PARAM_CONFIG) {
     const { oldKey, newKey } = config;
-    if (!params.has(oldKey)) continue;
 
-    const mapper = config.mapper || defaultMapper;
-    const value = mapper(params, oldKey, newKey);
-    if (value != undefined && value !== '') {
-      params.set(newKey, value);
+    if (!params.has(oldKey)) {
+      continue;
     }
+
+    if (newKey !== undefined) {
+      const mapper = config.mapper || defaultMapper;
+      const value = mapper(params, oldKey, newKey);
+      if (value != undefined && value !== '') {
+        params.set(newKey, value);
+      }
+    }
+
     params.delete(oldKey);
   }
 }

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -39,7 +39,7 @@ import {
   URL_PARAM_DAYSBACK,
   URL_PARAM_DAYSBACK_OLD,
   URL_PARAM_GEOHAZARD,
-  URL_PARAM_GEOHAZARDS_OLD,
+  URL_PARAM_GEOHAZARD_OLD,
   isGeoHazardValid,
   separatedStringToNumberArray,
 } from '../search-criteria/url-params';
@@ -217,7 +217,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
     }
 
     // read param used in (old) regobs.no
-    const geoHazardsParamValueOld = searchParams.getAll(URL_PARAM_GEOHAZARDS_OLD);
+    const geoHazardsParamValueOld = searchParams.getAll(URL_PARAM_GEOHAZARD_OLD);
     if (geoHazardsParamValueOld?.length) {
       const geoHazards = geoHazardsParamValueOld.filter((x) => x.trim().length && !isNaN(parseInt(x))).map(Number);
       // new UrlParams().delete(URL_PARAM_GEOHAZARDS_OLD).apply(); //we will create url params in new format instead

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -37,9 +37,7 @@ import { SubTile, SupportTile } from '../../models/support-tile.model';
 import { isArraysEqual } from 'src/app/modules/common-core/helpers/arrays';
 import {
   URL_PARAM_DAYSBACK,
-  URL_PARAM_DAYSBACK_OLD,
   URL_PARAM_GEOHAZARD,
-  URL_PARAM_GEOHAZARD_OLD,
   isGeoHazardValid,
   separatedStringToNumberArray,
 } from '../search-criteria/url-params';
@@ -198,7 +196,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
   protected parseUrlParameters() {
     const url = new URL(document.location.href);
     const geoHazards = this.readGeoHazardsFromUrl(url.searchParams);
-    const daysBack = url.searchParams.get(URL_PARAM_DAYSBACK) || url.searchParams.get(URL_PARAM_DAYSBACK_OLD);
+    const daysBack = url.searchParams.get(URL_PARAM_DAYSBACK);
     const daysBackNumeric = daysBack ? convertToInt(daysBack) : null;
     return {
       geoHazards,
@@ -215,15 +213,6 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
         return geoHazards;
       }
     }
-
-    // read param used in (old) regobs.no
-    const geoHazardsParamValueOld = searchParams.getAll(URL_PARAM_GEOHAZARD_OLD);
-    if (geoHazardsParamValueOld?.length) {
-      const geoHazards = geoHazardsParamValueOld.filter((x) => x.trim().length && !isNaN(parseInt(x))).map(Number);
-      // new UrlParams().delete(URL_PARAM_GEOHAZARDS_OLD).apply(); //we will create url params in new format instead
-      return geoHazards;
-    }
-
     return null;
   }
 

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -37,6 +37,7 @@ import { SubTile, SupportTile } from '../../models/support-tile.model';
 import { isArraysEqual } from 'src/app/modules/common-core/helpers/arrays';
 import {
   URL_PARAM_DAYSBACK,
+  URL_PARAM_DAYSBACK_OLD,
   URL_PARAM_GEOHAZARD,
   URL_PARAM_GEOHAZARDS_OLD,
   isGeoHazardValid,
@@ -197,7 +198,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
   protected parseUrlParameters() {
     const url = new URL(document.location.href);
     const geoHazards = this.readGeoHazardsFromUrl(url.searchParams);
-    const daysBack = url.searchParams.get(URL_PARAM_DAYSBACK);
+    const daysBack = url.searchParams.get(URL_PARAM_DAYSBACK) || url.searchParams.get(URL_PARAM_DAYSBACK_OLD);
     const daysBackNumeric = daysBack ? convertToInt(daysBack) : null;
     return {
       geoHazards,

--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -24,9 +24,13 @@ import { IRegionInViewInput, IRegionInViewOutput } from '../../web-workers/regio
 import L from 'leaflet';
 import {
   URL_PARAM_NW_LAT,
+  URL_PARAM_NW_LAT_OLD,
   URL_PARAM_NW_LON,
+  URL_PARAM_NW_LON_OLD,
   URL_PARAM_SE_LAT,
+  URL_PARAM_SE_LAT_OLD,
   URL_PARAM_SE_LON,
+  URL_PARAM_SE_LON_OLD,
 } from 'src/app/core/services/search-criteria/url-params';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 
@@ -41,10 +45,10 @@ export const createMapView = (nwLat: number, nwLon: number, seLat: number, seLon
 };
 
 export const parseCoordinatesFromSearchParams = (params: URLSearchParams): IMapView | undefined => {
-  const nwLat = params.get(URL_PARAM_NW_LAT);
-  const nwLon = params.get(URL_PARAM_NW_LON);
-  const seLat = params.get(URL_PARAM_SE_LAT);
-  const seLon = params.get(URL_PARAM_SE_LON);
+  const nwLat = params.get(URL_PARAM_NW_LAT) || params.get(URL_PARAM_NW_LAT_OLD);
+  const nwLon = params.get(URL_PARAM_NW_LON) || params.get(URL_PARAM_NW_LON_OLD);
+  const seLat = params.get(URL_PARAM_SE_LAT) || params.get(URL_PARAM_SE_LAT_OLD);
+  const seLon = params.get(URL_PARAM_SE_LON) || params.get(URL_PARAM_SE_LON_OLD);
   if (nwLat && nwLon && seLat && seLon) {
     const formatedMapView = createMapView(+nwLat, +nwLon, +seLat, +seLon);
     return formatedMapView;

--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -24,13 +24,9 @@ import { IRegionInViewInput, IRegionInViewOutput } from '../../web-workers/regio
 import L from 'leaflet';
 import {
   URL_PARAM_NW_LAT,
-  URL_PARAM_NW_LAT_OLD,
   URL_PARAM_NW_LON,
-  URL_PARAM_NW_LON_OLD,
   URL_PARAM_SE_LAT,
-  URL_PARAM_SE_LAT_OLD,
   URL_PARAM_SE_LON,
-  URL_PARAM_SE_LON_OLD,
 } from 'src/app/core/services/search-criteria/url-params';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 
@@ -45,10 +41,10 @@ export const createMapView = (nwLat: number, nwLon: number, seLat: number, seLon
 };
 
 export const parseCoordinatesFromSearchParams = (params: URLSearchParams): IMapView | undefined => {
-  const nwLat = params.get(URL_PARAM_NW_LAT) || params.get(URL_PARAM_NW_LAT_OLD);
-  const nwLon = params.get(URL_PARAM_NW_LON) || params.get(URL_PARAM_NW_LON_OLD);
-  const seLat = params.get(URL_PARAM_SE_LAT) || params.get(URL_PARAM_SE_LAT_OLD);
-  const seLon = params.get(URL_PARAM_SE_LON) || params.get(URL_PARAM_SE_LON_OLD);
+  const nwLat = params.get(URL_PARAM_NW_LAT);
+  const nwLon = params.get(URL_PARAM_NW_LON);
+  const seLat = params.get(URL_PARAM_SE_LAT);
+  const seLon = params.get(URL_PARAM_SE_LON);
   if (nwLat && nwLon && seLat && seLon) {
     const formatedMapView = createMapView(+nwLat, +nwLon, +seLat, +seLon);
     return formatedMapView;

--- a/src/app/modules/map/services/map/parseCoordinates.spec.ts
+++ b/src/app/modules/map/services/map/parseCoordinates.spec.ts
@@ -1,12 +1,18 @@
 import { parseCoordinatesFromSearchParams } from './map.service';
 
 describe('Parse coordinates from url', () => {
-  it('should return correct MapView', () => {
-    const url = new URL('https://regobs.no?nwLat=70.79781234&nwLon=21.4343&seLat=67.5715&seLon=33.1458');
-    const mapView = parseCoordinatesFromSearchParams(url.searchParams);
-    expect(mapView?.bounds.getSouthWest().lat).toEqual(67.5715);
-    expect(mapView?.bounds.getSouthWest().lng).toEqual(21.4343);
-    expect(mapView?.bounds.getNorthEast().lat).toEqual(70.79781234);
-    expect(mapView?.bounds.getNorthEast().lng).toEqual(33.1458);
+  // Vi tester både dagens url-parametre og de gamle som er brukt i appen tidligere
+  [
+    'nwLat=70.79781234&nwLon=21.4343&seLat=67.5715&seLon=33.1458',
+    'NWLat=70.79781234&NWLon=21.4343&SELat=67.5715&SELon=33.1458',
+  ].forEach((params) => {
+    it(`should parse coordinates from ${params}`, () => {
+      const url = new URL('https://regobs.no?' + params);
+      const mapView = parseCoordinatesFromSearchParams(url.searchParams);
+      expect(mapView?.bounds.getSouthWest().lat).toEqual(67.5715);
+      expect(mapView?.bounds.getSouthWest().lng).toEqual(21.4343);
+      expect(mapView?.bounds.getNorthEast().lat).toEqual(70.79781234);
+      expect(mapView?.bounds.getNorthEast().lng).toEqual(33.1458);
+    });
   });
 });

--- a/src/app/modules/map/services/map/parseCoordinates.spec.ts
+++ b/src/app/modules/map/services/map/parseCoordinates.spec.ts
@@ -1,18 +1,14 @@
 import { parseCoordinatesFromSearchParams } from './map.service';
 
+const params = 'nwLat=70.79781234&nwLon=21.4343&seLat=67.5715&seLon=33.1458';
+
 describe('Parse coordinates from url', () => {
-  // Vi tester både dagens url-parametre og de gamle som er brukt i appen tidligere
-  [
-    'nwLat=70.79781234&nwLon=21.4343&seLat=67.5715&seLon=33.1458',
-    'NWLat=70.79781234&NWLon=21.4343&SELat=67.5715&SELon=33.1458',
-  ].forEach((params) => {
-    it(`should parse coordinates from ${params}`, () => {
-      const url = new URL('https://regobs.no?' + params);
-      const mapView = parseCoordinatesFromSearchParams(url.searchParams);
-      expect(mapView?.bounds.getSouthWest().lat).toEqual(67.5715);
-      expect(mapView?.bounds.getSouthWest().lng).toEqual(21.4343);
-      expect(mapView?.bounds.getNorthEast().lat).toEqual(70.79781234);
-      expect(mapView?.bounds.getNorthEast().lng).toEqual(33.1458);
-    });
+  it(`should parse coordinates from ${params}`, () => {
+    const url = new URL('https://regobs.no?' + params);
+    const mapView = parseCoordinatesFromSearchParams(url.searchParams);
+    expect(mapView?.bounds.getSouthWest().lat).toEqual(67.5715);
+    expect(mapView?.bounds.getSouthWest().lng).toEqual(21.4343);
+    expect(mapView?.bounds.getNorthEast().lat).toEqual(70.79781234);
+    expect(mapView?.bounds.getNorthEast().lng).toEqual(33.1458);
   });
 });

--- a/src/app/pages/tabs/tabs.routes.ts
+++ b/src/app/pages/tabs/tabs.routes.ts
@@ -50,10 +50,12 @@ export const routes: Routes = [
         loadComponent: () => import('../warning-list/warning-list.page').then((m) => m.WarningListPage),
         canActivate: [desktopBlockGuard],
       },
+      // Redirect from old regobs.no route
       {
         path: 'observation/search',
         redirectTo: 'search',
       },
+      // Support old route used in app
       {
         path: 'observation-list',
         redirectTo: 'search',

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,13 +28,27 @@ import { AuthService, Browser, DefaultBrowser } from 'ionic-appauth';
 import { CapacitorBrowser } from 'ionic-appauth/lib/capacitor';
 import { authFactory } from './app/modules/auth/factories/auth-factory';
 import { register } from 'swiper/element/bundle';
+import { mapOldParamsToNew } from './app/core/services/search-criteria/url-params';
 
 if (environment.production) {
   enableProdMode();
 }
 
+function replaceOldParamsWithNew() {
+  console.log('rewrite old regobs.no query paramters');
+  try {
+    const url = new URL(window.location.href);
+    mapOldParamsToNew(url.searchParams);
+    history.replaceState(null, '', url);
+  } catch (error) {
+    console.error('Got error when rewriting old params');
+    console.error(error);
+  }
+}
+
 function startApp() {
   register();
+  replaceOldParamsWithNew();
 
   console.log('starting app');
   bootstrapApplication(AppComponent, {


### PR DESCRIPTION
Se saken:
https://nveprojects.atlassian.net/browse/RO-1872

Vi støtter nå de fleste URL-parametere som regobs.no bruker
- NWLat, NWLon, SELat, SELon
- GeoHazards
- SelectedNumberOfDays
- FromDate og ToDate
- ObserverNickName
- SelectedRegion
- Countries (fjernes ved oppstart siden vi ikke støtter det på nye regobs)
- SelectedRegistrationTypes
- ObserverCompetence

Forenklet også test-oppsettet litt.

