### PR TITLE
RO-2753: fikse tekst zoom problem i date-picker

### DIFF
--- a/android/app/src/main/java/no/nve/regobs4/MainActivity.java
+++ b/android/app/src/main/java/no/nve/regobs4/MainActivity.java
@@ -2,11 +2,26 @@ package no.nve.regobs4;
 
 import com.getcapacitor.BridgeActivity;
 import android.os.Bundle;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.content.res.Configuration;
 
 public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         registerPlugin(DownloadAndUnzipPlugin.class);
         super.onCreate(savedInstanceState);
+        float fontScale = getResources().getConfiguration().fontScale;
+        WebView webView = (WebView) this.bridge.getWebView();
+        WebSettings webSettings = webView.getSettings();
+
+        // På Android-enheter må vi sørge for at teksten i appen ikke blir større enn 120%,
+        // selv om brukeren har valgt en større skrifttype i systeminnstillingene (fontScale > 1.2).
+        // Grunnen er at ion-datetime-komponenten (spesielt wheel-visningen) ikke håndterer større tekststørrelser riktig,
+        // og det kan føre til at hjulet ikke stopper å rulle når brukeren først begynner å dra. Forskjellige maks
+        // zoomer ble testet, og 120 er maks som kan tåles dessverre. 
+        if (fontScale > 1.2) {
+            webSettings.setTextZoom(120);
+        }
     }
 }


### PR DESCRIPTION
Per i dag når man setter en stør system skrifttype stopper hjulet i dato-velger ikke når man først starter å dra den. Grunnen var beskrevet i github sakene på[ ionic sine issues ](https://github.com/ionic-team/ionic-framework/issues/29713).
Problemet burde bli løst på ionic sin side, men det ser slik ut at de slitter med[ det selv](https://github.com/ionic-team/ionic-framework/issues/25964#issuecomment-1517917335).

Jeg prøvde å sette font-size via ::part(wheel-item) men den blir alltid overskrevet når men endrer størrelsen via system innstillingene på android.

Jeg prøvde også å bruke vanlig kalender velger istedet for hjulet, men den hjalp ikke så mye. 
![967cf0b5-c241-4222-97f4-78ba1615f880](https://github.com/user-attachments/assets/a192d1dc-9550-486f-ac17-d8eb6945451e)
Nemlig ionic gjør at man må velge dato og tid separat når stor skrifttype er satt. Og tidspunkt velges med hjulet uansett... 

Endelig valge jeg en ganske eksrem løsning. Ekstrem fordi den påvirker tilgjengelihet i hele appen. Tydeligvis er det eneste løsningen som finnes [per i dag](https://github.com/ionic-team/ionic-framework/issues/29713#issuecomment-2872843759), og jeg klarte å finne. Den gjør at den setter maks textSize i appen.
Jeg testet forskjellige teskt zoom properties, og ser ut at hjulen slutter ikke å rolle når man setter textZoom større en 120. Så 120 må være grensa vi kan ha i appen. Jeg testet også hvilken font størrelsen fra selve system innstillingene vil sette textZoom til 120+ og det ble 1.3 som kanksje gir mening fordi jeg tipper at 1.3 er 130 zoom, og 1.2 er 120. Så hvis man har lyst til å ha en mindre tekst er det ikke påvirket. Vil man ha veldig stør tekst, kan man ha maks 120 zoom altså 1.2. Syns det er en fornuftig kompromis, og det fungerer i alle fall. 

