### PR TITLE
RO-1872: Fiks feil med mapping av geohazards

### DIFF
--- a/src/app/core/services/search-criteria/url-params.ts
+++ b/src/app/core/services/search-criteria/url-params.ts
@@ -30,7 +30,14 @@ const OLD_PARAM_CONFIG: OldParamConfig[] = [
   { oldKey: 'NWLon', newKey: URL_PARAM_NW_LON },
   { oldKey: 'SELat', newKey: URL_PARAM_SE_LAT },
   { oldKey: 'SELon', newKey: URL_PARAM_SE_LON },
-  { oldKey: 'GeoHazards', newKey: URL_PARAM_GEOHAZARD },
+  {
+    oldKey: 'GeoHazards',
+    newKey: URL_PARAM_GEOHAZARD,
+    mapper: (params, oldKey) => {
+      const values = params.getAll(oldKey);
+      return arrayToSeparatedString(values);
+    },
+  },
   { oldKey: 'SelectedNumberOfDays', newKey: URL_PARAM_DAYSBACK },
   { oldKey: 'FromDate', newKey: URL_PARAM_FROMDATE },
   { oldKey: 'ToDate', newKey: URL_PARAM_TODATE },


### PR DESCRIPTION
Siden GeoHazards kan angis flere ganger må den parses som et array.
Denne endringen fikser det.

Denne urlen skal åpne regobs i listevisninga for snø:

https://victorious-water-056410803-777.westeurope.azurestaticapps.net/observation/search/list?GeoHazards=10&SelectedNumberOfDays=3&Countries=578

Denne skal åpne med jord og vann:

https://victorious-water-056410803-777.westeurope.azurestaticapps.net/observation/search/list?GeoHazards=60&GeoHazards=20&SelectedNumberOfDays=3&Countries=578