### PR TITLE
RO-2777: Ikke vis ikon i skredfarevurdering hvis faregrad ikke er angitt

### DIFF
--- a/src/app/components/observation/registrations/avalanche-evaluation-view/avalanche-evaluation-view.component.ts
+++ b/src/app/components/observation/registrations/avalanche-evaluation-view/avalanche-evaluation-view.component.ts
@@ -32,7 +32,7 @@ export class AvalancheEvaluationViewComponent {
   dangerName = this.dangerLevelKdv.getName(this.dangerTid);
   dangerIcon = computed(() => {
     const dangerTid = this.dangerTid();
-    if (dangerTid != null) {
+    if (dangerTid) {
       return IconConfig[dangerTid];
     }
     return undefined;


### PR DESCRIPTION
Beta.regobs.no viser ikon for faregrad selv om faregrad ikke er valgt i skredfarevurdering, se f.eks.: http://beta.regobs.no/Registration/411149

Denne PR'en fikser dette, slik at vi ikke viser ikon i slike tilfeller. Se f.eks.:
https://victorious-water-056410803-730.westeurope.azurestaticapps.net/registration/411149

