### PR TITLE
RO-2792: fikse url param merging

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -299,7 +299,7 @@ export class SearchCriteriaService {
         LangKey: langKey,
         SelectedGeoHazards: geoHazards,
         // Remove extent if one or more regions are selected
-        Extent: useMapExtent && (criteria.SelectedRegions || []).length === 0 ? extent : undefined,
+        Extent: useMapExtent ? extent : undefined,
       })),
       map((criteria) => removeNullOrUndefined(criteria)),
       tap((currentCriteria) => this.logger.debug('Current combined criteria', DEBUG_TAG, currentCriteria)),
@@ -452,7 +452,6 @@ export class SearchCriteriaService {
     await this.router.navigate([], {
       relativeTo: this.activatedRoute,
       queryParams,
-      queryParamsHandling: 'merge',
       replaceUrl: true,
     });
   }

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -299,7 +299,7 @@ export class SearchCriteriaService {
         LangKey: langKey,
         SelectedGeoHazards: geoHazards,
         // Remove extent if one or more regions are selected
-        Extent: useMapExtent ? extent : undefined,
+        Extent: useMapExtent && (criteria.SelectedRegions || []).length === 0 ? extent : undefined,
       })),
       map((criteria) => removeNullOrUndefined(criteria)),
       tap((currentCriteria) => this.logger.debug('Current combined criteria', DEBUG_TAG, currentCriteria)),

--- a/src/app/pages/tabs/tabs.page.ts
+++ b/src/app/pages/tabs/tabs.page.ts
@@ -40,10 +40,15 @@ export class TabsPage {
 
   constructor() {
     this.selectedTab$ = this.tabsService.selectedTab$;
-    combineLatest([this.searchCriteriaService.searchCriteria$, this.tabsService.selectedTab$]).subscribe(([, tab]) =>
-      this.applyCurrentQueryParams(tab)
-    );
     addIcons({ mapOutline, list, warning, openOutline });
+  }
+
+  async ngOnInit() {
+    combineLatest([this.searchCriteriaService.searchCriteria$, this.tabsService.selectedTab$]).subscribe(
+      async ([, tab]) => {
+        await this.applyCurrentQueryParams(tab);
+      }
+    );
   }
 
   warningsInView = computed(() => {
@@ -94,9 +99,9 @@ export class TabsPage {
     }
   });
 
-  private applyCurrentQueryParams(path: TABS | null) {
+  private async applyCurrentQueryParams(path: TABS | null) {
     if (path == TABS.HOME || path == TABS.OBSERVATION_LIST || path == TABS.WARNING_LIST) {
-      this.searchCriteriaService.applyQueryParams();
+      await this.searchCriteriaService.applyQueryParams();
     }
   }
 }


### PR DESCRIPTION
queryParamsHandling: 'merge', i search-criteria.service gjorde at vi ikke kunne fjerne en siste parameter av en bestemt type i urlen. 
Nå fjernes den riktig. Problemet som ikke ble løst er at når man velger en region i liste visning må man selv huke av filter på kartuntsnitt. Det samme skjer i dag når man velger en region i liste visning man må gjøre det selv. Hadde vært kjekt å kunne automatisere det litt basert på brukerens valgene. Jeg valgte å ikke løse det her fordi det trenger litt mer jobb og kanskje går utover scopet av denne oppgaven.