### PR TITLE
RO-2875: Ikke gå til hele Norge ved oppstart i app

### DIFF
--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -350,8 +350,10 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
   async onMapReady(leafletMap: L.Map) {
     this.map = leafletMap;
 
-    // Hvis applikasjonen har startet opp uten kartutsnitt i url, sett bounds til hele norge (inkl. svalbard)
-    if (!this.mapService.hadStartupMapView) {
+    // Hvis applikasjonen har startet opp uten kartutsnitt i url, sett bounds til hele norge (inkl. svalbard),
+    // men bare hvis vi ikke har på GPS-sporing (som vi gjør i appen)
+    const followMode = await firstValueFrom(this.mapService.followMode$);
+    if (!this.mapService.hadStartupMapView && !followMode) {
       const bounds = L.latLngBounds([settings.map.startupBounds.topLeft, settings.map.startupBounds.bottomRight]);
       leafletMap.fitBounds(bounds, { animate: false, noMoveStart: true });
     }


### PR DESCRIPTION
Det viste seg at funksjonen som satte standard kartutsnitt ved oppstart, deaktiverte followMode (at kartet zoomer inn på GPS-posisjonen og følger denne).
Dette fordi leaflet.fitBounds() trigget zoomstart-eventet, som igjen skrudde av followMode.

Jeg har testet på web og Android.

Det finnes sikkert mange måter å løse dette på, f.eks. ved å bruke mapComponent sin flyTo() i stedet for leaflet.fitBounds.
En ulempe med å løse det slik jeg har gjort, er at hvis man ikke får GPS-posisjon fra telefonen, f.eks. fordi bruker ikke tillater å dele posisjonsdata, vises det gamle standard kartutsnittet, som var nesten hele sør-Norge, i stedet for det "nye" standard kartusnittet, som er hele Norge.

Så kom gjerne med forslag til bedre løsning!

PS! Denne løser også feilen i oversiktskartet for offlinekart (https://nveprojects.atlassian.net/browse/RO-2893), men ikke feilen på kartutsnitt for valgt kartpakke.