### PR TITLE
Fiks to bugs med kartutsnitt under oppstart av applikasjonen

### DIFF
--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -29,7 +29,6 @@ import {
   URL_PARAM_SE_LON,
 } from 'src/app/core/services/search-criteria/url-params';
 import { GeoHazard } from 'src/app/modules/common-core/models';
-import { settings } from 'src/settings';
 
 type WithMargin = (ob: L.LatLngBoundsExpression, maxMargin: number) => boolean;
 
@@ -53,21 +52,12 @@ export const parseMapViewFromSearchParams = (params: URLSearchParams): IMapView 
   return;
 };
 
-const getInitialMapView = (): IMapView => {
-  const mapView = parseMapViewFromSearchParams(getSearchParams());
-  if (mapView) return mapView;
-
-  const bounds = L.latLngBounds([settings.map.startupBounds.topLeft, settings.map.startupBounds.bottomRight]);
-  return {
-    bounds,
-    center: bounds.getCenter(),
-  };
-};
-
 const getSearchParams = () => {
   const url = new URL(document.location.href);
   return url.searchParams;
 };
+
+const startupMapView = parseMapViewFromSearchParams(getSearchParams());
 
 /**
  * Common data and functions for MapComponent.
@@ -87,10 +77,12 @@ export class MapService {
   private _showUserLocationObservable: Observable<boolean>;
   private _centerMapToUserSubject: Subject<void>;
   private _centerMapToUserObservable: Observable<void>;
-  private _mapViewSubject = new BehaviorSubject<IMapView>(getInitialMapView());
+  private _mapViewSubject = new BehaviorSubject<IMapView | undefined>(startupMapView);
   private _mapView$: Observable<IMapView | undefined>;
   private _noMapExtentAvailable$: Observable<boolean>;
   private _relevantMapChange$: Observable<IMapView>;
+
+  hadStartupMapView = startupMapView !== undefined;
 
   /**
    * Extent, center and zoom for the map in HomePage

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -63,6 +63,7 @@ import { GeoFabComponent } from '../../modules/shared/components/geo-fab/geo-fab
 import { AddMenuComponent } from '../../modules/shared/components/add-menu/add-menu.component';
 import { DataLoadComponent } from '../../modules/data-load/components/data-load/data-load.component';
 import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter-menu/filter-menu.component';
+import { settings } from 'src/settings';
 
 const DEBUG_TAG = 'HomePage';
 
@@ -333,6 +334,12 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
 
   async onMapReady(leafletMap: L.Map) {
     this.map = leafletMap;
+
+    // Hvis applikasjonen har startet opp uten kartutsnitt i url, sett bounds til hele norge (inkl. svalbard)
+    if (!this.mapService.hadStartupMapView) {
+      const bounds = L.latLngBounds([settings.map.startupBounds.topLeft, settings.map.startupBounds.bottomRight]);
+      leafletMap.fitBounds(bounds, { animate: false, noMoveStart: true });
+    }
 
     this.map.on('click', () => {
       this.mapItemBar().hide(); // click outside marker will deselect any marker, so hide the at-a-glance view

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -419,7 +419,7 @@ export const settings: ISettings = {
       searchHistorySize: 5,
     },
     mapSearchZoomToLevel: 13,
-    unknownMapCenter: [59.911197, 10.741059],
+    unknownMapCenter: [61.46125881009806, 7.871872706969867],
     startupBounds: {
       topLeft: [81.256, 3.237107], // NW of Svalbard
       bottomRight: [57.68535, 12.8905], // SE, includes all of Finnmark and southern norway

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -421,8 +421,8 @@ export const settings: ISettings = {
     mapSearchZoomToLevel: 13,
     unknownMapCenter: [61.46125881009806, 7.871872706969867],
     startupBounds: {
-      topLeft: [81.256, 3.237107], // NW of Svalbard
-      bottomRight: [57.68535, 12.8905], // SE, includes all of Finnmark and southern norway
+      topLeft: [80.59833, 3.237107], // NW of Svalbard
+      bottomRight: [57.68535, 31.745317], // SE, includes all of Finnmark and southern norway
     },
     flyToOnGpsZoom: 13,
     maxClusterRadius: 60, // 30,


### PR DESCRIPTION
Kartutsnittet som jeg valgte i #761 var ikke riktig, det inkluderte ikke hele Norge. Denne endringen fikser default kartutsnitt i settings.

Da jeg varslet i helgen ble jeg oppmerksom på en relatert feil. Varslingsverktøyet kan linke til regobs med linker som denne: https://beta.regobs.no/observation/search/list?GeoHazards=10&FromDate=2025-05-01T00:00:00.000Z&ToDate=2025-05-04T22:59:59.999Z&ObserverNickName=kjus@nortind

Den linken har ikke kartutsnitt. Etter endringene i #761 var det ikke mulig å starte applikasjonen uten kartutsnitt lenger. Kartutsnitt ble alltid satt til hele Norge + svalbard. Siden det kartutsnittet var feil fungerer ikke linken over (ingen observasjoner dukker opp, selv om det burde dukket opp minst én).

Jeg har nå endra det til at default kartutsnitt bare settes hvis man starter kartet på home.page.ts uten kartutsnitt i urlen. Det er nå fortsatt mulig å starte listevisninga uten kartutsnitt, og da søke på alle observasjoner i regobs uten kartutsnitt.

Dette kan testes ved å følge denne linken, som tar deg til samme url som over, bare i PR-bygget: https://victorious-water-056410803-774.westeurope.azurestaticapps.net/observation/search/list?GeoHazards=10&FromDate=2025-05-01T00:00:00.000Z&ToDate=2025-05-04T22:59:59.999Z&ObserverNickName=kjus@nortind
