### PR TITLE
RO-2094: håndtere valg av sørpeskred i filtermeny

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -557,15 +557,15 @@ export class SearchCriteriaService {
       SubTypes: [RegistrationTid.AvalancheObs],
     };
     if (slushFlow) {
-      this.searchCriteriaChanges.next({ PropertyFilters: [CRITERIA_SLUSH_FLOW] });
-
-      // turn on avalancheObs automatically since slush flow is a type of avalancheObs
-      this.setObservationType(avalacheObsType);
+      this.searchCriteriaChanges.next({
+        PropertyFilters: [CRITERIA_SLUSH_FLOW],
+        SelectedRegistrationTypes: [avalacheObsType], //Fjerner alt annet bortsett fra skredhendelse
+      });
     } else {
       this.searchCriteriaChanges.next({ PropertyFilters: undefined });
 
       // turn off avalancheObs automatically since slush flow is a type of avalancheObs
-      this.removeObservationType(avalacheObsType);
+      await this.removeObservationType(avalacheObsType);
     }
   }
 

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.html
@@ -47,7 +47,8 @@
                 @for (group of groupsWithIsCheckedComputed(); track group.id) {
                   <ion-item>
                     <ion-checkbox
-                      [checked]="group?.isChecked"
+                      [checked]="!isSlushFlowFilterActive() && group?.isChecked"
+                      [disabled]="isSlushFlowFilterActive()"
                       (ionChange)="toggleObservationGroup($event.detail.checked, group.id, group.subTypes)"
                       labelPlacement="end"
                       justify="start"
@@ -59,7 +60,8 @@
                     @for (type of group?.subTypes; track type.id) {
                       <ion-item class="subtype">
                         <ion-checkbox
-                          [checked]="!slushFlowFilterIsActive && type.isChecked"
+                          [checked]="!isSlushFlowFilterActive() && type.isChecked"
+                          [disabled]="isSlushFlowFilterActive()"
                           labelPlacement="end"
                           justify="start"
                           (ionChange)="toggleObservationType($event.detail.checked, type.parentId, type.id)"
@@ -69,7 +71,7 @@
                     }
                   }
                 }
-                <app-slush-flow-filter> </app-slush-flow-filter>
+                <app-slush-flow-filter [label]="slushFlowLabel()"> </app-slush-flow-filter>
               </ion-list>
             </div>
           </ion-accordion>

--- a/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/side-menu/components/filter-menu/filter-menu.component.ts
@@ -15,9 +15,9 @@ import {
   IonContent,
   IonListHeader,
 } from '@ionic/angular/standalone';
-import { ChangeDetectionStrategy, Component, OnInit, Signal, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, Signal, computed, inject, signal } from '@angular/core';
 import { distinctUntilChanged, map } from 'rxjs/operators';
-import { SearchCriteriaService } from 'src/app/core/services/search-criteria/search-criteria.service';
+import { SearchCriteriaService, SLUSH_FLOW_ID } from 'src/app/core/services/search-criteria/search-criteria.service';
 import { UserSettingService } from '../../../../core/services/user-setting/user-setting.service';
 import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 import { RegistrationTypeCriteriaDto, RegistrationTypeDto } from 'src/app/modules/common-regobs-api';
@@ -39,6 +39,7 @@ import { HeaderWithSelectedItemsComponent } from '../header-with-selected-items/
 import { RegionFilterComponent } from '../region-filter/region-filter.component';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 import { Capacitor } from '@capacitor/core';
