### PR TITLE
RO-2781: Vise interaktiv snøprofil i karusell

### DIFF
--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -35,6 +35,7 @@
           <ion-icon name="download-outline"></ion-icon> {{ "REGISTRATION.CARD.DOWNLOAD" | translate }}
         </a>
 
+        <!-- Kun snøprofil har Href -->
         @if (currentAttachmentData().Href; as href) {
           <a [href]="href" target="_blank">
             <ion-icon name="open-outline"></ion-icon>

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -8,8 +8,18 @@
   (swiperslidechange)="setCurrentSlideIndex($event)"
 >
   @for (attachment of attachments(); track attachment.Url) {
-    <swiper-slide>
-      <img [alt]="attachment.Comment" [src]="attachment.Url" />
+    <swiper-slide lazy="true">
+      @if (isAttachmentSnowProfile(attachment)) {
+        <img
+          [alt]="attachment.Comment"
+          [src]="snowProfileUrl()"
+          (error)="useFallbackSnowProfileImage(attachment)"
+          class="snow-profile"
+          loading="lazy"
+        />
+      } @else {
+        <img [alt]="attachment.Comment" [src]="attachment.Url" />
+      }
     </swiper-slide>
   }
 </swiper-container>
@@ -21,17 +31,25 @@
         <span> {{ currentAttachmentData().RegistrationName }}</span>
       }
       <div class="image-description__links">
-        <a [href]="currentAttachmentData().Url" download class="download-button">
+        <a [href]="currentAttachmentData().Url" download>
           <ion-icon name="download-outline"></ion-icon> {{ "REGISTRATION.CARD.DOWNLOAD" | translate }}
         </a>
-        <a [href]="currentAttachmentData().Url" target="_blank" class="download-button">
-          <ion-icon name="open-outline"></ion-icon> {{ "REGISTRATION.CARD.GO_TO_ORIGINAL_IMAGE" | translate }}
-        </a>
+
+        @if (currentAttachmentData().Href; as href) {
+          <a [href]="href" target="_blank">
+            <ion-icon name="open-outline"></ion-icon>
+            {{ "REGISTRATION.CARD.GO_TO_SNOW_PROFILE" | translate }}
+          </a>
+        } @else {
+          <a [href]="currentAttachmentData().Url" target="_blank">
+            <ion-icon name="open-outline"></ion-icon> {{ "REGISTRATION.CARD.GO_TO_ORIGINAL_IMAGE" | translate }}
+          </a>
+        }
       </div>
     </div>
 
     <!-- kommentar -->
