### PR TITLE
RO-2910: fjerne upgrade-insecure-requests fra index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,10 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
     <!-- Ikke endre direkte. Sjekk README.md for å se hvordan man oppdaterer Content-Security-Policy -->
-    <meta http-equiv="Content-Security-Policy" content="connect-src 'self' https://plausible.io https://offlinemap.blob.core.windows.net https://nveb2c01prod.b2clogin.com https://nveb2c01test.b2clogin.com https://nveb2c01staging.b2clogin.com https://api.regobs.no https://test-api.regobs.no https://demo-api.regobs.no https://api01.nve.no https://ws.geonorge.no/stedsnavn https://secure.geonames.org https://www.iskart.no https://sentry.io; upgrade-insecure-requests; form-action 'self'; object-src 'none'; font-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://plausible.io; worker-src 'self' blob:; default-src 'self' data: gap: cdvfile: blob:; img-src * filesystem: app-file: cdvfile: data: blob:; media-src * blob:" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="connect-src 'self' https://plausible.io https://offlinemap.blob.core.windows.net https://nveb2c01prod.b2clogin.com https://nveb2c01test.b2clogin.com https://nveb2c01staging.b2clogin.com https://api.regobs.no https://test-api.regobs.no https://demo-api.regobs.no https://api01.nve.no https://ws.geonorge.no/stedsnavn https://secure.geonames.org https://www.iskart.no https://sentry.io; form-action 'self'; object-src 'none'; font-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://plausible.io; worker-src 'self' blob:; default-src 'self' data: gap: cdvfile: blob:; img-src * filesystem: app-file: cdvfile: data: blob:; media-src * blob:"
+    />
 
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icon/apple-touch-icon.png" />
     <link rel="icon" type="image/png" href="assets/icon/favicon.ico" />


### PR DESCRIPTION
 upgrade-insecure-requests sørger at alle http koblinger byttes om til http på siden. Hvis vi setter headeren i index.html påvirker det localhost versjon av appen. Chrome og Edge ignorerer den fra localhost, noe som Safari ikke gjør. Derfor vil localhost ikke fungere i Safari. Vi trenger ikke å ha headeren i index.html egentlig. Prod versjon av appen bruker kun https protokol uansett. Derfor sletter vi den så at den ikke skaper støy på localhost i safari. 