### PR TITLE
RO-2787: Fiks feil med filtermeny-knapp

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -68,6 +68,7 @@ export const routes: Routes = [
   {
     path: 'obskorps',
     loadComponent: () => import('./pages/obskorps/obskorps.page').then((m) => m.ObskorpsPage),
+    title: 'Obskorps',
   },
   {
     path: 'auth/callback',

--- a/src/app/modules/shared/components/header/header.component.html
+++ b/src/app/modules/shared/components/header/header.component.html
@@ -1,32 +1,23 @@
 <ion-header *ngIf="showHeader()">
-  <!-- TODO: fix header color -->
-  <!-- class="app-header-color" [class]="headerColor()" -->
   <ion-toolbar appHeaderColor>
-    <ion-buttons slot="start" *ngIf="!showMenuButton()">
-      <ion-back-button text="" [defaultHref]="defaultHref()"></ion-back-button>
-    </ion-buttons>
-
-    <ion-buttons slot="end" *ngIf="showMenuButton()">
-      <ion-menu-button color="light"> </ion-menu-button>
-    </ion-buttons>
-    <ion-buttons slot="start" *ngIf="showMenuButton() && showFilterButton()">
-      <ion-menu-button menu="filter" color="light">
-        <ion-icon name="options-outline"></ion-icon>
-      </ion-menu-button>
-    </ion-buttons>
-
-    <ng-content>
-      @if (tripRunning()) {
-        <ion-title>
-          <ion-button class="stop-trip" size="small" color="success" (click)="endTrip()">
-            {{ "TRIP.STOP_TRIP" | translate }}
-          </ion-button>
-        </ion-title>
-      } @else if (title()) {
-        <ion-title>
-          {{ title()! | translate }}
-        </ion-title>
-      }
+    <ng-content select="ion-buttons">
+      <ion-buttons slot="start">
+        <ion-back-button text="" defaultHref="/"></ion-back-button>
+      </ion-buttons>
     </ng-content>
+
+    @if (tripRunning()) {
+      <ion-title>
+        <ion-button class="stop-trip" size="small" color="success" (click)="endTrip()">
+          {{ "TRIP.STOP_TRIP" | translate }}
+        </ion-button>
+      </ion-title>
+    } @else {
+      <ng-content select="ion-title">
+        <ion-title>
+          {{ defaultTitle }}
+        </ion-title>
+      </ng-content>
+    }
   </ion-toolbar>
 </ion-header>

--- a/src/app/modules/shared/components/header/header.component.ts
+++ b/src/app/modules/shared/components/header/header.component.ts
@@ -1,14 +1,5 @@
-import {
-  IonToolbar,
-  IonBackButton,
-  IonMenuButton,
-  IonIcon,
-  IonTitle,
-  IonHeader,
-  IonButton,
-  IonButtons,
-} from '@ionic/angular/standalone';
-import { Component, inject, input, computed } from '@angular/core';
+import { IonToolbar, IonBackButton, IonTitle, IonHeader, IonButton, IonButtons } from '@ionic/angular/standalone';
+import { Component, inject, computed } from '@angular/core';
 import { FullscreenService } from '../../../../core/services/fullscreen/fullscreen.service';
 import { TripLoggerService } from '../../../../core/services/trip-logger/trip-logger.service';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
@@ -19,23 +10,22 @@ import { addIcons } from 'ionicons';
 import { optionsOutline } from 'ionicons/icons';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { HeaderColorDirective } from '../../directives/header-color/header-color.directive';
+import { Capacitor } from '@capacitor/core';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
   imports: [
+    HeaderColorDirective,
     IonBackButton,
     IonButton,
     IonButtons,
     IonHeader,
-    IonIcon,
-    IonMenuButton,
     IonTitle,
     IonToolbar,
     NgIf,
     TranslatePipe,
-    HeaderColorDirective,
   ],
 })
 export class HeaderComponent {
@@ -43,16 +33,12 @@ export class HeaderComponent {
   private tripLoggerService = inject(TripLoggerService);
   private userSettingService = inject(UserSettingService);
 
-  readonly showMenuButton = input(true);
-  readonly showFilterButton = input(true);
-  readonly fullscreenSupport = input(false);
-  readonly title = input<string>();
-  readonly defaultHref = input('/');
+  readonly defaultTitle = Capacitor.isNativePlatform() ? 'Varsom' : 'Varsom Regobs';
 
   tripRunning = toSignal(this.tripLoggerService.isTripRunning$, { initialValue: false });
   private appMode = toSignal(this.userSettingService.appMode$, { initialValue: AppMode.Prod });
   private isFullscreen = toSignal(this.fullscreenService.isFullscreen$, { initialValue: false });
-  showHeader = computed(() => (this.fullscreenSupport() ? !this.isFullscreen() : true));
+  showHeader = computed(() => !this.isFullscreen());
 
   get tripRunning$() {
     return this.tripLoggerService.getLegacyTripAsObservable();

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -6,7 +6,19 @@
   </ion-menu>
 
   <div id="main-content-home-page" class="ion-page">
-    <app-header title="{{ appname }}" [fullscreenSupport]="true"></app-header>
+    <app-header>
+      <!-- Høyremeny -->
+      <ion-buttons slot="end">
+        <ion-menu-button color="light"> </ion-menu-button>
+      </ion-buttons>
+
+      <!-- Venstremeny / filtermeny -->
+      <ion-buttons slot="start">
+        <ion-menu-button menu="filter" color="light">
+          <ion-icon name="options-outline"></ion-icon>
+        </ion-menu-button>
+      </ion-buttons>
+    </app-header>
     <ion-content>
       <app-map
         (mapReady)="onMapReady($event)"

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -2,7 +2,16 @@ import { DOCUMENT, NgIf, AsyncPipe } from '@angular/common';
 import { AfterViewChecked, Component, NgZone, OnDestroy, OnInit, inject, viewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Capacitor } from '@capacitor/core';
-import { AlertController, IonContent, ToastController, IonSplitPane, IonMenu } from '@ionic/angular/standalone';
+import {
+  AlertController,
+  IonButtons,
+  IonContent,
+  IonIcon,
+  IonMenu,
+  IonMenuButton,
+  IonSplitPane,
+  ToastController,
+} from '@ionic/angular/standalone';
 import { TranslateService } from '@ngx-translate/core';
 import { Feature, Point } from 'geojson';
 import L from 'leaflet';
@@ -83,8 +92,11 @@ function positionDtoToLatLng(position: PositionDto): L.LatLng {
     FilterMenuComponent,
     GeoFabComponent,
     HeaderComponent,
+    IonButtons,
     IonContent,
+    IonIcon,
     IonMenu,
+    IonMenuButton,
     IonSplitPane,
     MapCenterInfoComponent_1,
     MapComponent,
@@ -278,13 +290,6 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
 
   private isErrorToastVisible(): boolean {
     return this.errorToast != null;
-  }
-
-  get appname(): string {
-    if (Capacitor.isNativePlatform()) {
-      return 'Varsom';
-    }
-    return 'Varsom Regobs';
   }
 
   ngAfterViewChecked(): void {

--- a/src/app/pages/observation-list/list.page.ts
+++ b/src/app/pages/observation-list/list.page.ts
@@ -3,7 +3,7 @@ import { HeaderComponent } from '../../modules/shared/components/header/header.c
 import { AddMenuComponent } from '../../modules/shared/components/add-menu/add-menu.component';
 import { RouterOutlet } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
-import { IonMenu, IonSplitPane, IonTitle } from '@ionic/angular/standalone';
+import { IonButtons, IonIcon, IonMenu, IonMenuButton, IonSplitPane, IonTitle } from '@ionic/angular/standalone';
 import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter-menu/filter-menu.component';
 
 /**
@@ -14,7 +14,7 @@ import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter
   selector: 'app-list-page',
   template: `
     <ion-split-pane contentId="main-content-list-page">
-      <ion-menu side="start" menuId="filter" contentId="main-content-list-page">
+      <ion-menu side="start" menuId="list-filter" contentId="main-content-list-page">
         @defer {
           <app-filter-menu></app-filter-menu>
         }
@@ -22,6 +22,18 @@ import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter
 
       <div id="main-content-list-page" class="ion-page">
         <app-header>
+          <!-- Høyremeny -->
+          <ion-buttons slot="end">
+            <ion-menu-button color="light"> </ion-menu-button>
+          </ion-buttons>
+
+          <!-- Venstremeny / filtermeny -->
+          <ion-buttons slot="start">
+            <ion-menu-button menu="list-filter" color="light">
+              <ion-icon name="options-outline"></ion-icon>
+            </ion-menu-button>
+          </ion-buttons>
+
           <ion-title>{{ 'OBSERVATION_LIST.TITLE' | translate }}</ion-title>
         </app-header>
         <router-outlet></router-outlet>
@@ -34,7 +46,10 @@ import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter
     AddMenuComponent,
     FilterMenuComponent,
     HeaderComponent,
+    IonButtons,
+    IonIcon,
     IonMenu,
+    IonMenuButton,
     IonSplitPane,
     IonTitle,
     RouterOutlet,

--- a/src/app/pages/obskorps/obskorps.page.html
+++ b/src/app/pages/obskorps/obskorps.page.html
@@ -1,4 +1,15 @@
-<app-header title="Obskorps" [showFilterButton]="false"></app-header>
+<app-header>
+  <ion-buttons slot="start">
+    <ion-button color="light" routerLink="/" routerDirection="back">Gå til forside</ion-button>
+  </ion-buttons>
+
+  <!-- Høyremeny -->
+  <ion-buttons slot="end">
+    <ion-menu-button color="light"></ion-menu-button>
+  </ion-buttons>
+
+  <ion-title>Obskorps</ion-title>
+</app-header>
 
 <ion-content [fullscreen]="true" color="light">
   <div class="form">

--- a/src/app/pages/obskorps/obskorps.page.spec.ts
+++ b/src/app/pages/obskorps/obskorps.page.spec.ts
@@ -12,6 +12,7 @@ import { LoggingService } from 'src/app/modules/shared/services/logging/logging.
 import { provideTranslateService } from '@ngx-translate/core';
 import { AppMode } from 'src/app/modules/common-core/models';
 import { TestLoggingService } from 'src/app/modules/shared/services/logging/test-logging.service';
+import { provideRouter } from '@angular/router';
 
 @Component({
   selector: 'app-header',
@@ -44,6 +45,7 @@ describe('ObskorpsPage', () => {
         provideHttpClientTesting(),
         { provide: LoggingService, useClass: TestLoggingService },
         provideTranslateService(),
+        provideRouter([]),
       ],
       schemas: [NO_ERRORS_SCHEMA],
     });

--- a/src/app/pages/obskorps/obskorps.page.ts
+++ b/src/app/pages/obskorps/obskorps.page.ts
@@ -18,9 +18,14 @@ import {
   IonList,
   IonNote,
   IonSpinner,
+  IonTitle,
+  IonButtons,
+  IonMenuButton,
+  IonRouterLink,
 } from '@ionic/angular/standalone';
 import { HeaderComponent } from '../../modules/shared/components/header/header.component';
 import { NgIf, AsyncPipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
 
 const toDateInputValue = (date: Date) => {
   const isoString = date.toISOString();
@@ -36,14 +41,19 @@ const toDateInputValue = (date: Date) => {
     AsyncPipe,
     HeaderComponent,
     IonButton,
+    IonButtons,
     IonContent,
     IonInput,
     IonItem,
     IonLabel,
     IonList,
+    IonMenuButton,
     IonNote,
+    IonRouterLink,
     IonSpinner,
+    IonTitle,
     NgIf,
+    RouterLink,
   ],
 })
 export class ObskorpsPage implements OnInit {

--- a/src/app/pages/warning-list/warning-list.page.html
+++ b/src/app/pages/warning-list/warning-list.page.html
@@ -1,4 +1,8 @@
-<app-header [title]="title()"></app-header>
+<app-header>
+  <ion-title>
+    {{ title() }}
+  </ion-title>
+</app-header>
 <ion-segment slot="fixed" [value]="selectedTab()" (ionChange)="onSegmentChange($event)">
   <ion-segment-button value="inMapView" [disabled]="noMapExtentAvailable()">
     <ion-label>{{ "WARNING_LIST.RELEVANT" | translate }}</ion-label>

--- a/src/app/pages/warning-list/warning-list.page.ts
+++ b/src/app/pages/warning-list/warning-list.page.ts
@@ -17,6 +17,7 @@ import {
   IonSegment,
   IonSegmentButton,
   SegmentCustomEvent,
+  IonTitle,
 } from '@ionic/angular/standalone';
 import { HeaderComponent } from '../../modules/shared/components/header/header.component';
 import { RefreshWithCancelComponent } from '../../modules/shared/components/refresh-with-cancel/refresh-with-cancel.component';
@@ -43,18 +44,19 @@ type SelectedTab = 'inMapView' | 'all' | 'favourites';
     IonCol,
     IonContent,
     IonGrid,
+    IonItemDivider,
     IonLabel,
+    IonList,
     IonRow,
     IonSegment,
     IonSegmentButton,
+    IonTitle,
     NgTemplateOutlet,
     RefreshWithCancelComponent,
     SvgIconComponent,
     TranslatePipe,
-    IonList,
-    WarningListItemComponent,
     WarningListHeaderComponent,
-    IonItemDivider,
+    WarningListItemComponent,
   ],
 })
 export class WarningListPage {


### PR DESCRIPTION
Feilen var at det ikke gikk an å åpne menyen i listevisninga. Det stemte bare delvis, for det spørs hvilken side man startet appen på. Starten man appen på forsiden / kartsiden funket ikke knappen i listevisninga, men også motsatt.

Det er en del endringer her, men feilen skyldtes bare at vi hadde to ulike menyer i applikasjonen, en på kartsiden og en i listevisninga, og samme id på begge to. Her er gammel meny-knapp som lå i header-komponent:

https://github.com/NVE/regObs4/blob/f3d4898489b597362e279b62eb466053dbf8d414/src/app/modules/shared/components/header/header.component.html#L13-L15

Og menyen i listevisninga som har samme id som den på kartsiden (filter)

https://github.com/NVE/regObs4/blob/f3d4898489b597362e279b62eb466053dbf8d414/src/app/pages/observation-list/list.page.ts#L17-L21

Menyknappen i listevisninga gjorde akkurat det den skulle den, den åpnet og lukket menyen på den siden som først ble rendret av applikasjonen. Hvis man startet applikasjonen på kartsiden, åpnet knappen på listevisninga menyen på kartsiden.

Ved å bruke forskjellige id-er løste problemet seg. Menyen på listevisninga har nå egen id (list-filter).

For å fikse dette fiksa jeg en del på header.component. Det kan nå diskuteres hvor nyttig den egentlig er, men nå er den faktisk fleksibel nok til at man kunne brukt den på alle sider som viser header, så jeg syns det fortsatt er nyttig. Alle skjemasider kunne nå bytte til header.component og spart en del importer og litt kode.

Jeg har i denne commiten bare fiksa de stedene header.component ble brukt fra før.



