### PR TITLE
RO-2858: legge til web config

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -22,6 +22,11 @@
             "tsConfig": "src/tsconfig.app.json",
             "assets": [
               {
+                "glob": "web.config",
+                "input": "./",
+                "output": "/"
+              },
+              {
                 "glob": "**/*",
                 "input": "src/assets",
                 "output": "assets"

--- a/web.config
+++ b/web.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <rule name="Angular Route">
+          <match url=".*" />
+          <conditions>
+          <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+          <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="/index.html" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Den sørger for at vi klarer å logge inn i appen med riktig URL-viderekobling. Appen forventer at auth/callback brukes som retur-URL etter pålogging med Azure, og vi må informere IIS om at Angular skal håndtere routing. Alle "ukjente" URL-er (som ikke finnes som en html filer i applikasjonen's mappe på server som auth/callback) må derfor videresendes til index.html, som er hovedfilen i applikasjonen.