### PR TITLE
RO-2843: Skjule regionfilter for andre naturfarer enn snø

### DIFF
--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -65,9 +65,9 @@
         </ion-accordion>
 
         <!-- Snøskredregioner -->
-        <div *ngIf="isSupported('region')">
+        <div *ngIf="isSupported('region') && isGeohazardSnow()">
           <div *ngIf="regions$ | async as regions" slot="content">
-            <ion-accordion *ngIf="isSupported('region')" value="a-regions">
+            <ion-accordion value="a-regions">
               <ion-item slot="header" color="light">
                 <app-selected-items-counter-label [selectedItemsCount]="nRegionsSelected$ | async">
                   {{ "OBSERVATION_FILTER.REGION_FILTER_TITLE_SNOW" | translate }}

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -157,7 +157,8 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
 
   competenceItems$?: Observable<CompetenceOption[]>;
 
-  currentGeoHazard?: GeoHazard[];
+  private currentGeoHazard = toSignal(this.userSettingService.currentGeoHazard$, { initialValue: [GeoHazard.Snow] });
+  isGeohazardSnow = computed(() => this.currentGeoHazard().includes(GeoHazard.Snow));
   showObservations$?: Observable<boolean>;
   observationTypes$?: Observable<ObservationTypeView[]>;
   noCompetenceFilterActive$?: Observable<boolean>;
@@ -257,8 +258,6 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
     this.isMobileWeb = this.platform.is('mobileweb');
     this.platformType = this.isIosOrAndroid ? 'app' : 'web';
     this.showObservations$ = this.userSettingService.showObservations$;
-
-    this.userSettingService.currentGeoHazard$.subscribe((curGeohazard) => (this.currentGeoHazard = curGeohazard));
 
     const competenceCriteria$ = this.searchCriteriaService.searchCriteria$.pipe(
       map((searchCriteria) => searchCriteria.ObserverCompetence || []),


### PR DESCRIPTION
Dette fikser feilen med at filter på snøskredregioner også vises for andre naturfarer enn snø.
For å gjenskape feilen på beta.regobs.no, må du først velge naturfare snø, og deretter bytte til is eller vann/jord. Da vises fortsatt filter på snøskred-regioner.