### PR TITLE
RO-2906: fikse app visning på nyere android modeller.

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -14,7 +14,7 @@ const config: CapacitorConfig = {
     },
     Keyboard: {
       resize: KeyboardResize.Ionic,
-      resizeOnFullScreen: true,
+      resizeOnFullScreen: false,
       style: KeyboardStyle.Default,
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@capacitor/share": "^7.0.0",
         "@capacitor/splash-screen": "^7.0.0",
         "@capacitor/status-bar": "^7.0.0",
+        "@capawesome/capacitor-android-edge-to-edge-support": "^7.2.2",
         "@geoman-io/leaflet-geoman-free": "^2.13.1",
         "@ionic/angular": "^8.4.0",
         "@ionic/storage-angular": "^4.0.0",
@@ -4293,6 +4294,25 @@
       "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.2.tgz",
       "integrity": "sha512-ynq39s4D2rhk+aVLWKfKfMCz9SHPKijL9tq8aFL5dG7ik7/+PvBHmg9cPHbqdvFEUSMmaGzL6cIjzkOruW7vGA==",
       "license": "ISC"
+    },
+    "node_modules/@capawesome/capacitor-android-edge-to-edge-support": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@capawesome/capacitor-android-edge-to-edge-support/-/capacitor-android-edge-to-edge-support-7.2.2.tgz",
+      "integrity": "sha512-AAqCFswAVlA6WX0iaVbMCEnt/2mNBZGmU3JbbFlqWAg61NCMxm8+JlmiNoG+6wf/6S/BWVRL8Ac3L9csaZH/8w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "11.0.3",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@capacitor/share": "^7.0.0",
     "@capacitor/splash-screen": "^7.0.0",
     "@capacitor/status-bar": "^7.0.0",
+    "@capawesome/capacitor-android-edge-to-edge-support": "^7.2.2",
     "@geoman-io/leaflet-geoman-free": "^2.13.1",
     "@ionic/angular": "^8.4.0",
     "@ionic/storage-angular": "^4.0.0",


### PR DESCRIPTION
Jeg forsøker å bruker [denne pluginen](https://capawesome.io/plugins/android-edge-to-edge-support/) som jeg fant på nettet.
Det virker som den skal. Appen vises nå riktig. Det er ikke mulig å teste det på de gamle android gjenstander er jeg redd, men vi må uansett teste om endringene ikke påvirker de. 

Jeg prøvde å installere Capacitor 7.2.0 fordi det står i release notes at de fiksa det, men jeg fikk ikke noe resultat. Feilen var fortsatt der. Det var kun pluginen som hjalp så langt. 