### PR TITLE
RO-2780: vise fullskjerm modal på bildeklikk i bildevisning

### DIFF
--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -6,7 +6,7 @@ import {
   ElementRef,
   inject,
   input,
-  signal,
+  model,
   viewChild,
 } from '@angular/core';
 import { IonFabButton, IonIcon, ModalController } from '@ionic/angular/standalone';
@@ -33,7 +33,7 @@ export class ObservationImageCarouselComponent {
   clickedAttachmentUrl = input<string>(); //bruker url istedenfor index fordi det er lettere å finne et bilde via url når man vil åpne denne modalen i bildevisning
   attachments = input<AttachmentViewModel[]>([]);
   registration = input<RegistrationViewModel>();
-  currentSlideIndex = signal(0);
+  attachmentIndex = model<number>(0);
   constructor() {
     addIcons({ close, downloadOutline, openOutline });
   }
@@ -45,7 +45,8 @@ export class ObservationImageCarouselComponent {
     if (!roundedDownOrientation) return '';
     return settings.orientation[roundedDownOrientation];
   });
-  currentAttachmentData = computed(() => this.attachments()?.[this.currentSlideIndex()]);
+
+  currentAttachmentData = computed(() => this.attachments()?.[this.attachmentIndex()]);
 
   closeModal() {
     this.modalController.dismiss();
@@ -54,12 +55,10 @@ export class ObservationImageCarouselComponent {
   setCurrentSlideIndex(e: Event) {
     const customEvent = e as CustomEvent;
     const activeIndex = customEvent.detail[0].activeIndex;
-    this.currentSlideIndex.set(activeIndex);
+    this.attachmentIndex.set(activeIndex);
   }
 
   ngAfterViewInit() {
-    const activeAttachmentIndex = this.attachments()?.findIndex((x) => x.Url === this.clickedAttachmentUrl());
-    if (!activeAttachmentIndex) return;
-    this.swiper()?.nativeElement.swiper.slideTo(activeAttachmentIndex);
+    this.swiper()?.nativeElement.swiper.slideTo(this.attachmentIndex());
   }
 }

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -30,7 +30,6 @@ import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrie
 export class ObservationImageCarouselComponent {
   readonly swiper = viewChild<ElementRef<SwiperContainer>>('swiper');
   private modalController = inject(ModalController);
-  clickedAttachmentUrl = input<string>(); //bruker url istedenfor index fordi det er lettere å finne et bilde via url når man vil åpne denne modalen i bildevisning
   attachments = input<AttachmentViewModel[]>([]);
   registration = input<RegistrationViewModel>();
   attachmentIndex = model<number>(0);

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -6,7 +6,7 @@ import {
   ElementRef,
   inject,
   input,
-  model,
+  signal,
   viewChild,
 } from '@angular/core';
 import { IonFabButton, IonIcon, ModalController } from '@ionic/angular/standalone';
@@ -30,9 +30,10 @@ import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrie
 export class ObservationImageCarouselComponent {
   readonly swiper = viewChild<ElementRef<SwiperContainer>>('swiper');
   private modalController = inject(ModalController);
-  attachmentIndex = model<number>(0);
+  clickedAttachmentUrl = input<string>(); //bruker url istedenfor index fordi det er lettere å finne et bilde via url når man vil åpne denne modalen i bildevisning
   attachments = input<AttachmentViewModel[]>([]);
   registration = input<RegistrationViewModel>();
+  currentSlideIndex = signal(0);
   constructor() {
     addIcons({ close, downloadOutline, openOutline });
   }
@@ -44,7 +45,7 @@ export class ObservationImageCarouselComponent {
     if (!roundedDownOrientation) return '';
     return settings.orientation[roundedDownOrientation];
   });
-  currentAttachmentData = computed(() => this.attachments()?.[this.attachmentIndex()]);
+  currentAttachmentData = computed(() => this.attachments()?.[this.currentSlideIndex()]);
 
   closeModal() {
     this.modalController.dismiss();
@@ -53,10 +54,12 @@ export class ObservationImageCarouselComponent {
   setCurrentSlideIndex(e: Event) {
     const customEvent = e as CustomEvent;
     const activeIndex = customEvent.detail[0].activeIndex;
-    this.attachmentIndex.set(activeIndex);
+    this.currentSlideIndex.set(activeIndex);
   }
 
   ngAfterViewInit() {
-    this.swiper()?.nativeElement.swiper.slideTo(this.attachmentIndex());
+    const activeAttachmentIndex = this.attachments()?.findIndex((x) => x.Url === this.clickedAttachmentUrl());
+    if (!activeAttachmentIndex) return;
+    this.swiper()?.nativeElement.swiper.slideTo(activeAttachmentIndex);
   }
 }

--- a/src/app/components/observation/observation/observation.component.html
+++ b/src/app/components/observation/observation/observation.component.html
@@ -18,12 +18,7 @@
 
   <!-- lazy-preload-prev-next="2" -->
   @for (attachment of attachments(); track attachment.AttachmentId; let index = $index) {
-    <swiper-slide (click)="openImageCarousel(index)" lazy="true">
-      <!-- <div class="img-desc">
-          @if (attachment.Comment) {
-            <ion-icon name="chatbubble-ellipses" color="primary"></ion-icon>
-          }
-        </div> -->
+    <swiper-slide (click)="openImageCarousel(attachment.Url)" lazy="true">
       <img [alt]="attachment.Comment" [src]="attachment.UrlFormats?.Large" loading="lazy" decoding="async" />
     </swiper-slide>
   }

--- a/src/app/components/observation/observation/observation.component.html
+++ b/src/app/components/observation/observation/observation.component.html
@@ -18,7 +18,7 @@
 
   <!-- lazy-preload-prev-next="2" -->
   @for (attachment of attachments(); track attachment.AttachmentId; let index = $index) {
-    <swiper-slide (click)="openImageCarousel(attachment.Url)" lazy="true">
+    <swiper-slide (click)="openImageCarousel(index)" lazy="true">
       <img [alt]="attachment.Comment" [src]="attachment.UrlFormats?.Large" loading="lazy" decoding="async" />
     </swiper-slide>
   }

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -270,12 +270,14 @@ export class ObservationComponent {
     return promise;
   }
 
-  async openImageCarousel(index: number) {
+  async openImageCarousel(attachmentUrl: string | undefined) {
+    if (!attachmentUrl) return;
+
     const modal = await this.modalController.create({
       component: ObservationImageCarouselComponent,
       cssClass: 'fullscreen-modal',
       componentProps: {
-        attachmentIndex: index,
+        clickedAttachmentUrl: attachmentUrl,
         attachments: this.attachments(),
         registration: this.registration(),
       },

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -270,14 +270,12 @@ export class ObservationComponent {
     return promise;
   }
 
-  async openImageCarousel(attachmentUrl: string | undefined) {
-    if (!attachmentUrl) return;
-
+  async openImageCarousel(index: number) {
     const modal = await this.modalController.create({
       component: ObservationImageCarouselComponent,
       cssClass: 'fullscreen-modal',
       componentProps: {
-        clickedAttachmentUrl: attachmentUrl,
+        attachmentIndex: index,
         attachments: this.attachments(),
         registration: this.registration(),
       },

--- a/src/app/pages/observation-list/image-list/image-list.component.html
+++ b/src/app/pages/observation-list/image-list/image-list.component.html
@@ -5,7 +5,7 @@
   </ion-refresher>
 
   <div class="list-header">
-    <p>Viser alle bilder fra alle filtrerte observasjoner.</p>
+    <p>{{ "OBSERVATION_LIST.IMAGES_DESCRIPTION" | translate }}</p>
     <app-show-filter-criteria></app-show-filter-criteria>
     <app-list-controls pageType="images"></app-list-controls>
   </div>
@@ -13,7 +13,10 @@
   <div class="grid">
     @for (reg of registrations(); track reg.RegId) {
       @for (attachment of reg.Attachments; track attachment.AttachmentId) {
-        <app-grid-image [attachment]="attachment"></app-grid-image>
+        <app-grid-image
+          [attachment]="attachment"
+          (click)="openImageCarousel(attachment.Url, reg.RegId, reg.Attachments)"
+        ></app-grid-image>
       }
     } @empty {
       @if (error().hasError) {

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -95,26 +95,25 @@ export class ImageListComponent {
 
   async openImageCarousel(attachmentUrl: string | undefined, regId: number, attachments: AttachmentViewModel[]) {
     if (!attachmentUrl) return;
-    this.translateService.get('DATA_LOAD.DATA').subscribe(async (message) => {
-      const loader = await this.loadingController.create({
-        message,
-        backdropDismiss: true, // enable cancel
-      });
-      await loader.present();
-
-      const attachmentIndex = attachments.findIndex((attachment) => attachment.Url === attachmentUrl);
-      const registration = await firstValueFrom(this.searchService.SearchSearch({ RegId: regId }));
-      const modal = await this.modalController.create({
-        component: ObservationImageCarouselComponent,
-        cssClass: 'fullscreen-modal',
-        componentProps: {
-          attachmentIndex: attachmentIndex,
-          attachments: attachments,
-          registration: registration[0],
-        },
-      });
-      await modal.present();
-      this.loadingController.dismiss();
+    const message = this.translateService.instant('DATA_LOAD.DATA');
+    const loader = await this.loadingController.create({
+      message,
+      backdropDismiss: true,
     });
+    await loader.present();
+
+    const attachmentIndex = attachments.findIndex((attachment) => attachment.Url === attachmentUrl);
+    const registration = await firstValueFrom(this.searchService.SearchSearch({ RegId: regId }));
+    const modal = await this.modalController.create({
+      component: ObservationImageCarouselComponent,
+      cssClass: 'fullscreen-modal',
+      componentProps: {
+        attachmentIndex: attachmentIndex,
+        attachments: attachments,
+        registration: registration[0],
+      },
+    });
+    await modal.present();
+    this.loadingController.dismiss();
   }
 }

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -21,7 +21,7 @@ import { GridImageComponent } from './grid-image.component';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { UpdateObservationsService } from 'src/app/modules/side-menu/components/update-observations/update-observations.service';
 import { ObservationImageCarouselComponent } from 'src/app/components/observation/observation-image-carousel/observation-image-carousel.component';
-import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
+import { AttachmentViewModel, SearchService } from 'src/app/modules/common-regobs-api';
 
 /**
  * Bildesøk
@@ -47,6 +47,7 @@ import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
 })
 export class ImageListComponent {
   private searchCriteriaService = inject(SearchCriteriaService);
+  private searchService = inject(SearchService);
   private modalController = inject(ModalController);
   private searchRegistrations = inject(SearchRegistrationService);
   private infiniteScroll = viewChild(IonInfiniteScroll);
@@ -100,18 +101,14 @@ export class ImageListComponent {
         backdropDismiss: true, // enable cancel
       });
       await loader.present();
-      const searchCriteria$ = this.searchCriteriaService.searchCriteria$.pipe(
-        map((criteria) => ({
-          ...criteria,
-          regId,
-        }))
-      );
-      const registration = await firstValueFrom(this.searchRegistrations.search(searchCriteria$).registrations$);
+
+      const attachmentIndex = attachments.findIndex((attachment) => attachment.Url === attachmentUrl);
+      const registration = await firstValueFrom(this.searchService.SearchSearch({ RegId: regId }));
       const modal = await this.modalController.create({
         component: ObservationImageCarouselComponent,
         cssClass: 'fullscreen-modal',
         componentProps: {
-          clickedAttachmentUrl: attachmentUrl,
+          attachmentIndex: attachmentIndex,
           attachments: attachments,
           registration: registration[0],
         },

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -6,8 +6,10 @@ import {
   IonInfiniteScrollContent,
   IonRefresher,
   IonRefresherContent,
+  LoadingController,
+  ModalController,
 } from '@ionic/angular/standalone';
-import { tap, combineLatest, map } from 'rxjs';
+import { tap, combineLatest, map, firstValueFrom } from 'rxjs';
 import { SearchCriteriaService } from 'src/app/core/services/search-criteria/search-criteria.service';
 import { SearchRegistrationService } from 'src/app/core/services/search-registration/search-registration.service';
 import { SearchRegistrationsWithAttachments } from 'src/app/modules/common-regobs-api/models/search-registrations-with-attachments';
@@ -16,8 +18,10 @@ import { EmptyStateComponent } from '../empty-state/empty-state.component';
 import { ShowFilterCriteriaComponent } from '../../../modules/side-menu/components/show-filter-criteria/show-filter-criteria.component';
 import { ListControlsComponent } from '../list-controls/list-controls.component';
 import { GridImageComponent } from './grid-image.component';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { UpdateObservationsService } from 'src/app/modules/side-menu/components/update-observations/update-observations.service';
+import { ObservationImageCarouselComponent } from 'src/app/components/observation/observation-image-carousel/observation-image-carousel.component';
+import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
 
 /**
  * Bildesøk
@@ -43,10 +47,13 @@ import { UpdateObservationsService } from 'src/app/modules/side-menu/components/
 })
 export class ImageListComponent {
   private searchCriteriaService = inject(SearchCriteriaService);
+  private modalController = inject(ModalController);
   private searchRegistrations = inject(SearchRegistrationService);
   private infiniteScroll = viewChild(IonInfiniteScroll);
   private ionRefresher = viewChild(IonRefresher);
   private updateObservationsService = inject(UpdateObservationsService);
+  private translateService = inject(TranslateService);
+  private loadingController = inject(LoadingController);
 
   private searchHandler = this.searchRegistrations.searchAttachments(this.searchCriteriaService.searchCriteria$);
   registrations = toSignal(
@@ -83,5 +90,34 @@ export class ImageListComponent {
 
   refresh() {
     this.searchHandler.update();
+  }
+
+  async openImageCarousel(attachmentUrl: string | undefined, regId: number, attachments: AttachmentViewModel[]) {
+    if (!attachmentUrl) return;
+    this.translateService.get('DATA_LOAD.DATA').subscribe(async (message) => {
+      const loader = await this.loadingController.create({
+        message,
+        backdropDismiss: true, // enable cancel
+      });
+      await loader.present();
+      const searchCriteria$ = this.searchCriteriaService.searchCriteria$.pipe(
+        map((criteria) => ({
+          ...criteria,
+          regId,
+        }))
+      );
+      const registration = await firstValueFrom(this.searchRegistrations.search(searchCriteria$).registrations$);
+      const modal = await this.modalController.create({
+        component: ObservationImageCarouselComponent,
+        cssClass: 'fullscreen-modal',
+        componentProps: {
+          clickedAttachmentUrl: attachmentUrl,
+          attachments: attachments,
+          registration: registration[0],
+        },
+      });
+      await modal.present();
+      this.loadingController.dismiss();
+    });
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -286,6 +286,7 @@
     "EMPTY_STATE_WHEN_OBSERVATIONS_DISABLED": "Toggle observations on in the left side menu.",
     "FILTER_BY_MAP_VIEW": "Filter by map view",
     "FORMS": "Forms",
+    "IMAGES_DESCRIPTION": "Shows all images from all filtered observations.",
     "LOADING": "Loading observations",
     "MAX_COUNT_REACHED_HEADER": "No more observations",
     "MAX_COUNT_REACHED_TEXT": "We show max {{ maxCount }} observations here. If you didn't find what you looked for you may try to zoom in or narrow the period you want to see observations from.",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -292,6 +292,7 @@
     "EMPTY_STATE_WHEN_OBSERVATIONS_DISABLED": "Du kan aktivere visning av observasjoner igjen fra filtermenyen på venstre side.",
     "FILTER_BY_MAP_VIEW": "Filtrer på kartutsnitt",
     "FORMS": "Skjemaer",
+    "IMAGES_DESCRIPTION": "Viser alle bilder fra alle filtrerte observasjoner.",
     "LOADING": "Laster observasjoner",
     "MAX_COUNT_REACHED_HEADER": "Ingen flere observasjoner",
     "MAX_COUNT_REACHED_TEXT": "Vi viser maks {{ maxCount }} observasjoner her. Hvis du ikke fant det du lette etter, prøv å zoome inn på kartet eller snevre inn perioden du vil se observasjoner fra.",


### PR DESCRIPTION
Man kan klikke på et bilde i bildevisning for å vise bildet i fullskjerm. Den kommer med andre bilder fra samme observasjon. 

Et annet alternativ for loader er å åpne bilde med en gang i modalen men kun vise spinner/loader på metada, men det vil kreve mer arbeid, og jeg syns det her er bra nok. 
Lurte på om vi kanskje trenger 'vis observasjon' knapp i fullskjerm modalen hvis man åpner den via bildevisning, men kanskje ikke så viktig?