### PR TITLE
RO-2822: fikse filter meny høyde

### DIFF
--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.scss
@@ -2,6 +2,7 @@
   height: 100%;
   --background-color: #fff;
   background-color: var(--background-color);
+  margin-bottom: 56px; // høyde på tab bar.
 }
 
 ion-title.title-small {


### PR DESCRIPTION
Jeg setter fast høyde i filter-menu komponent fordi den settes ikke på selve tab knappen med css. Vi trenger å redusere tab baren høyde for å kunne vise "dekket" input felter av tab baren i filter meny som søk på kallenavn.