+import { KdvService } from 'src/app/modules/common-registration/registration.services';
 
 // Return true if not changed
 export function arrayHasNotChanged<T>(prev: Immutable<Array<T>>, curr: Immutable<Array<T>>) {
@@ -85,6 +86,8 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
   private userSettingService = inject(UserSettingService);
   private searchCriteriaService = inject(SearchCriteriaService);
   private searchCriteriaModelService = inject(SearchCriteriaModelService);
+  private kdvService = inject(KdvService);
+  private slushFlowKdv = toSignal(this.kdvService.getKdvRepositoryByKeyObservable('Snow_AvalancheKDV'));
   observationTypeGroups = toSignal(this.searchCriteriaModelService.getObservationTypeGroups$());
 
   private currentGeoHazard = toSignal(this.userSettingService.currentGeoHazard$, { initialValue: [GeoHazard.Snow] });
@@ -170,7 +173,14 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
 
   showObservations$ = this.userSettingService.showObservations$;
 
-  slushFlowFilterIsActive = false;
+  isSlushFlowFilterActive = signal(false);
+  slushFlowLabel = computed(() => {
+    const slushFlowLabel = this.slushFlowKdv()?.find((type) => type.Id === SLUSH_FLOW_ID);
+    if (slushFlowLabel && slushFlowLabel.Name) {
+      return slushFlowLabel.Name;
+    }
+    return 'Slush flow'; // fallback name
+  });
 
   // returnerer observasjonstyper med evt. grupper
   groupsWithIsCheckedComputed = computed(() => {
@@ -198,7 +208,8 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
 
   // Returnerer navn på valgte observasjonstyper
   selectedObservationTypes: Signal<string[]> = computed(() => {
-    const result: string[] = [];
+    let result: string[] = [];
+
     const groups = this.groupsWithIsCheckedComputed();
     for (const group of groups) {
       if (group.subTypes?.length) {
@@ -214,6 +225,15 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
         }
       }
     }
+
+    // Slushflow er eneste som skal returneres hvis isSlushFlowFilterActive er true
+    if (this.isSlushFlowFilterActive()) {
+      const slushFlowLabel = this.slushFlowLabel();
+      if (slushFlowLabel) {
+        result = [slushFlowLabel];
+      }
+    }
+
     return result;
   });
 
@@ -224,7 +244,7 @@ export class FilterMenuComponent extends NgDestoryBase implements OnInit {
 
   async ngOnInit() {
     this.searchCriteriaService.searchCriteria$.subscribe((criteria) => {
-      this.slushFlowFilterIsActive = this.searchCriteriaService.isSlushFlow(criteria);
+      this.isSlushFlowFilterActive.set(this.searchCriteriaService.isSlushFlow(criteria));
     });
   }
 

--- a/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.html
+++ b/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.html
@@ -1,5 +1,5 @@
 <ion-item *ngIf="visible$ | async">
   <ion-checkbox [checked]="value$ | async" (ionChange)="setValue($event)" labelPlacement="end" justify="start">
-    {{ caption$ | async }}</ion-checkbox
+    {{ label() }}</ion-checkbox
   >
 </ion-item>

--- a/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.ts
+++ b/src/app/modules/side-menu/components/slush-flow-filter/slush-flow-filter.component.ts
@@ -1,11 +1,10 @@
 import { IonItem, IonCheckbox } from '@ionic/angular/standalone';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
 import { map } from 'rxjs';
-import { SearchCriteriaService, SLUSH_FLOW_ID } from 'src/app/core/services/search-criteria/search-criteria.service';
+import { SearchCriteriaService } from 'src/app/core/services/search-criteria/search-criteria.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { GeoHazard } from 'src/app/modules/common-core/models';
-import { KdvService } from 'src/app/modules/common-registration/registration.services';
 import { NgIf, AsyncPipe } from '@angular/common';
 
 @Component({
@@ -18,7 +17,7 @@ import { NgIf, AsyncPipe } from '@angular/common';
 export class SlushFlowFilterComponent {
   private searchCriteriaService = inject(SearchCriteriaService);
   private userSettingService = inject(UserSettingService);
-  private kdvService = inject(KdvService);
+  label = input<string>('');
 
   visible$ = this.userSettingService.currentGeoHazard$.pipe(
     map((geoHazard) => {
@@ -30,16 +29,6 @@ export class SlushFlowFilterComponent {
   value$ = this.searchCriteriaService.searchCriteria$.pipe(
     map((criteria) => {
       return this.searchCriteriaService.isSlushFlow(criteria);
-    })
-  );
-
-  caption$ = this.kdvService.getKdvRepositoryByKeyObservable('Snow_AvalancheKDV').pipe(
-    map((avalancheKdvs) => {
-      const slushFlowKdv = avalancheKdvs.find((type) => type.Id === SLUSH_FLOW_ID);
-      if (slushFlowKdv) {
-        return slushFlowKdv.Name;
-      }
-      return "Slush flow'"; // fallback name
     })
   );
 


### PR DESCRIPTION
I dag når man velger sørpeskred vises alle andre filtrene fortsatt i url-en. Man kan fortsette å blande sørpeskred med andre filtrene. Det er ikke ønsket.

Denne PR-en gjør at andre sjekkbokser avsjekkes og deaktiveres når man velger sørpeskred. Accordion header viser også riktig label. 

Jeg har flyttet en del logikk fra slush-flow-filter component til filtermeny for å ha riktig navn på sørpeskred i begge filene.  