### PR TITLE
RO-2827: Bedre feilhåndtering når bilder ikke laster i bildesøk og bildekarusell

### DIFF
--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -18,7 +18,12 @@
           loading="lazy"
         />
       } @else {
-        <img [alt]="attachment.Comment" [src]="attachment.Url" />
+        <app-remote-image
+          [attachment]="attachment"
+          preferSize="Large"
+          [withFallbackText]="true"
+          [largeFallback]="false"
+        ></app-remote-image>
       }
     </swiper-slide>
   }

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -22,13 +22,23 @@ import { settings } from 'src/settings';
 import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrientationValue';
 import { PlotService } from 'src/app/core/services/plot.service';
 import { Router, RouterLink } from '@angular/router';
+import { RemoteImageComponent } from '../../../modules/shared/components/remote-image/remote-image.component';
 
 @Component({
   selector: 'app-observation-image-carousel',
   templateUrl: './observation-image-carousel.component.html',
   styleUrls: ['./observation-image-carousel.component.scss'],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  imports: [IonIcon, IonFabButton, TranslatePipe, DatePipe, KeyValueComponent, RouterLink, IonChip],
+  imports: [
+    IonIcon,
+    IonFabButton,
+    TranslatePipe,
+    DatePipe,
+    KeyValueComponent,
+    RouterLink,
+    IonChip,
+    RemoteImageComponent,
+  ],
 })
 export class ObservationImageCarouselComponent {
   readonly swiper = viewChild<ElementRef<SwiperContainer>>('swiper');

--- a/src/app/modules/shared/components/remote-image/remote-image.component.html
+++ b/src/app/modules/shared/components/remote-image/remote-image.component.html
@@ -2,7 +2,7 @@
   <img (error)="onError()" [src]="this.imgUrlSafe()" class="image-preview" />
 } @else {
   <div [class]="{ error: true, large: largeFallback() }">
-    <img style="width: 100px" src=".\assets\images\broken-image.svg" />
+    <img style="width: 100px" src=".\assets\images\broken-image.svg" [alt]="alt()" (load)="onLoad($event)" />
     @if (withFallbackText()) {
       <p>{{ "REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE" | translate }}</p>
       <p>{{ "REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE_NET_Q" | translate }}</p>

--- a/src/app/modules/shared/components/remote-image/remote-image.component.ts
+++ b/src/app/modules/shared/components/remote-image/remote-image.component.ts
@@ -7,6 +7,8 @@ import {
   computed,
   linkedSignal,
   signal,
+  Output,
+  EventEmitter,
 } from '@angular/core';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { RemoteOrLocalAttachmentEditModel } from 'src/app/core/services/draft/draft-model';
@@ -31,10 +33,12 @@ export class RemoteImageComponent {
   private sanitizer = inject(DomSanitizer);
 
   readonly attachment = input.required<RemoteOrLocalAttachmentEditModel>();
+  readonly alt = input<string>(''); // alternativ tekst til bildet
   readonly preferSize = input<keyof NonNullable<RemoteOrLocalAttachmentEditModel['UrlFormats']>>('Thumbnail');
   readonly largeFallback = input(false);
   readonly withFallbackText = input(false);
   readonly isThumbnail = input(false);
+  @Output() load = new EventEmitter<Event>(); // kalles når bildet er lastet inn
 
   private readonly imgUrl = linkedSignal(() => {
     let imageUrl: string;
@@ -56,6 +60,10 @@ export class RemoteImageComponent {
 
   @HostBinding('style.pointer-events')
   pointerEvents = 'auto';
+
+  onLoad(event: Event) {
+    this.load.emit(event);
+  }
 
   onError() {
     const attachment = this.attachment();

--- a/src/app/pages/observation-list/image-list/grid-image.component.ts
+++ b/src/app/pages/observation-list/image-list/grid-image.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
 import { AttachmentViewModel } from 'src/app/modules/common-regobs-api';
 import { IonChip } from '@ionic/angular/standalone';
+import { RemoteImageComponent } from '../../../modules/shared/components/remote-image/remote-image.component';
 
 /**
  * Komponent som viser ett bilde i bildesøk. Bør ikke brukes andre steder enn det.
@@ -9,9 +10,16 @@ import { IonChip } from '@ionic/angular/standalone';
  */
 @Component({
   selector: 'app-grid-image',
-  imports: [IonChip],
+  imports: [IonChip, RemoteImageComponent],
   template: `
-    <img [src]="src()" (load)="setAspectRatioClass($event)" [alt]="attachmentAlt()" />
+    <app-remote-image
+      [attachment]="attachment()"
+      (load)="setAspectRatioClass($event)"
+      [alt]="attachmentAlt()"
+      preferSize="Large"
+      [withFallbackText]="true"
+      [largeFallback]="false"
+    />
 
     @if (attachment().RegistrationName) {
       <ion-chip color="primary" class="grid-image__text">{{ attachment().RegistrationName }}</ion-chip>


### PR DESCRIPTION
NB! Denne er ikke ferdig ennå!

Jobber med å bruke app-remote-image i bildekarusellen, siden denne allerede har innebygget feilhåndtering. Men komponenten funker ikke så bra nå, må gjøres noen justeringer i css, tror jeg:
![image](https://github.com/user-attachments/assets/cea0ad38-089a-48fd-8621-16553bca1605)

Gjenstår:
- [ ] Fikse styling
- [ ] Fikse aspectRatio. Nå ser det ut som img.naturalWidth og img.naturalHeighter er 36x36 uansett i setAspectRatioClass() i grid-image.component.ts

William Goddard har en observasjon igår med et bilde som feiler, se: 
https://beta.regobs.no/search/pictures?hazard=10&daysBack=2&nick=william&orderBy=changeTime
Du må deaktivere filter på kartutsnitt for å se bildene.
og sammenlign med PR-bygget:
https://victorious-water-056410803-766.westeurope.azurestaticapps.net/search/pictures?hazard=10&daysBack=2&nick=william&orderBy=changeTime

