### PR TITLE
RO-2738-UX: fikset aktiv status på tabbene på desktop

### DIFF
--- a/src/app/pages/tabs/tabs.page.scss
+++ b/src/app/pages/tabs/tabs.page.scss
@@ -14,19 +14,20 @@ a {
     transition: color 0.3s ease-in-out;
   }
 
-  ion-tab-button:hover {
-    background: rgb(200, 234, 249); //--interactive-ghost-background-hover fra designsystem
+  ion-tab-button:not(.tab-button--active):hover {
+    background: rgba(200, 234, 249, 0.9); // --interactive-ghost-background-hover fra designsystem
   }
 
-  ion-tab-button:hover ion-label,
-  ion-tab-button:hover ion-icon {
+  ion-tab-button:not(.tab-button--active):hover ion-label,
+  ion-tab-button:not(.tab-button--active):hover ion-icon {
     color: black;
   }
 
   .tab-button--active {
     ion-label,
     ion-icon {
-      color: white;
+      color: black;
     }
+    background: rgb(200, 234, 249);
   }
 }


### PR DESCRIPTION
PR-en løser kommentarer [under saken](https://nveprojects.atlassian.net/browse/RO-2738) - nemlig aktiv status på tabbene må vises tydeligere. Nå skal bakgrunnsfarge bli på hele tiden når tabben er aktiv. 