### PR TITLE
RO-2893: Fiks feil med kartet i kartpakke-modal

### DIFF
--- a/src/app/modules/map/components/map-controls/map-controls.component.html
+++ b/src/app/modules/map/components/map-controls/map-controls.component.html
@@ -1,6 +1,10 @@
-<div class="map-controls" [ngClass]="{ fullscreen: (fullscreen$ | async) }">
-  <app-map-search></app-map-search>
-  <app-fullscreen-toggle *ngIf="showFullscreenToggle()"></app-fullscreen-toggle>
-  <app-gps-center *ngIf="showGpsCenter()"></app-gps-center>
+<app-map-search></app-map-search>
+@if (showFullscreenToggle()) {
+  <app-fullscreen-toggle></app-fullscreen-toggle>
+}
+@if (showGpsCenter()) {
+  <app-gps-center></app-gps-center>
+}
+@if (showZoomButtons()) {
   <app-map-zoom></app-map-zoom>
-</div>
+}

--- a/src/app/modules/map/components/map-controls/map-controls.component.scss
+++ b/src/app/modules/map/components/map-controls/map-controls.component.scss
@@ -1,4 +1,4 @@
-.map-controls {
+:host {
   position: relative;
   top: 10px;
   right: 10px;
@@ -7,8 +7,4 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 2px;
-
-  &.fullscreen {
-    top: var(--fab-fullscreen-top);
-  }
 }

--- a/src/app/modules/map/components/map-controls/map-controls.component.ts
+++ b/src/app/modules/map/components/map-controls/map-controls.component.ts
@@ -1,6 +1,4 @@
-import { Component, inject, input } from '@angular/core';
-import { FullscreenService } from '../../../../core/services/fullscreen/fullscreen.service';
-import { NgClass, NgIf, AsyncPipe } from '@angular/common';
+import { Component, input } from '@angular/core';
 import { MapSearchComponent } from './map-search/map-search.component';
 import { FullscreenToggleComponent } from './fullscreen-toggle/fullscreen-toggle.component';
 import { GpsCenterComponent } from './gps-center/gps-center.component';
@@ -10,20 +8,10 @@ import { MapZoomComponent } from './map-zoom/map-zoom.component';
   selector: 'app-map-controls',
   templateUrl: './map-controls.component.html',
   styleUrls: ['./map-controls.component.scss'],
-  imports: [
-    NgClass,
-    MapSearchComponent,
-    NgIf,
-    FullscreenToggleComponent,
-    GpsCenterComponent,
-    MapZoomComponent,
-    AsyncPipe,
-  ],
+  imports: [MapSearchComponent, FullscreenToggleComponent, GpsCenterComponent, MapZoomComponent],
 })
 export class MapControlsComponent {
-  private fullscreenService = inject(FullscreenService);
-
   readonly showFullscreenToggle = input(true);
   readonly showGpsCenter = input(true);
-  fullscreen$ = this.fullscreenService.isFullscreen$;
+  readonly showZoomButtons = input(true);
 }