-    @if (currentAttachmentData().Comment) {
+    @if (comment()) {
       <app-key-value [key]="'REGISTRATION.DANGER_OBS.COMMENT' | translate" [value]="currentAttachmentData().Comment">
       </app-key-value>
     }

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -50,8 +50,7 @@
 
     <!-- kommentar -->
     @if (comment()) {
-      <app-key-value [key]="'REGISTRATION.DANGER_OBS.COMMENT' | translate" [value]="currentAttachmentData().Comment">
-      </app-key-value>
+      <app-key-value [key]="'REGISTRATION.DANGER_OBS.COMMENT' | translate" [value]="comment()"></app-key-value>
     }
     <!-- region -->
     @if (registration()?.ObsLocation?.ForecastRegionName) {

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -36,8 +36,8 @@
         </a>
 
         <!-- Kun snøprofil har Href -->
-        @if (currentAttachmentData().Href; as href) {
-          <a [href]="href" target="_blank">
+        @if (currentAttachmentData().Href; as snowProfileImageUrl) {
+          <a [href]="snowProfileImageUrl" target="_blank">
             <ion-icon name="open-outline"></ion-icon>
             {{ "REGISTRATION.CARD.GO_TO_SNOW_PROFILE" | translate }}
           </a>

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
@@ -120,3 +120,9 @@ ion-fab-button::part(native):hover {
     font-size: 1.25rem;
   }
 }
+
+.snow-profile {
+  width: 100%;
+  height: 100%;
+  background-color: white;
+}

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -42,6 +42,7 @@ export class ObservationImageCarouselComponent {
   registration = input<RegistrationViewModel>();
   attachmentIndex = model<number>(0);
 
+  // Bruker linkedSignal her for å gjøre det mulig å overstyre hva urlen er dersom kall til plot-api feiler
   snowProfileUrl = linkedSignal(() => {
     const reg = this.registration();
     if (!reg) return undefined;

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -22,8 +22,7 @@ import { settings } from 'src/settings';
 import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrientationValue';
 import { BreakpointService } from 'src/app/core/services/breakpoint.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
+import { PlotService } from 'src/app/core/services/plot.service';
 
 @Component({
   selector: 'app-observation-image-carousel',
@@ -38,24 +37,15 @@ export class ObservationImageCarouselComponent {
   attachments = input<(AttachmentViewModel & { Href?: string })[]>([]);
   settings = inject(UserSettingService);
   isDesktop = inject(BreakpointService).isDesktop;
+  plotService = inject(PlotService);
 
   registration = input<RegistrationViewModel>();
   attachmentIndex = model<number>(0);
 
-  private plotApi = toSignal(this.settings.appMode$.pipe(map((x) => settings.services.regObs.plotUrl[x])), {
-    initialValue: settings.services.regObs.plotUrl.PROD,
-  });
-
-  private preferredProfileType = computed(() => {
-    if (this.isDesktop()) {
-      return 'SimpleProfile';
-    }
-
-    return 'MobileProfile';
-  });
-
   snowProfileUrl = linkedSignal(() => {
-    return `${this.plotApi()}/SnowProfile/svg/${this.registration()?.RegId}/${this.preferredProfileType()}?lastMod=${this.registration()?.DtChangeTime}`;
+    const reg = this.registration();
+    if (!reg) return undefined;
+    return this.plotService.getSnowProfileSvgUrl(reg);
   });
 
   useFallbackSnowProfileImage(attachment: AttachmentViewModel) {

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -20,7 +20,6 @@ import { DatePipe } from '@angular/common';
 import { KeyValueComponent } from '../key-value/key-value.component';
 import { settings } from 'src/settings';
 import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrientationValue';
-import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { PlotService } from 'src/app/core/services/plot.service';
 
 @Component({
@@ -34,7 +33,6 @@ export class ObservationImageCarouselComponent {
   readonly swiper = viewChild<ElementRef<SwiperContainer>>('swiper');
   private modalController = inject(ModalController);
   attachments = input<(AttachmentViewModel & { Href?: string })[]>([]);
-  settings = inject(UserSettingService);
   plotService = inject(PlotService);
 
   registration = input<RegistrationViewModel>();

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -20,7 +20,6 @@ import { DatePipe } from '@angular/common';
 import { KeyValueComponent } from '../key-value/key-value.component';
 import { settings } from 'src/settings';
 import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrientationValue';
-import { BreakpointService } from 'src/app/core/services/breakpoint.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { PlotService } from 'src/app/core/services/plot.service';
 
@@ -36,7 +35,6 @@ export class ObservationImageCarouselComponent {
   private modalController = inject(ModalController);
   attachments = input<(AttachmentViewModel & { Href?: string })[]>([]);
   settings = inject(UserSettingService);
-  isDesktop = inject(BreakpointService).isDesktop;
   plotService = inject(PlotService);
 
   registration = input<RegistrationViewModel>();

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -6,6 +6,7 @@ import {
   ElementRef,
   inject,
   input,
+  linkedSignal,
   model,
   viewChild,
 } from '@angular/core';
@@ -19,6 +20,10 @@ import { DatePipe } from '@angular/common';
 import { KeyValueComponent } from '../key-value/key-value.component';
 import { settings } from 'src/settings';
 import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrientationValue';
+import { BreakpointService } from 'src/app/core/services/breakpoint.service';
+import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
 
 @Component({
   selector: 'app-observation-image-carousel',
@@ -30,11 +35,31 @@ import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrie
 export class ObservationImageCarouselComponent {
   readonly swiper = viewChild<ElementRef<SwiperContainer>>('swiper');
   private modalController = inject(ModalController);
-  attachments = input<AttachmentViewModel[]>([]);
+  attachments = input<(AttachmentViewModel & { Href?: string })[]>([]);
+  settings = inject(UserSettingService);
+  isDesktop = inject(BreakpointService).isDesktop;
+
   registration = input<RegistrationViewModel>();
   attachmentIndex = model<number>(0);
-  constructor() {
-    addIcons({ close, downloadOutline, openOutline });
+
+  private plotApi = toSignal(this.settings.appMode$.pipe(map((x) => settings.services.regObs.plotUrl[x])), {
+    initialValue: settings.services.regObs.plotUrl.PROD,
+  });
+
+  private preferredProfileType = computed(() => {
+    if (this.isDesktop()) {
+      return 'SimpleProfile';
+    }
+
+    return 'MobileProfile';
+  });
+
+  snowProfileUrl = linkedSignal(() => {
+    return `${this.plotApi()}/SnowProfile/svg/${this.registration()?.RegId}/${this.preferredProfileType()}?lastMod=${this.registration()?.DtChangeTime}`;
+  });
+
+  useFallbackSnowProfileImage(attachment: AttachmentViewModel) {
+    this.snowProfileUrl.set(attachment.Url as string);
   }
 
   roundedDownOrientationValue = computed(() => {
@@ -46,6 +71,21 @@ export class ObservationImageCarouselComponent {
   });
 
   currentAttachmentData = computed(() => this.attachments()?.[this.attachmentIndex()]);
+  comment = computed(() => {
+    if (this.currentAttachmentData().Comment) {
+      return this.currentAttachmentData().Comment;
+    }
+
+    if (this.isAttachmentSnowProfile(this.currentAttachmentData())) {
+      return this.registration()?.SnowProfile2?.Comment;
+    }
+
+    return undefined;
+  });
+
+  constructor() {
+    addIcons({ close, downloadOutline, openOutline });
+  }
 
   closeModal() {
     this.modalController.dismiss();
@@ -59,5 +99,9 @@ export class ObservationImageCarouselComponent {
 
   ngAfterViewInit() {
     this.swiper()?.nativeElement.swiper.slideTo(this.attachmentIndex());
+  }
+
+  isAttachmentSnowProfile(attachment: AttachmentViewModel & { Href?: string }) {
+    return !!attachment.Href;
   }
 }

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -59,10 +59,12 @@ export class ObservationImageCarouselComponent {
 
   currentAttachmentData = computed(() => this.attachments()?.[this.attachmentIndex()]);
   comment = computed(() => {
+    // Prioriter kommentar fra bilde dersom det er lagt til
     if (this.currentAttachmentData().Comment) {
       return this.currentAttachmentData().Comment;
     }
 
+    // Vis kommentar fra snøprofil-skjema dersom det finnes
     if (this.isAttachmentSnowProfile(this.currentAttachmentData())) {
       return this.registration()?.SnowProfile2?.Comment;
     }

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -92,6 +92,7 @@ export class ObservationImageCarouselComponent {
   }
 
   isAttachmentSnowProfile(attachment: AttachmentViewModel & { Href?: string }) {
+    // Kun snøprofil har Href
     return !!attachment.Href;
   }
 }

--- a/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.ts
+++ b/src/app/components/observation/registrations/ice-thickness-view/ice-thickness-view.component.ts
@@ -1,11 +1,8 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { IceThicknessViewModel } from 'src/app/modules/common-regobs-api';
 import { SummaryComponent } from '../../summary/summary.component';
-import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { AppMode } from 'src/app/modules/common-core/models/app-mode.enum';
-import { settings } from 'src/settings';
 import { IcePlotComponent } from '../../graphics/ice-plot.component';
+import { PlotService } from 'src/app/core/services/plot.service';
 
 @Component({
   selector: 'app-ice-thickness-view',
@@ -16,13 +13,11 @@ import { IcePlotComponent } from '../../graphics/ice-plot.component';
 })
 /** Brukes i observasjonskort for å vise istykkelse */
 export class IceThicknessViewComponent {
+  private plotService = inject(PlotService);
+
   readonly regId = input.required<number>();
   readonly data = input.required<IceThicknessViewModel>();
   readonly summaries = input.required<any>();
 
-  private userSettingsService = inject(UserSettingService);
-
-  private appMode = toSignal(this.userSettingsService.appMode$, { initialValue: AppMode.Prod });
-  private plotBaseUrl = settings.iceThicknessPlotUrl[this.appMode()];
-  readonly plotUrl = computed(() => `${this.plotBaseUrl}${this.regId().toString()}`);
+  readonly plotUrl = computed(() => this.plotService.getIceThicknessUrl(this.regId()));
 }

--- a/src/app/core/services/plot.service.ts
+++ b/src/app/core/services/plot.service.ts
@@ -1,0 +1,37 @@
+import { computed, inject, Injectable } from '@angular/core';
+import { UserSettingService } from './user-setting/user-setting.service';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+import { settings } from 'src/settings';
+import { BreakpointService } from './breakpoint.service';
+import { RegistrationViewModel } from 'src/app/modules/common-regobs-api';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PlotService {
+  private settings = inject(UserSettingService);
+  private isDesktop = inject(BreakpointService).isDesktop;
+
+  private plotApi = toSignal(this.settings.appMode$.pipe(map((x) => settings.services.regObs.plotUrl[x])), {
+    initialValue: settings.services.regObs.plotUrl.PROD,
+  });
+
+  private preferredSnowProfileType = computed(() => {
+    if (this.isDesktop()) {
+      return 'SimpleProfile';
+    }
+    return 'MobileProfile';
+  });
+
+  getIceThicknessUrl(regid: string | number) {
+    return `${this.plotApi()}/IceThickness/${regid}`;
+  }
+
+  getSnowProfileSvgUrl(registration: RegistrationViewModel) {
+    const { RegId, DtChangeTime } = registration;
+    // Nettleseren cacher i utgangspunktet svg-ene. For å fremprovosere den til å hente nytt plott ved endring av obs
+    // legger vi på lastMod= med endret dato. Da caches fortsatt plotet inntil obsen er endra.
+    return `${this.plotApi()}/SnowProfile/svg/${RegId}/${this.preferredSnowProfileType()}?lastMod=${DtChangeTime}`;
+  }
+}

--- a/src/app/core/services/plot.service.ts
+++ b/src/app/core/services/plot.service.ts
@@ -6,6 +6,9 @@ import { settings } from 'src/settings';
 import { BreakpointService } from './breakpoint.service';
 import { RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 
+/**
+ * Beregner url-er til bruk av plot.regobs.no
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/src/app/modules/common-registration/helpers/registration.helper.ts
+++ b/src/app/modules/common-registration/helpers/registration.helper.ts
@@ -87,7 +87,7 @@ export function getSnowProfileAttachments(
 export function getAllAttachmentsFromViewModel(
   viewModel: RegistrationViewModel,
   registrationTid?: RegistrationTid
-): AttachmentViewModel[] {
+): (AttachmentViewModel & { Href?: string })[] {
   const snowProfile = getSnowProfileAttachments(viewModel, registrationTid);
   const attachments = getAllAttachmentsFromEditModel(
     viewModel as RegistrationEditModelWithRemoteOrLocalAttachments,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -379,7 +379,8 @@
       },
       "OBSERVED_BY": "Sent in by",
       "DOWNLOAD": "Download",
-      "GO_TO_ORIGINAL_IMAGE": "See original"
+      "GO_TO_ORIGINAL_IMAGE": "See original",
+      "GO_TO_SNOW_PROFILE": "Go to profile"
     },
     "CONFIRM_RESET": "Are you sure you want to reset all fields?",
     "COPIED_TO_CLIPBOARD": "Copied to clipboard",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -385,7 +385,8 @@
       },
       "OBSERVED_BY": "Sendt inn av",
       "DOWNLOAD": "Last ned",
-      "GO_TO_ORIGINAL_IMAGE": "Se original"
+      "GO_TO_ORIGINAL_IMAGE": "Se original",
+      "GO_TO_SNOW_PROFILE": "Gå til profil"
     },
     "CONFIRM_RESET": "Er du sikker på du vil nullstille alle felt?",
     "COPIED_TO_CLIPBOARD": "Kopiert til utklippstavlen",

--- a/src/settings.model.ts
+++ b/src/settings.model.ts
@@ -126,10 +126,4 @@ export interface ISettings {
     en: string;
   };
   feedbackWebUrl: string;
-
-  /**
-   * URL til tjenesten som plotter istykkelse. Legg til reg-ID på slutten av URL.
-   * Eksempel: https://test-plot.regobs.no/v1/IceThickness/265830/
-   */
-  iceThicknessPlotUrl: any;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,6 +70,11 @@ export const settings: ISettings = {
   },
   services: {
     regObs: {
+      plotUrl: {
+        PROD: 'https://plot.regobs.no/v1',
+        DEMO: 'https://demo-plot.regobs.no/v1',
+        TEST: 'https://test-plot.regobs.no/v1',
+      },
       apiUrl: {
         PROD: 'https://api.regobs.no/v5',
         DEMO: 'https://demo-api.regobs.no/v5',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,11 +70,6 @@ export const settings: ISettings = {
   },
   services: {
     regObs: {
-      plotUrl: {
-        PROD: 'https://plot.regobs.no/v1',
-        DEMO: 'https://demo-plot.regobs.no/v1',
-        TEST: 'https://test-plot.regobs.no/v1',
-      },
       apiUrl: {
         PROD: 'https://api.regobs.no/v5',
         DEMO: 'https://demo-api.regobs.no/v5',
@@ -90,6 +85,11 @@ export const settings: ISettings = {
         PROD: 'https://www.regobs.no',
         DEMO: 'https://demo.regobs.no',
         TEST: 'https://test.regobs.no',
+      },
+      plotUrl: {
+        PROD: 'https://plot.regobs.no/v1',
+        DEMO: 'https://demo-plot.regobs.no/v1',
+        TEST: 'https://test-plot.regobs.no/v1',
       },
       createUserUrl: '/Account/Register?c=Home',
       passwordRecoveryUrl: '/Account/PasswordRecovery?c=Home',
@@ -470,9 +470,4 @@ export const settings: ISettings = {
   },
   feedbackWebUrl:
     'https://forms.office.com/Pages/ResponsePage.aspx?id=DYSNvMlgC0G0-xG4aAZ4DNWEVVcEorZHtmeqQxJTsoVUQ001UkpYUlU0SEwySEpQRkdZMVJDUU1VOCQlQCN0PWcu',
-  iceThicknessPlotUrl: {
-    TEST: 'https://test-plot.regobs.no/v1/IceThickness/',
-    DEMO: 'https://demo-plot.regobs.no/v1/IceThickness/',
-    PROD: 'https://plot.regobs.no/v1/IceThickness/',
-  },
 };


### PR DESCRIPTION
Har prøvd å ikke gjøre dette for avansert i første omgang. Viser nå SVG-plot i karusell. På store skjermer SimpleProfile, og på mindre skjermer MobileProfile (samme som apiet genererer og lagrer som bilde).
Hvis henting av svg fra plot-api feiler, vil bilde fra attachments bli brukt.

- [ ] ~Legg til innstilling for om bruker foretrekker interaktivt plott eller ikke~
- [ ] ~For snøprofil-bilder i karusell, vis toggle for interaktiv profil eller ikke under bildet~
- [x] ~Vis en liten forklarende tekst om at interaktivt plott tar litt tid å tegne opp.~ Viser en spinner
- [ ] ~Bruk alltid statisk bilde eller svg på mobil (litt usikker, kanskje interaktivt er OK også på mobil)~
- [x] Bruk egnet plot til aktiv skjermstørrelse
- [ ] ~(La bruker velge plot-type selv under innstillinger)~

~Det er ikke så lett å vise en spinner mens interaktivt plott tegnes opp, siden alt av opptegning styres inne i iframen. Vi kan nok vise en spinner mens siden laster ved hjelp av `load`-event, men jeg tror ikke det er lastingen som tar mest tid.~
Ved å vise SVG i stedet for interaktivt plot går det fint å vise en spinner. Har latt swiper.js håndtere spinneren selv via lazy-funksjonaliteten der.

