### PR TITLE
RO-2782: revert endringer i map.service og warning.service

### DIFF
--- a/src/app/core/services/warning/warning.service.ts
+++ b/src/app/core/services/warning/warning.service.ts
@@ -6,7 +6,7 @@ import 'moment-timezone';
 import { LangKey, GeoHazard } from 'src/app/modules/common-core/models';
 import { HttpClient } from '@angular/common/http';
 import { NanoSql } from '../../../../nanosql';
-import { map, tap, switchMap, shareReplay, distinctUntilChanged, filter } from 'rxjs/operators';
+import { map, tap, switchMap, shareReplay, distinctUntilChanged } from 'rxjs/operators';
 import { IWarning } from './warning.interface';
 import { WarningGroup } from './warning-group.model';
 import { IWarningApiResult } from './warning-api-result.interface';
@@ -28,11 +28,9 @@ import { nSQL } from '@nano-sql/core';
 import { LogLevel } from '../../../modules/shared/services/logging/log-level.model';
 import { UserSetting } from '../../models/user-settings.model';
 import { NSqlFullUpdateObservable } from '../../helpers/nano-sql/NSqlFullUpdateObservable';
-import { IMapView } from 'src/app/modules/map/services/map/map-view.interface';
-import { fromWorker } from 'observable-webworker';
-import { IRegionInViewInput, IRegionInViewOutput } from 'src/app/modules/map/web-workers/region-in-view-models';
 
 const DEBUG_TAG = 'WarningService';
+
 @Injectable({
   providedIn: 'root',
 })
