### PR TITLE
RO-2854: håndtere ukjent komeptanse når den er returnert som null fra api 

### DIFF
--- a/src/app/components/competence/competence.component.html
+++ b/src/app/components/competence/competence.component.html
@@ -10,10 +10,6 @@
 </ng-template>
 <ng-template #noStars>
   <ion-label class="small-text">
-    @if (competenceLevelName(); as competence) {
-      {{ competence }}
-    } @else {
-      {{ "COMPETENCE.UNKNOWN" | translate }}
-    }
+    {{ "COMPETENCE.UNKNOWN" | translate }}
   </ion-label>
 </ng-template>

--- a/src/app/components/competence/competence.component.ts
+++ b/src/app/components/competence/competence.component.ts
@@ -12,6 +12,6 @@ import { TranslatePipe } from '@ngx-translate/core';
 })
 export class CompetenceComponent {
   readonly maxCompetenceLevel = 5;
-  readonly competenceLevelName = input<string>();
+  readonly competenceLevelTID = input<number>();
   readonly starCount = input<number>();
 }

--- a/src/app/components/map-item-bar/map-item-bar.component.html
+++ b/src/app/components/map-item-bar/map-item-bar.component.html
@@ -54,7 +54,7 @@
             <div class="card-icon-item">
               <app-competence
                 [starCount]="starCount()"
-                [competenceLevelName]="registration()?.CompetenceLevelTID?.toString()"
+                [competenceLevelTID]="registration()?.CompetenceLevelTID"
               ></app-competence>
             </div>
           </ion-col>

--- a/src/app/components/observation/observation/observation.component.html
+++ b/src/app/components/observation/observation/observation.component.html
@@ -80,7 +80,9 @@
       <ion-icon name="person-circle-outline"></ion-icon>
       <!-- https://css-tricks.com/five-methods-for-five-star-ratings/#method-5-using-unicode-symbols -->
       <ion-label>
-        {{ registration().Observer.NickName }} ({{ registration().Observer.CompetenceLevelName }})
+        {{ registration().Observer.NickName }} ({{
+          registration().Observer.CompetenceLevelName || "COMPETENCE.UNKNOWN_SHORT" | translate
+        }})
       </ion-label>
     </ion-chip>
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -56,7 +56,8 @@
     "WEST_SHORT": "W"
   },
   "COMPETENCE": {
-    "UNKNOWN": "Competence unknown"
+    "UNKNOWN": "Competence unknown",
+    "UNKNOWN_SHORT": "Unknown"
   },
   "DATA_LOAD": {
     "DATA": "Loading...",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -56,7 +56,8 @@
     "WEST_SHORT": "V"
   },
   "COMPETENCE": {
-    "UNKNOWN": "Ukjent kompetanse"
+    "UNKNOWN": "Ukjent kompetanse",
+    "UNKNOWN_SHORT": "Ukjent"
   },
   "DATA_LOAD": {
     "DATA": "Laster data...",


### PR DESCRIPTION
Når man lager en ny observasjon med ukjent kompetanse kommer ofte svar fra api Registration POST med null som kompetanse navn 
![image](https://github.com/user-attachments/assets/1e3f3328-401d-4c1d-b3d9-92ca37b1ff43)
Det gjør at man ser tomme parenteser i sin kompetanse på observasjonen. For å unngå dette lager jeg 'Unknown' prop i språkfil som skal erstatte eventuelt mangel på CompetenceName. 
Jeg har også oppdatert app-competence komponent fordi den tok CompetenceTID property, ikke CompetenceName for å vise stjerner. 