### PR TITLE
RO-2899: fikse utsatt høyde visning i skredaktivitet skjema

### DIFF
--- a/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.html
+++ b/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.html
@@ -4,37 +4,24 @@
   }}</ion-label>
   <ion-text class="ion-align-self-start ion-text-wrap ion-margin-bottom">
     <ion-grid class="exposedHight">
-      <ion-row
-        class="top padding-bottom"
-        (click)="toggleExsposedHeightCombo('top')"
-        [ngClass]="{ selected: exposedHeightTop }"
-      >
-        <ion-col size="12" class="ion-text-center ion-align-self-center">
-          {{ "REGISTRATION.SNOW.AVALANCHE_PROBLEM.TOP" | translate }}
-        </ion-col>
-      </ion-row>
-      <ion-row
-        class="middle padding-bottom"
-        (click)="toggleExsposedHeightCombo('middle')"
-        [ngClass]="{ selected: exposedHeightMiddle }"
-      >
-        <ion-col size="12" class="ion-text-center ion-align-self-center">
-          {{ "REGISTRATION.SNOW.AVALANCHE_PROBLEM.MIDDLE" | translate }}
-        </ion-col>
-      </ion-row>
-      <ion-row
-        (click)="toggleExsposedHeightCombo('bottom')"
-        class="bottom"
-        [ngClass]="{ selected: exposedHeightBottom }"
-      >
-        <ion-col size="12" class="ion-text-center ion-align-self-center">
-          {{ "REGISTRATION.SNOW.AVALANCHE_PROBLEM.BOTTOM" | translate }}
-        </ion-col>
-      </ion-row>
+      @for (item of heightEntries(); track item.key) {
+        <ion-row
+          [class]="item.key + ' padding-bottom'"
+          [class.selected]="item.value"
+          (click)="toggleExsposedHeightCombo(item.key)"
+        >
+          <ion-col size="12" class="ion-text-center ion-align-self-center">
+            <p [class.selected]="item.value">
+              {{ "REGISTRATION.SNOW.AVALANCHE_PROBLEM." + item.key.toUpperCase() | translate }}
+            </p>
+          </ion-col>
+        </ion-row>
+      }
     </ion-grid>
   </ion-text>
 </ion-item>
