### PR TITLE
RO-2780: vise bilde beskrivelsen i kolonner + fjerne italic fra appen

### DIFF
--- a/src/app/components/observation/graphics/exposed-height/exposed-height.component.ts
+++ b/src/app/components/observation/graphics/exposed-height/exposed-height.component.ts
@@ -18,7 +18,6 @@ export enum ExposedHeightType {
     `
       text {
         fill: var(--safe-text-gray);
-        font-style: italic;
       }
 
       svg + svg {

--- a/src/app/components/observation/key-value/key-value.component.css
+++ b/src/app/components/observation/key-value/key-value.component.css
@@ -6,7 +6,3 @@
 .key {
   font-weight: var(--key-value-font-weight, 600);
 }
-
-.value {
-  font-style: var(--key-value-font-style, italic);
-}

--- a/src/app/components/observation/key-value/key-value.component.ts
+++ b/src/app/components/observation/key-value/key-value.component.ts
@@ -12,7 +12,7 @@ import { IonText } from '@ionic/angular/standalone';
       @if (key()) {
         <span class="key">{{ key() }}:</span>&nbsp;
       }
-      <span class="value">{{ value() }}</span>
+      <span>{{ value() }}</span>
     </ion-text>
   `,
   styleUrl: './key-value.component.css',

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -24,66 +24,59 @@
   }
 </swiper-container>
 <div class="image-description">
-  <div class="image-description__inner">
+  <div class="image-description__content">
     <!-- tittel -->
