### PR TITLE
BUG: fikse typo i bilde beskrivelsen på små skjermer

### DIFF
--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
@@ -91,7 +91,7 @@ ion-fab-button::part(native):hover {
 }
 
 @media (max-width: 700px) {
-  .image-descritpion__params {
+  .image-description__params {
     grid-template-columns: 1fr;
   }
   .image-description__content {


### PR DESCRIPTION
Den viser nå kun 1 tekst kolonne på små skjermer i beskrivelsen i bilde karuselle