-@if (exposedHeightTop || exposedHeightMiddle || exposedHeightBottom) {
+
+@if (heights().top || heights().middle || heights().bottom) {
   <app-select
     [(selectedValue)]="exposedHeight1"
     [options]="heightArray"

--- a/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.scss
+++ b/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.scss
@@ -5,12 +5,6 @@
     background-position: center !important;
     background-size: contain !important;
 
-    &.selected {
-      ion-col {
-        color: #fff;
-      }
-    }
-
     &.top {
       background: #fff url('/assets/images/mountain-top-grey.png') no-repeat;
       &.selected {
@@ -36,4 +30,8 @@
 
 ion-text {
   width: 100%;
+}
+
+.selected {
+  color: #fff;
 }

--- a/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.ts
+++ b/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.ts
@@ -1,9 +1,9 @@
-import { IonGrid, IonItem, IonRow, IonCol, IonText, IonLabel } from '@ionic/angular/standalone';
-import { Component, model, computed } from '@angular/core';
-import { SelectOption } from '../../../../shared/components/input/select/select-option.model';
 import { NgClass } from '@angular/common';
-import { SelectComponent } from '../../../../shared/components/input/select/select.component';
+import { Component, computed, model, signal } from '@angular/core';
+import { IonCol, IonGrid, IonItem, IonLabel, IonRow, IonText } from '@ionic/angular/standalone';
 import { TranslatePipe } from '@ngx-translate/core';
+import { SelectOption } from '../../../../shared/components/input/select/select-option.model';
+import { SelectComponent } from '../../../../shared/components/input/select/select.component';
 
 interface HeightSelectOption extends SelectOption {
   id: number;
@@ -17,6 +17,12 @@ enum ExposedHeightCombo {
   MiddleBlack = 4,
 }
 
+/** Fjell høyde områder */
+type ExposedHeightPosition = 'top' | 'middle' | 'bottom';
+
+/** Nøkkel er fjell utsatt høyde, verdi er om den er valgt.  */
+type HeightsState = Record<ExposedHeightPosition, boolean>;
+
 @Component({
   selector: 'app-exposed-height',
   templateUrl: './exposed-height.component.html',
@@ -28,9 +34,17 @@ export class ExposedHeightComponent {
   readonly exposedHeight1 = model<number>();
   readonly exposedHeight2 = model<number>();
 
-  exposedHeightTop = false;
-  exposedHeightMiddle = false;
-  exposedHeightBottom = false;
+  // Valgte høyder
+  heights = signal<HeightsState>({
+    top: false,
+    middle: false,
+    bottom: false,
+  });
+
+  // Høyder gjort om til et array for enklere iterasjon i html malen
+  heightEntries = computed(() =>
+    Object.entries(this.heights()).map(([key, value]) => ({ key: key as ExposedHeightPosition, value }))
+  );
 
   heightArray = createHeightArray();
 
@@ -40,80 +54,58 @@ export class ExposedHeightComponent {
   });
 
   ngOnInit() {
-    this.setExposedHeights(this.exposedHeightComboTID());
-  }
-
-  setExposedHeights(exposedHeightComboTID: number | undefined) {
-    if (exposedHeightComboTID === 0) {
-      this.exposedHeightTop = true;
-      this.exposedHeightMiddle = true;
-      this.exposedHeightBottom = true;
-    } else if (exposedHeightComboTID === 1) {
+    if (this.exposedHeightComboTID() === 0) {
+      this.heights.update(() => ({ top: true, middle: true, bottom: true }));
+    } else if (this.exposedHeightComboTID() === 1) {
       // Hvit nederst
-      this.exposedHeightTop = true;
-      this.exposedHeightMiddle = true;
-      this.exposedHeightBottom = false;
-    } else if (exposedHeightComboTID === 2) {
+      this.heights.update((heights) => ({ ...heights, top: true, bottom: true }));
+    } else if (this.exposedHeightComboTID() === 2) {
       // Svart nederst
-      this.exposedHeightTop = false;
-      this.exposedHeightMiddle = false;
-      this.exposedHeightBottom = true;
-    } else if (exposedHeightComboTID === 3) {
+      this.heights.update((heights) => ({ ...heights, bottom: true }));
+    } else if (this.exposedHeightComboTID() === 3) {
       // Hvit i midten
-      this.exposedHeightTop = true;
-      this.exposedHeightMiddle = false;
-      this.exposedHeightBottom = true;
-    } else if (exposedHeightComboTID === 4) {
+      this.heights.update((heights) => ({ ...heights, top: true, bottom: true }));
+    } else if (this.exposedHeightComboTID() === 4) {
       // Svart i midten
-      this.exposedHeightTop = false;
-      this.exposedHeightMiddle = true;
-      this.exposedHeightBottom = false;
-    } else {
-      this.exposedHeightTop = false;
-      this.exposedHeightMiddle = false;
-      this.exposedHeightBottom = false;
+      this.heights.update((heights) => ({ ...heights, middle: true }));
     }
   }
 
   toggleExsposedHeightCombo(position: 'top' | 'middle' | 'bottom') {
-    if (position === 'top') {
-      this.exposedHeightTop = !this.exposedHeightTop;
-    } else if (position === 'middle') {
-      this.exposedHeightMiddle = !this.exposedHeightMiddle;
-    } else {
-      this.exposedHeightBottom = !this.exposedHeightBottom;
-    }
+    this.heights.update((heights) => ({ ...heights, [position]: !heights[position] }));
     this.applyChanges();
   }
 
-  sholdUseExposedHight2() {
-    return (
-      (this.exposedHeightTop && this.exposedHeightBottom && !this.exposedHeightMiddle) ||
-      (!this.exposedHeightTop && !this.exposedHeightBottom && this.exposedHeightMiddle)
-    );
-  }
+  sholdUseExposedHight2 = computed(
+    () =>
+      (this.heights().top && this.heights().bottom && !this.heights().middle) ||
+      (!this.heights().top && !this.heights().bottom && this.heights().middle)
+  );
 
-  private updateExposedHeightComboTID(top: boolean, middle: boolean, bottom: boolean) {
-    if (top && middle && bottom) {
-      this.exposedHeightComboTID.set(ExposedHeightCombo.NotGiven);
-    } else if (!top && middle && !bottom) {
-      this.exposedHeightComboTID.set(ExposedHeightCombo.MiddleBlack);
-    } else if (top && !middle && bottom) {
-      this.exposedHeightComboTID.set(ExposedHeightCombo.MiddleWhite);
-    } else if (bottom) {
-      this.exposedHeightComboTID.set(ExposedHeightCombo.BottomBlack);
-    } else if (top) {
-      this.exposedHeightComboTID.set(ExposedHeightCombo.BottomWhite);
-    } else {
-      this.exposedHeightComboTID.set(undefined);
+  currentExposedHeightComboTID = computed(() => {
+    if (this.heights().top && this.heights().middle && this.heights().bottom) {
+      return ExposedHeightCombo.NotGiven;
     }
-  }
+    if (!this.heights().top && this.heights().middle && !this.heights().bottom) {
+      return ExposedHeightCombo.MiddleBlack;
+    }
+    if (this.heights().top && !this.heights().middle && this.heights().bottom) {
+      return ExposedHeightCombo.MiddleWhite;
+    }
+    if (this.heights().bottom) {
+      return ExposedHeightCombo.BottomBlack;
+    }
+    if (this.heights().top) {
+      return ExposedHeightCombo.BottomWhite;
+    }
+    return undefined;
+  });
 
   applyChanges() {
-    this.updateExposedHeightComboTID(this.exposedHeightTop, this.exposedHeightMiddle, this.exposedHeightBottom);
     if (!this.sholdUseExposedHight2()) {
       this.exposedHeight2.set(undefined);
     }
+    this.exposedHeightComboTID.set(this.currentExposedHeightComboTID());
   }
 }
 

--- a/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.ts
+++ b/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.ts
@@ -1,4 +1,3 @@
-import { NgClass } from '@angular/common';
 import { Component, computed, model, signal } from '@angular/core';
 import { IonCol, IonGrid, IonItem, IonLabel, IonRow, IonText } from '@ionic/angular/standalone';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -27,7 +26,7 @@ type HeightsState = Record<ExposedHeightPosition, boolean>;
   selector: 'app-exposed-height',
   templateUrl: './exposed-height.component.html',
   styleUrls: ['./exposed-height.component.scss'],
-  imports: [IonCol, IonGrid, IonItem, IonLabel, IonRow, IonText, NgClass, SelectComponent, TranslatePipe],
+  imports: [IonCol, IonGrid, IonItem, IonLabel, IonRow, IonText, SelectComponent, TranslatePipe],
 })
 export class ExposedHeightComponent {
   readonly exposedHeightComboTID = model<number>();
@@ -82,7 +81,15 @@ export class ExposedHeightComponent {
       (!this.heights().top && !this.heights().bottom && this.heights().middle)
   );
 
-  currentExposedHeightComboTID = computed(() => {
+  applyChanges() {
+    if (!this.sholdUseExposedHight2()) {
+      this.exposedHeight2.set(undefined);
+    }
+    const currentExposedHeightComboTID = this.currentExposedHeightComboTID();
+    this.exposedHeightComboTID.set(currentExposedHeightComboTID);
+  }
+
+  private currentExposedHeightComboTID(): number | undefined {
     if (this.heights().top && this.heights().middle && this.heights().bottom) {
       return ExposedHeightCombo.NotGiven;
     }
@@ -99,13 +106,6 @@ export class ExposedHeightComponent {
       return ExposedHeightCombo.BottomWhite;
     }
     return undefined;
-  });
-
-  applyChanges() {
-    if (!this.sholdUseExposedHight2()) {
-      this.exposedHeight2.set(undefined);
-    }
-    this.exposedHeightComboTID.set(this.currentExposedHeightComboTID());
   }
 }
 


### PR DESCRIPTION
[Lenke til saken](https://nveprojects.atlassian.net/browse/RO-2899).

I safari forsvinner ledetekstene når man klikker på et høyde nivå i skredaktivitet skjema. 
Jeg klarte ikke å finne noe feil, fordi alt var riktig i DOM-en. Jeg merket at hvis jeg avsjekker farge på fonten i safari, og sjekker den på nytt så ble riktig "bilde" i nettleseren tegnet med riktige farger. Tipper det var noe galt med å skrive tekst direkte i <ion-col>.

Jeg har lagt til de fleste variabler til signaler og computed. Jeg har også bruket et objekt for å strukturere data på valgte høyden. Syns det er nå enklere å endre, html malen ble mindre. 

Jeg bestemte å wrappe teksten med <p> og legge .selected klassen direkte på den hvis høyden er valgt. Viktig å teste den på ios. Det var selve appen på iphone som sleit masse med det. 