### PR TITLE
RO-2805: Lagre versjon i sentry ved bygg av webapp

### DIFF
--- a/pipelines/regobs-mobile-app-build-release.yml
+++ b/pipelines/regobs-mobile-app-build-release.yml
@@ -134,6 +134,7 @@ steps:
 
   - script: |
       sentry-cli releases new $(json.version)
+      sentry-cli releases set-commits $(json.version) --local --ignore-missing
       sentry-cli releases files $(json.version) upload-sourcemaps www/browser -x .js -x .map --dist $(json.revision) --validate --verbose --rewrite --strip-common-prefix --url-prefix=~
       sentry-cli releases finalize $(json.version)
     displayName: 'Create Sentry release and upload sourcemaps to Sentry'

--- a/pipelines/regobs-web-build-release.yml
+++ b/pipelines/regobs-web-build-release.yml
@@ -64,6 +64,18 @@ stages:
               command: custom
               customCommand: 'run create-version-file'
 
+          - task: Bash@3
+            displayName: Install sentry-cli
+            inputs:
+              targetType: inline
+              script: curl -sL https://sentry.io/get-cli/ | sh
+
+          - script: |
+              sentry-cli releases new $(json.version)
+              sentry-cli releases set-commits $(json.version) --local --ignore-missing
+              sentry-cli releases files $(json.version) upload-sourcemaps www/browser -x .js -x .map --dist $(json.revision) --validate --verbose --rewrite --strip-common-prefix --url-prefix=~
+            displayName: 'Create Sentry release and upload sourcemaps to Sentry'
+
           - task: Npm@1
             displayName: 'npm run build:prod'
             inputs:

--- a/pipelines/regobs-web-build-release.yml
+++ b/pipelines/regobs-web-build-release.yml
@@ -15,7 +15,7 @@ stages:
     jobs:
       - job:
         pool:
-          vmImage: 'windows-latest'
+          vmImage: 'ubuntu-latest'
 
         steps:
           - task: Cache@2

--- a/pipelines/regobs-web-build-release.yml
+++ b/pipelines/regobs-web-build-release.yml
@@ -9,6 +9,9 @@ pr:
 
 name: $(Date:yyyyMMdd)$(Rev:.r)
 
+variables:
+  - group: sentryProperties
+
 stages:
   - stage: 'Build'
     displayName: 'Build'
@@ -69,6 +72,14 @@ stages:
             inputs:
               jsonFile: '$(Build.SourcesDirectory)/src/environments/version.json'
               shouldPrefixVariables: true
+
+          - task: CopyFiles@2
+            displayName: 'Ta med sentry.properties i bygget. Trengs for å lage release i Sentry'
+            inputs:
+              SourceFolder: '$(Agent.TempDirectory)'
+              Contents: |
+                sentry.properties
+              TargetFolder: ./
 
           - task: Bash@3
             displayName: Install sentry-cli

--- a/pipelines/regobs-web-build-release.yml
+++ b/pipelines/regobs-web-build-release.yml
@@ -64,6 +64,12 @@ stages:
               command: custom
               customCommand: 'run create-version-file'
 
+          - task: oneLuckiDevJson2Variable@1
+            displayName: 'Create environment variables from version.json file'
+            inputs:
+              jsonFile: '$(Build.SourcesDirectory)/src/environments/version.json'
+              shouldPrefixVariables: true
+
           - task: Bash@3
             displayName: Install sentry-cli
             inputs:


### PR DESCRIPTION
Nå registrerer vi versjonen i Sentry når vi bygger webappen.
Jeg har også registrert commits vha. denne kommandoen:
`sentry-cli releases set-commits $(json.version) --local --ignore-missing`

Ellers er det meste likt med slik vi sender data til Sentry i bygg av appen.

Jeg har sjekket at commits blir registrert i Sentry ved å kjøre pipelinen til test med denne greina: `feature/ro-2805-lagre-versjon-i-sentry-ved-bygg`:
https://nve.sentry.io/releases/?environment=regObs&project=170000&statsPeriod=24h
 
![image](https://github.com/user-attachments/assets/9feec087-a2f1-4a4c-aef7-76cea1c1321e)

Du ser mer når du klikker på versjonen:
![image](https://github.com/user-attachments/assets/99d0f2b7-6470-4784-b1bb-54b8239ff5c3)

Jeg vet ikke hvor mye lettere det blir å koble en feil til spesifikk commit, det har jeg ikke testet.

