### PR TITLE
RO-2810: bygge og deploye regobs i azure pipelines

### DIFF
--- a/pipelines/regobs-ci.yml
+++ b/pipelines/regobs-ci.yml
@@ -1,5 +1,4 @@
-# Varsom app build script
-# https://aka.ms/yaml
+# Regobs ci script. Kjører tester og publiserer test rapport.
 
 trigger:
   - develop

--- a/pipelines/regobs-mobile-app-build-release.yml
+++ b/pipelines/regobs-mobile-app-build-release.yml
@@ -1,7 +1,4 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
+# Bygger og deployer Regobs mobil app til App Store og Google Play
 
 trigger:
   - release/*

--- a/pipelines/regobs-web-build-release.yml
+++ b/pipelines/regobs-web-build-release.yml
@@ -1,0 +1,158 @@
+# Regobs web bygg og release pipeline.
+trigger:
+  branches:
+    include:
+      - develop
+
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+stages:
+  - stage: 'Build'
+    displayName: 'Build'
+    jobs:
+      - job:
+        pool:
+          vmImage: 'windows-latest'
+
+        steps:
+          - task: Cache@2
+            displayName: Cache npm dependencies
+            inputs:
+              key: 'npm | "$(Agent.OS)" | package-lock.json'
+              restoreKeys: |
+                npm | "$(Agent.OS)"
+              path: node_modules
+
+          - task: NodeTool@0
+            displayName: 'Use Node 18.x'
+            inputs:
+              versionSpec: 18.x
+
+          - task: Npm@1
+            displayName: 'npm install'
+
+          - task: Npm@1
+            displayName: 'npm run test-ci'
+            enabled: true
+            inputs:
+              command: custom
+              customCommand: 'run test-ci'
+
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results **/TESTS-*.xml'
+            condition: succeededOrFailed()
+            enabled: true
+            inputs:
+              testResultsFiles: '**/TESTS-*.xml'
+
+          - task: PublishCodeCoverageResults@2
+            displayName: 'Publish code coverage from **/cobertura-coverage.xml'
+            condition: succeededOrFailed()
+            enabled: true
+            inputs:
+              codeCoverageTool: Cobertura
+              summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml'
+              reportDirectory: '$(System.DefaultWorkingDirectory)/coverage'
+              failIfCoverageEmpty: true
+
+          - task: Npm@1
+            displayName: 'npm create version file and update AndroidManifest.xml and plist.info'
+            inputs:
+              command: custom
+              customCommand: 'run create-version-file'
+
+          - task: Npm@1
+            displayName: 'npm run build:prod'
+            inputs:
+              command: custom
+              customCommand: 'run build:prod'
+
+          - task: CopyFiles@2
+            displayName: 'copy files to $(Build.ArtifactStagingDirectory)'
+            inputs:
+              sourceFolder: 'www'
+              contents: '**/*'
+              targetFolder: '$(Build.ArtifactStagingDirectory)'
+              cleanTargetFolder: true
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish BuildArtifact'
+            inputs:
+              pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+              artifactName: drop
+
+  - stage: Test
+    displayName: 'Deploy to Test'
+    dependsOn: Build
+    jobs:
+      - deployment: DeployToTest
+        displayName: 'Deploy to Test'
+        environment:
+          name: RegObs-Test
+          resourceName: NF-WEB-E-TST01
+        variables:
+          targetFolder: 'Z:\SharedData\Web\test.regobs.no\Releases_$(Build.BuildNumber)'
+          appName: 'test.regobs.no'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: drop
+
+                - task: CopyFiles@2
+                  enabled: true
+                  displayName: 'Copy Files to WebAppBasePath'
+                  inputs:
+                    SourceFolder: $(Pipeline.Workspace)\drop\browser
+                    TargetFolder: '$(targetFolder)'
+                    OverWrite: true
+
+                - task: IISWebAppManagementOnMachineGroup@0
+                  displayName: 'Deploy to IIS'
+                  inputs:
+                    IISDeploymentType: 'IISWebApplication'
+                    ParentWebsiteNameForApplication: '$(appName)'
+                    VirtualPathForApplication: '/'
+                    PhysicalPathForApplication: '$(targetFolder)'
+                    AppPoolName: '$(appName)'
+                    AppPoolNameForWebsite: '$(appName)'
+                    AppPoolNameForApplication: '$(appName)'
+
+  - stage: Prod
+    displayName: 'Deploy to Prod'
+    dependsOn: Test
+    jobs:
+      - deployment: DeployToProd
+        displayName: 'Deploy to Prod'
+        environment:
+          name: RegObs-Prod
+          resourceName: NF-REGOBS-E-PRO
+        variables:
+          targetFolder: 'Z:\SharedData\Web\regobs2025\Releases_$(Build.BuildNumber)'
+          appName: 'regobs2025'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: drop
+
+                - task: CopyFiles@2
+                  enabled: true
+                  displayName: 'Copy Files to WebAppBasePath'
+                  inputs:
+                    SourceFolder: $(Pipeline.Workspace)\drop\browser
+                    TargetFolder: '$(targetFolder)'
+                    OverWrite: true
+
+                - task: IISWebAppManagementOnMachineGroup@0
+                  displayName: 'Deploy to IIS'
+                  inputs:
+                    IISDeploymentType: 'IISWebApplication'
+                    ParentWebsiteNameForApplication: '$(appName)'
+                    VirtualPathForApplication: '/'
+                    PhysicalPathForApplication: '$(targetFolder)'
+                    AppPoolName: '$(appName)'
+                    AppPoolNameForWebsite: '$(appName)'
+                    AppPoolNameForApplication: '$(appName)'


### PR DESCRIPTION
Har flyttet alle azure pipeliner under pipelines mappen. Har også endret navn på de til å forstå bedre hva de inneholder.
Nå har vi web-build-release pipeline som kjører multi stage modus på regobs web appen. 
test.regobs.no bør nå kjøre som beta.regobs.no. 

test.regobs skal nå kjøre på nf-web-e-tst01.dmz.nve.no, mens
regobs skal kjøre på nf-regobs-e-prod01.dmz.nve.no. Siden gamle regobs er fortsatt i bruk kallte vi appen for regobs2025. Den skal endres tilbake til regobs når den gamle regobs fases ut. 