--- a/src/app/modules/map/components/map/map.component.html
+++ b/src/app/modules/map/components/map/map.component.html
@@ -1,5 +1,5 @@
-@if (loaded && options) {
-  <div leaflet [leafletOptions]="options" (leafletMapReady)="onLeafletMapReady($event)"></div>
+@if (options() !== undefined) {
+  <div leaflet [leafletOptions]="options()!" (leafletMapReady)="onLeafletMapReady($event)"></div>
 }
 <app-map-controls [showFullscreenToggle]="showFullscreenToggle()" [showGpsCenter]="showGpsCenter()"></app-map-controls>
 

--- a/src/app/modules/map/components/map/map.component.html
+++ b/src/app/modules/map/components/map/map.component.html
@@ -1,7 +1,13 @@
 @if (options() !== undefined) {
   <div leaflet [leafletOptions]="options()!" (leafletMapReady)="onLeafletMapReady($event)"></div>
 }
-<app-map-controls [showFullscreenToggle]="showFullscreenToggle()" [showGpsCenter]="showGpsCenter()"></app-map-controls>
+@if (showControls()) {
+  <app-map-controls
+    [showFullscreenToggle]="showFullscreenToggle()"
+    [showGpsCenter]="showGpsCenter()"
+    [showZoomButtons]="showZoomButtons()"
+  ></app-map-controls>
+}
 
 @if (showObserverTrips()) {
   <div

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -96,6 +96,8 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   private mapZoomService = inject(MapZoomService);
   private observerTripsService = inject(ObserverTripsService);
 
+  readonly showControls = input(true);
+  readonly showZoomButtons = input(true);
   readonly showMapSearch = input(true);
   readonly showFullscreenToggle = input(true);
   readonly showGpsCenter = input(true);

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -13,6 +13,7 @@ import {
   input,
   effect,
   untracked,
+  signal,
 } from '@angular/core';
 import { Capacitor } from '@capacitor/core';
 import { Position } from '@capacitor/geolocation';
@@ -138,7 +139,6 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   private observationTripLayers?: L.GeoJSON[] | null;
   private removeObserverTripEventHandlers = new Subject<void>();
 
-  loaded = false;
   private map?: L.Map;
   private layerGroup = L.layerGroup();
   private offlineTopoLayerGroup = L.layerGroup();
@@ -152,7 +152,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
   private offlineMapService?: OfflineMapService;
   private bounds?: L.LatLngBounds;
 
-  options?: L.MapOptions;
+  options = signal<L.MapOptions | undefined>(undefined);
 
   constructor() {
     // Update map view when map center input changes
@@ -190,13 +190,23 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     this.isActive = new BehaviorSubject(false);
   }
 
-  async ngOnInit() {
+  ngOnInit() {
     this.mapService.showUserLocation = this.showUserLocation();
     this.mapService.followMode = this.showUserLocation() && this.activateFollowModeOnStartup();
+
+    const autoActivate = this.autoActivate();
+    if (!this.isActive.value && autoActivate) {
+      this.isActive.next(autoActivate);
+    }
+
+    this.initMapOptions();
+  }
+
+  async initMapOptions() {
     const currentView = await firstValueFrom(this.mapService.mapView$);
     this.bounds = currentView?.bounds;
 
-    this.options = {
+    this.options.set({
       zoom: this.zoom() || currentView?.zoom || settings.map.tiles.defaultZoom,
       maxZoom: settings.map.tiles.maxZoom,
       minZoom: settings.map.tiles.minZoom,
@@ -209,14 +219,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
         [-90, 180.0],
       ],
       maxBoundsViscosity: 1.0,
-    };
-
-    const autoActivate = this.autoActivate();
-    if (!this.isActive.value && autoActivate) {
-      this.isActive.next(autoActivate);
-    }
-
-    this.loaded = true;
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -21,6 +21,7 @@
       [autoActivate]="true"
       [geoTag]="'package-map'"
       [zoom]="6"
+      [showZoomButtons]="false"
     ></app-map>
   </div>
 </ion-content>

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -159,9 +159,7 @@ export class OfflineMapPage extends NgDestoryBase {
     // Det har vært et problem at folk tror at det bare er på denne siden
     // offline-kartet finnes. Ved å ikke kunne zoome for langt inn skjønner
     // kanskje folk bedre at denne siden bare er til nedlasting.
-    map.setZoom(7);
     map.setMaxZoom(8);
-    map.setMinZoom(4);
 
     this.tilesLayer = new L.GeoJSON(undefined, {
       onEachFeature: (feature: CompoundPackageFeature, layer) => {

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -155,7 +155,13 @@ export class OfflineMapPage extends NgDestoryBase {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).LEAFLET_MAP = map;
 
+    // Sett noen maks grenser for bruk av kartet mtp zoom.
+    // Det har vært et problem at folk tror at det bare er på denne siden
+    // offline-kartet finnes. Ved å ikke kunne zoome for langt inn skjønner
+    // kanskje folk bedre at denne siden bare er til nedlasting.
     map.setZoom(7);
+    map.setMaxZoom(8);
+    map.setMinZoom(4);
 
     this.tilesLayer = new L.GeoJSON(undefined, {
       onEachFeature: (feature: CompoundPackageFeature, layer) => {

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.css
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.css
@@ -1,9 +1,11 @@
-.map-container {
-  flex-grow: 1;
+.content {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
-.right {
-  text-align: right;
+app-map {
+  flex-grow: 1;
 }
 
 .buttons-container {
@@ -14,12 +16,6 @@
   .buttons-container ion-col {
     flex-basis: 100%;
   }
-}
-
-/*targeting map-conatiner wrapper which is in a shadow-root. look 'part' attribute*/
-::part(scroll) {
-  display: flex;
-  flex-direction: column;
 }
 
 .footer-container {

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.html
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.html
@@ -23,6 +23,7 @@
       (mapReady)="showTileOnMap($event)"
       [updateMapViewOnExtentChange]="false"
       [showControls]="false"
+      [fitBounds]="false"
     ></app-map>
     <ion-grid class="footer-container">
       <ion-row>

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.html
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.html
@@ -1,4 +1,4 @@
-<ion-header translucent>
+<ion-header>
   <ion-toolbar>
     <ion-title>{{
       "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.HEADER" | translate: { name: packageOnServer().getName() }
@@ -9,8 +9,8 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="offline-package-map-wrapper">
-  <div class="map-container" *ngIf="center">
+<ion-content>
+  <div class="content">
     <app-map
       [offlinePackageMode]="true"
       [showMapSearch]="false"
@@ -21,82 +21,84 @@
       [center]="center"
       [zoom]="zoom"
       (mapReady)="showTileOnMap($event)"
+      [updateMapViewOnExtentChange]="false"
+      [showControls]="false"
     ></app-map>
-  </div>
-  <ion-grid class="footer-container">
-    <ion-row>
-      <ion-col size="4">{{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_PRODUCED_DATE" | translate }}</ion-col>
-      <ion-col>{{ packageOnServer().getLastModified() | date: "short" }}</ion-col>
-    </ion-row>
-
-    <ion-row>
-      <ion-col size="4">{{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_SIZE" | translate }}</ion-col>
-      <ion-col>{{
-        "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_SIZE_VALUE_WITH_UNIT"
-          | translate: { size: packageOnServer().getSizeInMiB() | number: "1.0-1" }
-      }}</ion-col>
-    </ion-row>
-
-    <div *ngIf="offlinePackageStatusThatTriggersChangeDetection$ | async as packageStatus; else downloadPackage">
+    <ion-grid class="footer-container">
       <ion-row>
-        <ion-col size="4">{{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_DOWNLOAD_STATUS" | translate }}</ion-col>
-        <ion-col>
-          {{ packageStatus.progress?.description }}
-          <span *ngIf="!!packageStatus.downloadComplete && packageStatus.downloadComplete"
-            >{{
-              "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_DOWNLOADED_DATE"
-                | translate: { date: getDownloadCompleteDate(packageStatus.downloadComplete) | date: "short" }
-            }}
-          </span>
-          <span *ngIf="!packageStatus.downloadComplete">({{ getPercentage(packageStatus) + "%" }})</span>
-        </ion-col>
-        <ion-col size="1">
-          <ion-icon *ngIf="!!packageStatus.downloadComplete" name="checkmark"></ion-icon>
-          <ion-icon *ngIf="!packageStatus.error && packageStatus.progress?.step === 0" name="stopwatch-outline">
-          </ion-icon>
-          <ion-icon *ngIf="!packageStatus.error && packageStatus.progress?.step === 1" name="cloud-download-outline">
-          </ion-icon>
-          <ion-icon *ngIf="!packageStatus.error && packageStatus.progress?.step === 2" name="folder-open-outline">
-          </ion-icon>
-          <ion-icon *ngIf="packageStatus.error" name="warning-outline"></ion-icon>
-        </ion-col>
+        <ion-col size="4">{{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_PRODUCED_DATE" | translate }}</ion-col>
+        <ion-col>{{ packageOnServer().getLastModified() | date: "short" }}</ion-col>
       </ion-row>
-      <ion-row *ngIf="!packageStatus.downloadComplete && !packageStatus.error">
-        <ion-col>
-          <ion-button expand="block" color="danger" (click)="cancel(packageStatus)">{{
-            "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.CANCEL_DOWNLOAD_BUTTON" | translate
-          }}</ion-button>
-        </ion-col>
+
+      <ion-row>
+        <ion-col size="4">{{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_SIZE" | translate }}</ion-col>
+        <ion-col>{{
+          "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_SIZE_VALUE_WITH_UNIT"
+            | translate: { size: packageOnServer().getSizeInMiB() | number: "1.0-1" }
+        }}</ion-col>
       </ion-row>
-      <ion-row class="buttons-container" *ngIf="packageStatus.error">
-        <ion-col>
-          <ion-button expand="block" (click)="startDownload()">{{
-            "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.TRY_AGAIN_BUTTON" | translate
-          }}</ion-button>
-        </ion-col>
-        <ion-col>
-          <ion-button (click)="delete()" expand="block" color="danger">{{
-            "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DELETE_BUTTON" | translate
-          }}</ion-button>
-        </ion-col>
-      </ion-row>
-      <ion-row class="buttons-container" *ngIf="packageStatus.downloadComplete">
-        <ion-col *ngIf="isPackageOutdated">
-          <!-- TODO: Vis hvis det finnes en nyere versjon -->
-          <ion-button expand="block" (click)="update()">
-            <ion-icon slot="start" name="refresh"></ion-icon>
-            {{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.UPDATE_BUTTON" | translate }}
-          </ion-button>
-        </ion-col>
-        <ion-col>
-          <ion-button (click)="delete()" expand="block" color="danger">
-            <ion-icon slot="start" name="trash"></ion-icon>
-            {{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DELETE_BUTTON" | translate }}
-          </ion-button>
-        </ion-col>
-      </ion-row>
-    </div>
-  </ion-grid>
+
+      <div *ngIf="offlinePackageStatusThatTriggersChangeDetection$ | async as packageStatus; else downloadPackage">
+        <ion-row>
+          <ion-col size="4">{{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_DOWNLOAD_STATUS" | translate }}</ion-col>
+          <ion-col>
+            {{ packageStatus.progress?.description }}
+            <span *ngIf="!!packageStatus.downloadComplete && packageStatus.downloadComplete"
+              >{{
+                "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.PACKAGE_DOWNLOADED_DATE"
+                  | translate: { date: getDownloadCompleteDate(packageStatus.downloadComplete) | date: "short" }
+              }}
+            </span>
+            <span *ngIf="!packageStatus.downloadComplete">({{ getPercentage(packageStatus) + "%" }})</span>
+          </ion-col>
+          <ion-col size="1">
+            <ion-icon *ngIf="!!packageStatus.downloadComplete" name="checkmark"></ion-icon>
+            <ion-icon *ngIf="!packageStatus.error && packageStatus.progress?.step === 0" name="stopwatch-outline">
+            </ion-icon>
+            <ion-icon *ngIf="!packageStatus.error && packageStatus.progress?.step === 1" name="cloud-download-outline">
+            </ion-icon>
+            <ion-icon *ngIf="!packageStatus.error && packageStatus.progress?.step === 2" name="folder-open-outline">
+            </ion-icon>
+            <ion-icon *ngIf="packageStatus.error" name="warning-outline"></ion-icon>
+          </ion-col>
+        </ion-row>
+        <ion-row *ngIf="!packageStatus.downloadComplete && !packageStatus.error">
+          <ion-col>
+            <ion-button expand="block" color="danger" (click)="cancel(packageStatus)">{{
+              "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.CANCEL_DOWNLOAD_BUTTON" | translate
+            }}</ion-button>
+          </ion-col>
+        </ion-row>
+        <ion-row class="buttons-container" *ngIf="packageStatus.error">
+          <ion-col>
+            <ion-button expand="block" (click)="startDownload()">{{
+              "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.TRY_AGAIN_BUTTON" | translate
+            }}</ion-button>
+          </ion-col>
+          <ion-col>
+            <ion-button (click)="delete()" expand="block" color="danger">{{
+              "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DELETE_BUTTON" | translate
+            }}</ion-button>
+          </ion-col>
+        </ion-row>
+        <ion-row class="buttons-container" *ngIf="packageStatus.downloadComplete">
+          <ion-col *ngIf="isPackageOutdated">
+            <!-- TODO: Vis hvis det finnes en nyere versjon -->
+            <ion-button expand="block" (click)="update()">
+              <ion-icon slot="start" name="refresh"></ion-icon>
+              {{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.UPDATE_BUTTON" | translate }}
+            </ion-button>
+          </ion-col>
+          <ion-col>
+            <ion-button (click)="delete()" expand="block" color="danger">
+              <ion-icon slot="start" name="trash"></ion-icon>
+              {{ "OFFLINE_MAP.MAP_PACKAGE_DETAILS_PAGE.DELETE_BUTTON" | translate }}
+            </ion-button>
+          </ion-col>
+        </ion-row>
+      </div>
+    </ion-grid>
+  </div>
 </ion-content>
 
 <ng-template #downloadPackage>

--- a/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
+++ b/src/app/pages/offline-map/offline-package-modal/offline-package-modal.component.ts
@@ -139,7 +139,12 @@ export class OfflinePackageModalComponent extends NgDestoryBase implements OnIni
   showTileOnMap(map: L.Map) {
     if (this.tileLayer) {
       this.tileLayer.addTo(map);
+      // Begrens panorering i kartet i modalen
+      map.setMaxBounds(this.tileLayer.getBounds().pad(0.1));
     }
+    // Begrens zooming i kartet i modalen
+    map.setMinZoom(this.zoom);
+    map.setMaxZoom(this.zoom);
   }
 
   async startDownload(): Promise<void> {


### PR DESCRIPTION
Tror feilen skyldtes bruk av async ngOnInit sammen med modal. Ny versjon av angular er kanskje litt mer kresen på hva som skjer i hvilken rekkefølge rundt endringsdetektering? 
Endret til å bruke en signal for å håndtere asynkront oppsett av kartet. Selve bugfiksen er i første commit.

Andre commit inneholder litt opprydning jeg tok i farta mens jeg holdt på:
   - Fjern knapper i kartet der de ikke trengs
  - Sett grenser for panorering og zoom i kartene
  - Fjern unødvendige elementer i map controls
  - Legger til støtte for å skjule zoom-knapper i map-controls

Den andre commiten kan evt sløyfes hvis vi ikke vil ta med den opprydningen her.