-    <div class="image-description__title">
-      @if (currentAttachmentData().RegistrationName) {
-        <span> {{ currentAttachmentData().RegistrationName }}</span>
+    @if (currentAttachmentData().RegistrationName) {
+      <ion-chip color="primary"> {{ currentAttachmentData().RegistrationName }}</ion-chip>
+    }
+    <!-- kommentar -->
+    @if (comment()) {
+      <app-key-value [key]="'REGISTRATION.DANGER_OBS.COMMENT' | translate" [value]="comment()"></app-key-value>
+    }
+    <div class="image-descritpion__params">
+      <!-- region -->
+      @if (registration()?.ObsLocation?.ForecastRegionName) {
+        <app-key-value
+          [key]="'REGISTRATION.DANGER_OBS.FOR_REGION' | translate"
+          [value]="registration()?.ObsLocation?.ForecastRegionName"
+        >
+        </app-key-value>
       }
-    </div>
-    <div class="image-description_column">
-      <!-- kommentar -->
-      @if (comment()) {
-        <app-key-value [key]="'REGISTRATION.DANGER_OBS.COMMENT' | translate" [value]="comment()"></app-key-value>
+
+      <!-- himmelretning -->
+      @if (currentAttachmentData().Aspect) {
+        <app-key-value
+          [key]="'REGISTRATION.IMAGE_ASPECT' | translate"
+          [value]="roundedDownOrientationValue() | translate"
+        >
+        </app-key-value>
       }
-      <div class="image-description_row">
-        <!-- region -->
-        @if (registration()?.ObsLocation?.ForecastRegionName) {
-          <app-key-value
-            [key]="'REGISTRATION.DANGER_OBS.FOR_REGION' | translate"
-            [value]="registration()?.ObsLocation?.ForecastRegionName"
-          >
-          </app-key-value>
-        }
 
-        <!-- himmelretning -->
-        @if (currentAttachmentData().Aspect) {
-          <app-key-value
-            [key]="'REGISTRATION.IMAGE_ASPECT' | translate"
-            [value]="roundedDownOrientationValue() | translate"
-          >
-          </app-key-value>
-        }
+      <!-- sendt inn av -->
+      @if (registration()?.Observer?.NickName) {
+        <app-key-value [key]="'REGISTRATION.CARD.OBSERVED_BY' | translate" [value]="registration()?.Observer?.NickName">
+        </app-key-value>
+      }
 
-        <!-- sendt inn av -->
-        @if (registration()?.Observer?.NickName) {
-          <app-key-value
-            [key]="'REGISTRATION.CARD.OBSERVED_BY' | translate"
-            [value]="registration()?.Observer?.NickName"
-          >
-          </app-key-value>
-        }
+      <!-- opphavsrett -->
+      @if (currentAttachmentData().Copyright) {
+        <app-key-value [key]="'MY_PROFILE.COPYRIGHT' | translate" [value]="currentAttachmentData().Copyright">
+        </app-key-value>
+      }
 
-        <!-- opphavsrett -->
-        @if (currentAttachmentData().Copyright) {
-          <app-key-value [key]="'MY_PROFILE.COPYRIGHT' | translate" [value]="currentAttachmentData().Copyright">
-          </app-key-value>
-        }
-
-        <!-- fotograf -->
-        @if (currentAttachmentData().Photographer) {
-          <app-key-value [key]="'MY_PROFILE.PHOTOGRAPHER' | translate" [value]="currentAttachmentData().Photographer">
-          </app-key-value>
-        }
-        <!-- observert dato-->
-        @if (registration()?.DtObsTime) {
-          <app-key-value
-            [key]="'REGISTRATION.CARD.TIME.OBSERVED' | translate"
-            [value]="registration()?.DtObsTime | date: 'short'"
-          >
-          </app-key-value>
-        }
-      </div>
+      <!-- fotograf -->
+      @if (currentAttachmentData().Photographer) {
+        <app-key-value [key]="'MY_PROFILE.PHOTOGRAPHER' | translate" [value]="currentAttachmentData().Photographer">
+        </app-key-value>
+      }
+      <!-- observert dato-->
+      @if (registration()?.DtObsTime) {
+        <app-key-value
+          [key]="'REGISTRATION.CARD.TIME.OBSERVED' | translate"
+          [value]="registration()?.DtObsTime | date: 'short'"
+        >
+        </app-key-value>
+      }
     </div>
     <div class="image-description__links">
       <a [href]="currentAttachmentData().Url" download>

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -33,7 +33,7 @@
     @if (comment()) {
       <app-key-value [key]="'REGISTRATION.DANGER_OBS.COMMENT' | translate" [value]="comment()"></app-key-value>
     }
-    <div class="image-descritpion__params">
+    <div class="image-description__params">
       <!-- region -->
       @if (registration()?.ObsLocation?.ForecastRegionName) {
         <app-key-value

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -30,72 +30,84 @@
       @if (currentAttachmentData().RegistrationName) {
         <span> {{ currentAttachmentData().RegistrationName }}</span>
       }
-      <div class="image-description__links">
-        <a [href]="currentAttachmentData().Url" download>
-          <ion-icon name="download-outline"></ion-icon> {{ "REGISTRATION.CARD.DOWNLOAD" | translate }}
-        </a>
+    </div>
+    <div class="image-description_column">
+      <!-- kommentar -->
+      @if (comment()) {
+        <app-key-value [key]="'REGISTRATION.DANGER_OBS.COMMENT' | translate" [value]="comment()"></app-key-value>
+      }
+      <div class="image-description_row">
+        <!-- region -->
+        @if (registration()?.ObsLocation?.ForecastRegionName) {
+          <app-key-value
+            [key]="'REGISTRATION.DANGER_OBS.FOR_REGION' | translate"
+            [value]="registration()?.ObsLocation?.ForecastRegionName"
+          >
+          </app-key-value>
+        }
 
-        <!-- Kun snøprofil har Href -->
-        @if (currentAttachmentData().Href; as snowProfileImageUrl) {
-          <a [href]="snowProfileImageUrl" target="_blank">
-            <ion-icon name="open-outline"></ion-icon>
-            {{ "REGISTRATION.CARD.GO_TO_SNOW_PROFILE" | translate }}
-          </a>
-        } @else {
-          <a [href]="currentAttachmentData().Url" target="_blank">
-            <ion-icon name="open-outline"></ion-icon> {{ "REGISTRATION.CARD.GO_TO_ORIGINAL_IMAGE" | translate }}
-          </a>
+        <!-- himmelretning -->
+        @if (currentAttachmentData().Aspect) {
+          <app-key-value
+            [key]="'REGISTRATION.IMAGE_ASPECT' | translate"
+            [value]="roundedDownOrientationValue() | translate"
+          >
+          </app-key-value>
+        }
+
+        <!-- sendt inn av -->
+        @if (registration()?.Observer?.NickName) {
+          <app-key-value
+            [key]="'REGISTRATION.CARD.OBSERVED_BY' | translate"
+            [value]="registration()?.Observer?.NickName"
+          >
+          </app-key-value>
+        }
+
+        <!-- opphavsrett -->
+        @if (currentAttachmentData().Copyright) {
+          <app-key-value [key]="'MY_PROFILE.COPYRIGHT' | translate" [value]="currentAttachmentData().Copyright">
+          </app-key-value>
+        }
+
+        <!-- fotograf -->
+        @if (currentAttachmentData().Photographer) {
+          <app-key-value [key]="'MY_PROFILE.PHOTOGRAPHER' | translate" [value]="currentAttachmentData().Photographer">
+          </app-key-value>
+        }
+        <!-- observert dato-->
+        @if (registration()?.DtObsTime) {
+          <app-key-value
+            [key]="'REGISTRATION.CARD.TIME.OBSERVED' | translate"
+            [value]="registration()?.DtObsTime | date: 'short'"
+          >
+          </app-key-value>
         }
       </div>
     </div>
+    <div class="image-description__links">
+      <a [href]="currentAttachmentData().Url" download>
+        <ion-icon name="download-outline"></ion-icon> {{ "REGISTRATION.CARD.DOWNLOAD" | translate }}
+      </a>
 
-    <!-- kommentar -->
-    @if (comment()) {
-      <app-key-value [key]="'REGISTRATION.DANGER_OBS.COMMENT' | translate" [value]="comment()"></app-key-value>
-    }
-    <!-- region -->
-    @if (registration()?.ObsLocation?.ForecastRegionName) {
-      <app-key-value
-        [key]="'REGISTRATION.DANGER_OBS.FOR_REGION' | translate"
-        [value]="registration()?.ObsLocation?.ForecastRegionName"
-      >
-      </app-key-value>
-    }
-
-    <!-- himmelretning -->
-    @if (currentAttachmentData().Aspect) {
-      <app-key-value
-        [key]="'REGISTRATION.IMAGE_ASPECT' | translate"
-        [value]="roundedDownOrientationValue() | translate"
-      >
-      </app-key-value>
-    }
-
-    <!-- sendt inn av -->
-    @if (registration()?.Observer?.NickName) {
-      <app-key-value [key]="'REGISTRATION.CARD.OBSERVED_BY' | translate" [value]="registration()?.Observer?.NickName">
-      </app-key-value>
-    }
-
-    <!-- opphavsrett -->
-    @if (currentAttachmentData().Copyright) {
-      <app-key-value [key]="'MY_PROFILE.COPYRIGHT' | translate" [value]="currentAttachmentData().Copyright">
-      </app-key-value>
-    }
-
-    <!-- fotograf -->
-    @if (currentAttachmentData().Photographer) {
-      <app-key-value [key]="'MY_PROFILE.PHOTOGRAPHER' | translate" [value]="currentAttachmentData().Photographer">
-      </app-key-value>
-    }
-    <!-- observert dato-->
-    @if (registration()?.DtObsTime) {
-      <app-key-value
-        [key]="'REGISTRATION.CARD.TIME.OBSERVED' | translate"
-        [value]="registration()?.DtObsTime | date: 'short'"
-      >
-      </app-key-value>
-    }
+      <!-- Kun snøprofil har Href -->
+      @if (currentAttachmentData().Href; as snowProfileImageUrl) {
+        <a [href]="snowProfileImageUrl" target="_blank">
+          <ion-icon name="open-outline"></ion-icon>
+          {{ "REGISTRATION.CARD.GO_TO_SNOW_PROFILE" | translate }}
+        </a>
+      } @else {
+        <a [href]="currentAttachmentData().Url" target="_blank">
+          <ion-icon name="open-outline"></ion-icon> {{ "REGISTRATION.CARD.GO_TO_ORIGINAL_IMAGE" | translate }}
+        </a>
+      }
+      @if (isImageListView()) {
+        <a [routerLink]="'registration/' + registration()?.RegId" (click)="closeModal()">
+          <ion-icon name="eye-outline"></ion-icon>
+          {{ "REGISTRATION.GO_TO" | translate }}
+        </a>
+      }
+    </div>
   </div>
 </div>
 <ion-fab-button (click)="closeModal()" [attr.aria-label]="'CLOSE' | translate">

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
@@ -1,7 +1,3 @@
-p {
-  margin: 0;
-}
-
 swiper-container {
   flex: 1;
   width: 100%;
@@ -58,11 +54,11 @@ ion-fab-button::part(native):hover {
 .image-description {
   background-color: white;
   max-height: min(400px, 30vh);
-  padding: 20px;
   width: 100%;
+  padding: 20px;
   display: flex;
   justify-content: center;
-  box-sizing: border-box;
+  overflow: auto;
 }
 
 @media (max-height: 550px) {
@@ -75,31 +71,32 @@ ion-fab-button::part(native):hover {
   }
 }
 
-.image-description__inner {
-  overflow: auto;
-  max-width: min(800px, 90%);
-  display: flex;
-  flex-direction: column;
-}
+.image-description__content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  max-width: 70%;
+  min-width: 670px;
 
-.image-description__title {
-  display: flex;
-  justify-content: space-between;
-  gap: 20px;
-  align-items: center;
-  margin-bottom: 10px;
-  span {
-    font-size: 1.5rem;
-    color: var(--ion-text-color-heading);
-    line-height: 100%;
+  ion-chip {
+    width: fit-content;
+    font-size: 1.15rem;
+    margin: 0;
   }
 }
 
-@media (max-width: 600px) {
-  .image-description__title {
-    flex-direction: column;
-    gap: 5px;
-    align-items: flex-start;
+.image-descritpion__params {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+@media (max-width: 700px) {
+  .image-descritpion__params {
+    grid-template-columns: 1fr;
+  }
+  .image-description__content {
+    min-width: unset;
+    max-width: unset;
   }
 }
 
@@ -119,29 +116,6 @@ ion-fab-button::part(native):hover {
   ion-icon {
     font-size: 1.25rem;
   }
-}
-
-.image-description_row {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-@media screen and (max-width: 600px) {
-  .image-description_row {
-    flex-direction: column;
-    width: 100%;
-    flex-wrap: nowrap;
-  }
-}
-
-.image-description_column {
-  display: flex;
-  width: 100%;
-  flex-direction: column;
-}
-
-.image-description_row > * {
-  flex: 1 1 50%;
 }
 
 .snow-profile {

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
@@ -80,7 +80,7 @@ ion-fab-button::part(native):hover {
 
   ion-chip {
     width: fit-content;
-    font-size: 1.15rem;
+    font-size: 1rem;
     margin: 0;
   }
 }

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
@@ -85,7 +85,7 @@ ion-fab-button::part(native):hover {
   }
 }
 
-.image-descritpion__params {
+.image-description__params {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
 }

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
@@ -121,6 +121,29 @@ ion-fab-button::part(native):hover {
   }
 }
 
+.image-description_row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+@media screen and (max-width: 600px) {
+  .image-description_row {
+    flex-direction: column;
+    width: 100%;
+    flex-wrap: nowrap;
+  }
+}
+
+.image-description_column {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+}
+
+.image-description_row > * {
+  flex: 1 1 50%;
+}
+
 .snow-profile {
   width: 100%;
   height: 100%;

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -10,7 +10,7 @@ import {
   model,
   viewChild,
 } from '@angular/core';
-import { IonFabButton, IonIcon, ModalController } from '@ionic/angular/standalone';
+import { IonFabButton, IonIcon, ModalController, IonChip } from '@ionic/angular/standalone';
 import { AttachmentViewModel, RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 import { SwiperContainer } from 'swiper/element';
 import { addIcons } from 'ionicons';
@@ -28,7 +28,7 @@ import { Router, RouterLink } from '@angular/router';
   templateUrl: './observation-image-carousel.component.html',
   styleUrls: ['./observation-image-carousel.component.scss'],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  imports: [IonIcon, IonFabButton, TranslatePipe, DatePipe, KeyValueComponent, RouterLink],
+  imports: [IonIcon, IonFabButton, TranslatePipe, DatePipe, KeyValueComponent, RouterLink, IonChip],
 })
 export class ObservationImageCarouselComponent {
   readonly swiper = viewChild<ElementRef<SwiperContainer>>('swiper');

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -14,24 +14,27 @@ import { IonFabButton, IonIcon, ModalController } from '@ionic/angular/standalon
 import { AttachmentViewModel, RegistrationViewModel } from 'src/app/modules/common-regobs-api';
 import { SwiperContainer } from 'swiper/element';
 import { addIcons } from 'ionicons';
-import { close, downloadOutline, openOutline } from 'ionicons/icons';
+import { close, downloadOutline, openOutline, eyeOutline } from 'ionicons/icons';
 import { TranslatePipe } from '@ngx-translate/core';
 import { DatePipe } from '@angular/common';
 import { KeyValueComponent } from '../key-value/key-value.component';
 import { settings } from 'src/settings';
 import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrientationValue';
 import { PlotService } from 'src/app/core/services/plot.service';
+import { Router, RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-observation-image-carousel',
   templateUrl: './observation-image-carousel.component.html',
   styleUrls: ['./observation-image-carousel.component.scss'],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  imports: [IonIcon, IonFabButton, TranslatePipe, DatePipe, KeyValueComponent],
+  imports: [IonIcon, IonFabButton, TranslatePipe, DatePipe, KeyValueComponent, RouterLink],
 })
 export class ObservationImageCarouselComponent {
   readonly swiper = viewChild<ElementRef<SwiperContainer>>('swiper');
   private modalController = inject(ModalController);
+  private router = inject(Router);
+  isImageListView = computed(() => this.router.url.includes('search/pictures'));
   attachments = input<(AttachmentViewModel & { Href?: string })[]>([]);
   plotService = inject(PlotService);
 
@@ -73,7 +76,7 @@ export class ObservationImageCarouselComponent {
   });
 
   constructor() {
-    addIcons({ close, downloadOutline, openOutline });
+    addIcons({ close, downloadOutline, openOutline, eyeOutline });
   }
 
   closeModal() {

--- a/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.css
+++ b/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.css
@@ -14,10 +14,6 @@ app-key-value {
   display: block;
 }
 
-.body-text {
-  font-style: var(--key-value-font-style, italic);
-}
-
 .exposition-graphics {
   display: flex;
   justify-content: left;

--- a/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.html
+++ b/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.html
@@ -4,7 +4,7 @@
   <h4 class="title">{{ title() }}</h4>
 }
 @if (comment()) {
-  <ion-text color="dark" class="body-text">{{ comment() }}</ion-text>
+  <ion-text color="dark">{{ comment() }}</ion-text>
 }
 @if (formatTime()) {
   <app-key-value

--- a/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.css
+++ b/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.css
@@ -14,10 +14,6 @@ app-key-value {
   display: block;
 }
 
-.soft-layer-attributes {
-  font-style: var(--key-value-font-style, italic);
-}
-
 .exposition-graphics {
   display: flex;
   justify-content: left;

--- a/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.html
+++ b/src/app/components/observation/registrations/avalanche-problem-view/avalanche-problem-view.component.html
@@ -4,7 +4,7 @@
   <h4 class="title">{{ cause() }}</h4>
 }
 @if (comment()) {
-  <ion-text color="dark" class="soft-layer-attributes">{{ comment() }}</ion-text>
+  <ion-text color="dark">{{ comment() }}</ion-text>
 }
 @if (type()) {
   <app-key-value [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.AVALANCHE_TYPE' | translate" [value]="type()" />
@@ -12,7 +12,7 @@
 @if (causeDepth()) {
   <app-key-value [key]="'REGISTRATION.SNOW.AVALANCHE_PROBLEM.WEAK_LAYER_DEPTH' | translate" [value]="causeDepth()" />
 }
-<ion-text color="dark" class="soft-layer-attributes">
+<ion-text color="dark">
   @if (easyCollapseLabel()) {
     {{ easyCollapseLabel() }}
   }

--- a/src/app/pages/observation-list/image-list/grid-image.component.ts
+++ b/src/app/pages/observation-list/image-list/grid-image.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
 import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
+import { IonChip } from '@ionic/angular/standalone';
 
 /**
  * Komponent som viser ett bilde i bildesøk. Bør ikke brukes andre steder enn det.
@@ -8,17 +9,15 @@ import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
  */
 @Component({
   selector: 'app-grid-image',
-  imports: [],
+  imports: [IonChip],
   template: `
     <img [src]="src()" (load)="setAspectRatioClass($event)" [alt]="attachmentAlt()" />
 
     @if (attachment().RegistrationName) {
-      <div class="grid-image__text">{{ attachment().RegistrationName }}</div>
+      <ion-chip color="primary" class="grid-image__text">{{ attachment().RegistrationName }}</ion-chip>
     }
     @if (attachment().Comment) {
-      <div class="grid-image__text">
-        <i>{{ attachment().Comment }}</i>
-      </div>
+      <div class="grid-image__text">{{ attachment().Comment }}</div>
     }
   `,
   styles: `
@@ -27,6 +26,7 @@ import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
       flex-direction: column;
       height: 100%;
       padding: 10px;
+      border-radius: 6px;
       box-sizing: border-box;
       background: #fff;
       transition: background 0.3s ease;
@@ -36,6 +36,11 @@ import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
       }
     }
 
+    ion-chip {
+      font-size: 1rem;
+      width: fit-content;
+      margin: 0;
+    }
     .grid-image__text {
       overflow: hidden;
       white-space: nowrap;


### PR DESCRIPTION
Den fikser visning av bilde beskrivelsen i bilde karusellen, men også fjerner italic fra appen siden det ble bestemt å ikke bruke den pga dårlig lesbarhet