### PR TITLE
RO-2886: import user-marker.scss i global.scss

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -22,22 +22,20 @@
 @import '@ionic/angular/css/padding.css';
 @import '@ionic/angular/css/float-elements.css';
 @import '@ionic/angular/css/text-alignment.css';
-@import '@ionic/angular/css/text-transformation.css';
 @import '@ionic/angular/css/flex-utils.css';
-
+@import './app/core/helpers/leaflet/user-marker/user-marker.scss';
+@import '@ionic/angular/css/text-transformation.css';
 /**
  * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
-
 // @import "@ionic/angular/css/palettes/dark.always.css";
 // @import "@ionic/angular/css/palettes/dark.class.css";
 // @import '@ionic/angular/css/palettes/dark.system.css';
 // @import '@ionic/angular/css/palettes/high-contrast.system.css';
 // @import '@ionic/angular/css/palettes/high-contrast-dark.system.css';
-
 /* Font for arrows */
 @font-face {
   font-family: 'Custom Arrows';


### PR DESCRIPTION
Custom user marker styling import manglet i applikasjonen, derfor ble vårt ikon aldri vist.
Siden user-marker ikke er en komponent, må jeg importere user-marker.scss direkte i global.scss.
Nå burde posisjon ikone vises i tillegg til accuracy sirkelen. 