### PR TITLE
RO-2756: bruke gps på nye observasjoner på mobil

### DIFF
--- a/src/app/modules/registration/pages/obs-location/obs-location.page.ts
+++ b/src/app/modules/registration/pages/obs-location/obs-location.page.ts
@@ -33,6 +33,8 @@ import { HeaderColorDirective } from '../../../shared/directives/header-color/he
 import { TranslatePipe } from '@ngx-translate/core';
 import moment from 'moment';
 import { InitDraft } from 'src/app/core/services/draft/init-draft.model';
+import { Capacitor } from '@capacitor/core';
+import { GeoPositionService } from 'src/app/core/services/geo-position/geo-position.service';
 
 @Component({
   selector: 'app-obs-location',
@@ -61,6 +63,7 @@ export class ObsLocationPage implements OnInit, OnDestroy {
   private fullscreenService = inject(FullscreenService);
   private swipeBackService = inject(SwipeBackService);
   private userSettingService = inject(UserSettingService);
+  private geoPositionService = inject(GeoPositionService);
 
   locationMarker!: L.Marker;
   isLoaded = false;
@@ -129,6 +132,13 @@ export class ObsLocationPage implements OnInit, OnDestroy {
         LocationDescription: obsLocation.LocationDescription,
         Id: obsLocation.ObsLocationID,
       };
+    }
+    // hvis man bruker appen på mobil, og registerer en ny observajon - kan vi sette posisjonen fra gps
+    else if (Capacitor.isNativePlatform()) {
+      const position = await this.geoPositionService.getSingleCurrentPosition();
+      if (position && position.coords) {
+        this.setLocationMarker(position.coords.latitude, position.coords.longitude);
+      }
     }
 
     this.ngZone.run(() => {


### PR DESCRIPTION
I dag når man åpner appen på mobil, panorerer ut fra sin posisjon, og prøver å starte en ny observasjon "derfra", posisjon blir ikke sentrert på faktisk mobil/bruker posisjonen.

Vi skal nå kunne se vår posisjon når vi starter en ny observasjon på mobil (må gi tillatelsen selvfølgelig). Jeg så at vi gjør en del "if" sjekker i obs-location.page. Der manglet vi egentlig en logikk på tilfellen hvor man er faktisk på mobil og kan bruke gps, istedet for default posisjon.

Jeg testet på android.