@@ -49,7 +47,6 @@ export class WarningService {
   private _warningsForCurrentGeoHazardObservable: Observable<WarningGroup[]>;
   private _warningGroupInMapViewObservable: Observable<IWarningGroupInMapView>;
   private latestWarnings: BehaviorSubject<{ [key: string]: IWarningGroup[] }>;
-  private mapViewAndAreaObservable$: Observable<IMapViewAndArea>;
 
   get warningsObservable$() {
     return this._warningsObservable;
@@ -68,7 +65,6 @@ export class WarningService {
     this._warningsObservable = this.getWarningsForCurrentLanguageAsObservable();
     this._warningsForCurrentGeoHazardObservable = this.getWarningsForCurrentLanguageAndCurrentGeoHazard();
     this._warningGroupInMapViewObservable = this.getWarningsForCurrentMapViewAsObservable();
-    this.mapViewAndAreaObservable$ = this.getMapViewAreaObservable();
   }
 
   private getDataLoadId(geoHazard: GeoHazard, language: LangKey) {
@@ -343,7 +339,7 @@ export class WarningService {
   }
 
   private getWarningsForCurrentMapViewAsObservable() {
-    return combineLatest([this.mapViewAndAreaObservable$, this.getWarningsAsObservable()]).pipe(
+    return combineLatest([this.mapService.mapViewAndAreaObservable$, this.getWarningsAsObservable()]).pipe(
       switchMap(([mapViewArea]) => this.getWarningsForCurrentMapView(mapViewArea)),
       map((result) => result),
       tap(() => {
@@ -689,44 +685,5 @@ export class WarningService {
       ? moment(toDate)
       : moment().endOf('day').add(settings.services.warning.defaultWarningDaysAhead, 'days');
     return { from: fromMoment, to: toMoment };
-  }
-
-  private getMapViewAreaObservable(): Observable<IMapViewAndArea> {
-    const currenteMapViewAndGeoHazards = combineLatest([
-      this.mapService.mapView$,
-      this.userSettingService.currentGeoHazard$,
-    ]).pipe(
-      filter((value): value is [IMapView, GeoHazard[]] => value[0] != null),
-      map(([mapView, geoHazards]) => ({
-        mapView,
-        bounds: [
-          mapView.bounds.getSouthWest().lng, // minx
-          mapView.bounds.getSouthWest().lat, // miny
-          mapView.bounds.getNorthEast().lng, // maxx
-          mapView.bounds.getNorthEast().lat, // maxy
-        ],
-        center: { lat: mapView.center.lat, lng: mapView.center.lng },
-        geoHazards,
-      }))
-    );
-
-    return currenteMapViewAndGeoHazards.pipe(
-      switchMap((cvg) =>
-        fromWorker<IRegionInViewInput, IRegionInViewOutput>(
-          () =>
-            new Worker(new URL('../../../modules/map/web-workers/region-in-view.worker', import.meta.url), {
-              type: 'module',
-            }),
-          currenteMapViewAndGeoHazards
-        ).pipe(
-          map((result) => ({
-            ...cvg.mapView,
-            ...result,
-          }))
-        )
-      ),
-      tap((val) => this.loggingService.debug('MapViewArea changed', DEBUG_TAG, val)),
-      shareReplay(1)
-    );
   }
 }

--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { IMapView } from './map-view.interface';
-import { Observable, BehaviorSubject, Subject, of, concat } from 'rxjs';
+import { Observable, combineLatest, BehaviorSubject, Subject, of, concat } from 'rxjs';
 import {
   switchMap,
   shareReplay,
@@ -16,8 +16,11 @@ import {
   debounceTime,
   pairwise,
 } from 'rxjs/operators';
+import { IMapViewAndArea } from './map-view-and-area.interface';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
 import { LoggingService } from '../../../shared/services/logging/logging.service';
+import { fromWorker } from 'observable-webworker';
+import { IRegionInViewInput, IRegionInViewOutput } from '../../web-workers/region-in-view-models';
 import L from 'leaflet';
 import {
   URL_PARAM_NW_LAT,
@@ -25,6 +28,7 @@ import {
   URL_PARAM_SE_LAT,
   URL_PARAM_SE_LON,
 } from 'src/app/core/services/search-criteria/url-params';
+import { GeoHazard } from 'src/app/modules/common-core/models';
 
 type WithMargin = (ob: L.LatLngBoundsExpression, maxMargin: number) => boolean;
 
@@ -64,6 +68,7 @@ export class MapService {
   private userSettingService = inject(UserSettingService);
   private loggingService = inject(LoggingService);
 
+  private _mapViewAndAreaObservable: Observable<IMapViewAndArea>;
   private _followModeSubject: BehaviorSubject<boolean>;
   private _followModeObservable: Observable<boolean>;
   private _showUserLocationSubject: BehaviorSubject<boolean>;
@@ -89,6 +94,13 @@ export class MapService {
    */
   get noMapExtentAvailable$(): Observable<boolean> {
     return this._noMapExtentAvailable$;
+  }
+
+  /**
+   * Extent, center, zoom and area info for the map in HomePage
+   */
+  get mapViewAndAreaObservable$(): Observable<IMapViewAndArea> {
+    return this._mapViewAndAreaObservable;
   }
 
   /**
@@ -166,6 +178,7 @@ export class MapService {
       distinctUntilChanged()
     );
     this._relevantMapChange$ = this.getMapViewThatHasRelevantChange();
+    this._mapViewAndAreaObservable = this.getMapViewAreaObservable();
   }
 
   centerMapToUser(): void {
@@ -219,6 +232,42 @@ export class MapService {
           : mapViewWithValue.pipe(take(1))
       ),
       tap((val) => this.loggingService.debug('MapView has relevant change!', DEBUG_TAG, val)),
+      shareReplay(1)
+    );
+  }
+
+  private getMapViewAreaObservable(): Observable<IMapViewAndArea> {
+    const currenteMapViewAndGeoHazards = combineLatest([this.mapView$, this.userSettingService.currentGeoHazard$]).pipe(
+      filter((value): value is [IMapView, GeoHazard[]] => value[0] != null),
+      map(([mapView, geoHazards]) => ({
+        mapView,
+        bounds: [
+          mapView.bounds.getSouthWest().lng, // minx
+          mapView.bounds.getSouthWest().lat, // miny
+          mapView.bounds.getNorthEast().lng, // maxx
+          mapView.bounds.getNorthEast().lat, // maxy
+        ],
+        center: { lat: mapView.center.lat, lng: mapView.center.lng },
+        geoHazards,
+      }))
+    );
+
+    return currenteMapViewAndGeoHazards.pipe(
+      switchMap((cvg) =>
+        fromWorker<IRegionInViewInput, IRegionInViewOutput>(
+          () =>
+            new Worker(new URL('../../web-workers/region-in-view.worker', import.meta.url), {
+              type: 'module',
+            }),
+          currenteMapViewAndGeoHazards
+        ).pipe(
+          map((result) => ({
+            ...cvg.mapView,
+            ...result,
+          }))
+        )
+      ),
+      tap((val) => this.loggingService.debug('MapViewArea changed', DEBUG_TAG, val)),
       shareReplay(1)
     );
   }


### PR DESCRIPTION
Tar bort endringene som ble innført i [denne PR-en](https://github.com/NVE/regObs4/pull/721) noe som tydeligvis førte til at appen kræsjet på android. 