### PR TITLE
RO-2896: fjern swipeGesture fra filtermeny

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -1,8 +1,8 @@
 <ion-split-pane contentId="main-content-home-page">
-  <ion-menu side="start" menuId="filter" contentId="main-content-home-page">
+  <ion-menu side="start" menuId="filter" contentId="main-content-home-page" max-edge-start="0">
     @defer {
       <app-filter-menu>
-        <ion-item lines="full" color="light" swipeGesture="false" button detail="false">
+        <ion-item lines="full" color="light" button detail="false">
           <ion-toggle [checked]="showObservations$ | async" (ionChange)="saveShowObservation($event)">
             {{ "MENU.SHOW_OBSERVATIONS" | translate }}
           </ion-toggle>

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -2,7 +2,7 @@
   <ion-menu side="start" menuId="filter" contentId="main-content-home-page">
     @defer {
       <app-filter-menu>
-        <ion-item lines="full" color="light" button detail="false">
+        <ion-item lines="full" color="light" swipeGesture="false" button detail="false">
           <ion-toggle [checked]="showObservations$ | async" (ionChange)="saveShowObservation($event)">
             {{ "MENU.SHOW_OBSERVATIONS" | translate }}
           </ion-toggle>

--- a/src/app/pages/observation-list/list.page.ts
+++ b/src/app/pages/observation-list/list.page.ts
@@ -14,7 +14,7 @@ import { FilterMenuComponent } from 'src/app/modules/side-menu/components/filter
   selector: 'app-list-page',
   template: `
     <ion-split-pane contentId="main-content-list-page">
-      <ion-menu side="start" menuId="list-filter" contentId="main-content-list-page">
+      <ion-menu side="start" menuId="list-filter" contentId="main-content-list-page" max-edge-start="0">
         @defer {
           <app-filter-menu></app-filter-menu>
         }


### PR DESCRIPTION
Panorering fra venstre kanten i kartet burde ikke åpne filtermeny lenger. Gjelder nativ app bare. 