### PR TITLE
Fiks liten feil relatert til RO-1872

### DIFF
--- a/src/app/modules/map/services/map/map.service.ts
+++ b/src/app/modules/map/services/map/map.service.ts
@@ -57,8 +57,6 @@ const getSearchParams = () => {
   return url.searchParams;
 };
 
-const startupMapView = parseMapViewFromSearchParams(getSearchParams());
-
 /**
  * Common data and functions for MapComponent.
  * Some functions and data are based on the map on HomePage only
@@ -77,12 +75,13 @@ export class MapService {
   private _showUserLocationObservable: Observable<boolean>;
   private _centerMapToUserSubject: Subject<void>;
   private _centerMapToUserObservable: Observable<void>;
-  private _mapViewSubject = new BehaviorSubject<IMapView | undefined>(startupMapView);
   private _mapView$: Observable<IMapView | undefined>;
   private _noMapExtentAvailable$: Observable<boolean>;
   private _relevantMapChange$: Observable<IMapView>;
 
-  hadStartupMapView = startupMapView !== undefined;
+  // Disse to baserer seg på samme variabel og må initialiseres sammen i constructor
+  private _mapViewSubject: BehaviorSubject<IMapView | undefined>;
+  hadStartupMapView: boolean;
 
   /**
    * Extent, center and zoom for the map in HomePage
@@ -147,6 +146,10 @@ export class MapService {
   }
 
   constructor() {
+    const startupMapView = parseMapViewFromSearchParams(getSearchParams());
+    this.hadStartupMapView = startupMapView != undefined;
+    this._mapViewSubject = new BehaviorSubject<IMapView | undefined>(startupMapView);
+
     this._showUserLocationSubject = new BehaviorSubject<boolean>(true);
     this._showUserLocationObservable = this._showUserLocationSubject.asObservable();
     this._followModeSubject = new BehaviorSubject<boolean>(false);


### PR DESCRIPTION
Endringene jeg la til i #774 innførte en annen liten feil med initialisering av kartutsnitt under oppstarten.
Denne fiksen retter den feilen. Parsing av kartutsnitt fra regobs.no-query-parametere bør nå fungere igjen.

Denne linken skulle tatt deg til Kolsås: https://test.regobs.no/?SelectedNumberOfDays=3&&NWLat=59.921151191973635&NWLon=10.498799621737703&SELat=59.91246049971994&SELon=10.539161502993808

Dette er nå fiksa:
https://victorious-water-056410803-776.westeurope.azurestaticapps.net/?SelectedNumberOfDays=3&&NWLat=59.921151191973635&NWLon=10.498799621737703&SELat=59.91246049971994&SELon=10.539161502993808