### PR TITLE
RO-2852: Bedre feilmelding i Edge når du har skrudd av posisjonsdeling

### DIFF
--- a/src/app/core/services/geo-position/geo-position.service.ts
+++ b/src/app/core/services/geo-position/geo-position.service.ts
@@ -222,7 +222,7 @@ export class GeoPositionService implements OnDestroy {
   private async createToast(message?: string) {
     const toast = await this.toastController.create({
       message: message,
-      duration: 6000,
+      duration: 10000,
     });
     await toast.present();
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -105,9 +105,9 @@
     "POSITION_ERROR": {
       "INVALID": "Invalid position data",
       "PermissionDenied": "To fetch your position you need to alter your location settings on the phone/device",
-      "PositionUnavailable": "Not able fetch your position",
-      "Timeout": "It took to long time to fetch your position",
-      "UNSUPPORTED": "Positioning is not supported on this unit"
+      "PositionUnavailable": "Not able fetch your position. You might need to alter your location settings on the phone/device",
+      "Timeout": "It took to long time to fetch your position. You might need to alter your location settings on the phone/device",
+      "UNSUPPORTED": "Positioning is not supported on this device"
     }
   },
   "GEOLOCATION_SERVICE": {

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -104,9 +104,9 @@
   "GEOLOCATION": {
     "POSITION_ERROR": {
       "INVALID": "Kan ikke vise posisjonen din pga. ufullstendige posisjonsdata",
-      "PermissionDenied": "Vi trenger tilgang til nøyaktig posisjon for å vise hvor du er. Du må gå til innstillinger på telefonen/nettbrettet for å gi appen tilgang.",
-      "PositionUnavailable": "Får ikke tak i posisjonen din",
-      "Timeout": "Det tok for lang tid å få tak i posisjonen din",
+      "PermissionDenied": "Vi trenger tilgang til nøyaktig posisjon for å vise hvor du er. Endre innstillinger i nettleser eller operativsystem for å gi oss tilgang.",
+      "PositionUnavailable": "Får ikke tak i posisjonen din. Vi trenger tilgang til nøyaktig posisjon for å vise hvor du er. Sjekk om du deler posisjonsdata i innstillinger i nettleser eller operativsystem.",
+      "Timeout": "Det tok for lang tid å få tak i posisjonen din. Sjekk om du deler posisjonsdata i innstillinger i nettleser eller operativsystem.",
       "UNSUPPORTED": "Enheten kan ikke gi deg posisjonsdata"
     }
   },


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/RO-2852, også kommentarer
Siden Edge oppfører seg litt annerledes enn Chrome, oppfordrer vi nå til å sjekke innstillinger for deling av posisjonsdata uansett hvilken feilmelding vi får fra nettleser, når du trykker på posisjonsknappen.
