### PR TITLE
RO-2776: Fikset slik at oppdater-knappen funker igjen i liste- og bildevisning

### DIFF
--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, viewChild } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import {
   IonContent,
   IonInfiniteScroll,
@@ -17,6 +17,7 @@ import { ShowFilterCriteriaComponent } from '../../../modules/side-menu/componen
 import { ListControlsComponent } from '../list-controls/list-controls.component';
 import { GridImageComponent } from './grid-image.component';
 import { TranslatePipe } from '@ngx-translate/core';
+import { UpdateObservationsService } from 'src/app/modules/side-menu/components/update-observations/update-observations.service';
 
 /**
  * Bildesøk
@@ -45,6 +46,7 @@ export class ImageListComponent {
   private searchRegistrations = inject(SearchRegistrationService);
   private infiniteScroll = viewChild(IonInfiniteScroll);
   private ionRefresher = viewChild(IonRefresher);
+  private updateObservationsService = inject(UpdateObservationsService);
 
   private searchHandler = this.searchRegistrations.searchAttachments(this.searchCriteriaService.searchCriteria$);
   registrations = toSignal(
@@ -52,6 +54,7 @@ export class ImageListComponent {
       tap(() => {
         this.infiniteScroll()?.complete();
         this.ionRefresher()?.complete();
+        this.updateObservationsService.setLastFetched(new Date());
       })
     ),
     { initialValue: [] as SearchRegistrationsWithAttachments[] }
@@ -67,6 +70,12 @@ export class ImageListComponent {
   isLoading = toSignal(this.searchHandler.isFetching$, { initialValue: false });
   maxItemsFetched = toSignal(this.searchHandler.maxItemsFetched$, { initialValue: false });
   error = toSignal(this.searchHandler.error$, { initialValue: { hasError: false } });
+
+  constructor() {
+    this.updateObservationsService.refreshRequested$?.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.refresh(); // oppfrisk sida når bruker trykker på oppfrisk-knappen i menyen
+    });
+  }
 
   loadNextPage() {
     this.searchHandler.increasePage();

--- a/src/app/pages/observation-list/observation-list/observation-list.component.ts
+++ b/src/app/pages/observation-list/observation-list/observation-list.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, viewChild } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import {
   IonContent,
   IonInfiniteScroll,
@@ -18,6 +18,7 @@ import { ListControlsComponent } from '../list-controls/list-controls.component'
 import { ShowFilterCriteriaComponent } from 'src/app/modules/side-menu/components/show-filter-criteria/show-filter-criteria.component';
 import { TranslatePipe } from '@ngx-translate/core';
 import { BreakpointService } from 'src/app/core/services/breakpoint.service';
+import { UpdateObservationsService } from 'src/app/modules/side-menu/components/update-observations/update-observations.service';
 
 @Component({
   selector: 'app-observation-list',
@@ -43,6 +44,7 @@ export class ObservationListComponent {
   private searchRegistrations = inject(SearchRegistrationService);
   private infiniteScroll = viewChild(IonInfiniteScroll);
   private ionRefresher = viewChild(IonRefresher);
+  private updateObservationsService = inject(UpdateObservationsService);
   isDesktop = inject(BreakpointService).isDesktop;
 
   private searchHandler = this.searchRegistrations.pagedSearch(this.searchCriteriaService.searchCriteria$);
@@ -51,6 +53,7 @@ export class ObservationListComponent {
       tap(() => {
         this.infiniteScroll()?.complete();
         this.ionRefresher()?.complete();
+        this.updateObservationsService.setLastFetched(new Date());
       })
     ),
     { initialValue: [] as RegistrationViewModel[] }
@@ -67,6 +70,12 @@ export class ObservationListComponent {
   isLoading = toSignal(this.searchHandler.isFetching$, { initialValue: false });
   maxItemsFetched = toSignal(this.searchHandler.maxItemsFetched$, { initialValue: false });
   error = toSignal(this.searchHandler.error$, { initialValue: { hasError: false } });
+
+  constructor() {
+    this.updateObservationsService.refreshRequested$?.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.refresh(); // oppfrisk sida når bruker trykker på oppfrisk-knappen i menyen
+    });
+  }
 
   loadNextPage() {
     this.searchHandler.increasePage();


### PR DESCRIPTION
Sjekk at oppdater-knappen funker både i liste- og bildevisning.
Jeg forsøkte også å fjerne sist-oppdatert-tidspunkt hvis søket feilet, men fant ingen god løsning for dette. På en måte gir det mening at "sist oppdatert" blir oppdatert også når søket feiler.
Takk til jorgkv for bistand!