### PR TITLE
RO-2900: fikse snøprofil preview modal høyde så at "ok" knappen er synlig på mobil

### DIFF
--- a/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.scss
+++ b/src/app/modules/registration/pages/snow/snow-profile/snow-profile.page.scss
@@ -1,6 +1,6 @@
 ion-modal {
-  --height: 100vh;
-  --width: 100vw;
+  --height: 100%;
+  --width: 100%;
 
   .img-container {
     height: 100%;


### PR DESCRIPTION
Den burde ikke bli satt til 100vh fordi da vokser den utover foreldre kontaineren som har tilpasset høyde på forskjellige gjenstander. Dette burde løse problemet.
Test både i native app og i web på mobil. 