### PR TITLE
RO-2912: Bilder laster ikke etter innsending av obs

### DIFF
--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.html
@@ -7,7 +7,7 @@
   keyboard="false"
   (swiperslidechange)="setCurrentSlideIndex($event)"
 >
-  @for (attachment of attachments(); track attachment.Url) {
+  @for (attachment of attachments(); track attachment.AttachmentId) {
     @if (attachment.Href) {
       <swiper-slide lazy="true">
         <img

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -22,6 +22,10 @@ import { settings } from 'src/settings';
 import { getRoundedDownOrientationValue } from 'src/app/utils/getRoundedDownOrientationValue';
 import { PlotService } from 'src/app/core/services/plot.service';
 import { Router, RouterLink } from '@angular/router';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { LogLevel } from 'src/app/modules/shared/services/logging/log-level.model';
+
+const DEBUG_TAG = 'ImageCarousel';
 
 @Component({
   selector: 'app-observation-image-carousel',
@@ -34,21 +38,16 @@ export class ObservationImageCarouselComponent {
   readonly swiper = viewChild<ElementRef<SwiperContainer>>('swiper');
   private modalController = inject(ModalController);
   private router = inject(Router);
+  private plotService = inject(PlotService);
+  private logger = inject(LoggingService);
+
   isImageListView = computed(() => this.router.url.includes('search/pictures'));
   attachments = input<(AttachmentViewModel & { Href?: string })[]>([]);
-  plotService = inject(PlotService);
   translateService = inject(TranslateService);
 
   registration = input<RegistrationViewModel>();
   attachmentIndex = model<number>(0);
-  useFallbackSnowProfileImage(attachment: AttachmentViewModel, event: Event) {
-    const target = event.target as HTMLImageElement;
-    if (target.src === attachment.Url) {
-      attachment.Url = 'assets/images/broken-image-w-bg.svg';
-      attachment.Alt = this.translateService.instant('REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE');
-    }
-    this.snowProfileUrl.set(attachment.Url as string);
-  }
+
   roundedDownOrientationValue = computed(() => {
     const aspectValue = this.currentAttachmentData().Aspect; //256
     if (!aspectValue) return '';
@@ -73,8 +72,23 @@ export class ObservationImageCarouselComponent {
     return undefined;
   });
 
+  snowProfileUrl = linkedSignal(() => {
+    const reg = this.registration();
+    if (!reg) return undefined;
+    return this.plotService.getSnowProfileSvgUrl(reg);
+  });
+
   constructor() {
     addIcons({ close, downloadOutline, openOutline, eyeOutline });
+  }
+
+  useFallbackSnowProfileImage(attachment: AttachmentViewModel, event: Event) {
+    const target = event.target as HTMLImageElement;
+    if (target.src === attachment.Url) {
+      attachment.Url = 'assets/images/broken-image-w-bg.svg';
+      attachment.Alt = this.translateService.instant('REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE');
+    }
+    this.snowProfileUrl.set(attachment.Url as string);
   }
 
   closeModal() {
@@ -92,20 +106,24 @@ export class ObservationImageCarouselComponent {
     this.swiper()?.nativeElement.swiper.slideTo(this.attachmentIndex());
   }
 
-  snowProfileUrl = linkedSignal(() => {
-    const reg = this.registration();
-    if (!reg) return undefined;
-    return this.plotService.getSnowProfileSvgUrl(reg);
-  });
-
   setFallbackImage(attachment: AttachmentViewModel) {
     // Raw bildene prosesseres ikke - har ikke vannmerke.
     // De bør derfor kunne hentes med en gang observasjonen har blitt sendt inn.
     // Prøv derfor først å hente de hvis Large har feila.
     if (attachment.UrlFormats && attachment.Url !== attachment.UrlFormats?.Raw) {
+      this.logger.log('Image loading failed. Will try Raw.', null, LogLevel.Warning, DEBUG_TAG, {
+        id: attachment.AttachmentId,
+        img: attachment.Url,
+        raw: attachment.UrlFormats.Raw,
+      });
       attachment.Url = attachment.UrlFormats.Raw;
       return;
     }
+
+    this.logger.error(null, DEBUG_TAG, 'Image loading failed. Will set fallback', {
+      id: attachment.AttachmentId,
+      img: attachment.Url,
+    });
 
     attachment.Url = 'assets/images/broken-image-w-bg.svg';
     attachment.Alt = this.translateService.instant('REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE');

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -99,6 +99,14 @@ export class ObservationImageCarouselComponent {
   });
 
   setFallbackImage(attachment: AttachmentViewModel) {
+    // Raw bildene prosesseres ikke - har ikke vannmerke.
+    // De bør derfor kunne hentes med en gang observasjonen har blitt sendt inn.
+    // Prøv derfor først å hente de hvis Large har feila.
+    if (attachment.UrlFormats && attachment.Url !== attachment.UrlFormats?.Raw) {
+      attachment.Url = attachment.UrlFormats.Raw;
+      return;
+    }
+
     attachment.Url = 'assets/images/broken-image-w-bg.svg';
     attachment.Alt = this.translateService.instant('REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE');
   }

--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.ts
@@ -110,7 +110,7 @@ export class ObservationImageCarouselComponent {
     // Raw bildene prosesseres ikke - har ikke vannmerke.
     // De bør derfor kunne hentes med en gang observasjonen har blitt sendt inn.
     // Prøv derfor først å hente de hvis Large har feila.
-    if (attachment.UrlFormats && attachment.Url !== attachment.UrlFormats?.Raw) {
+    if (attachment.UrlFormats && attachment.Url !== attachment.UrlFormats.Raw) {
       this.logger.log('Image loading failed. Will try Raw.', null, LogLevel.Warning, DEBUG_TAG, {
         id: attachment.AttachmentId,
         img: attachment.Url,

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -193,8 +193,16 @@ export class ObservationComponent {
     if (!attachment.UrlFormats) {
       return;
     }
-    attachment.UrlFormats.Large = 'assets/images/broken-image-w-bg.svg';
-    attachment.Alt = this.translateService.instant('REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE');
+
+    // Raw bildene prosesseres ikke - har ikke vannmerke.
+    // De bør derfor kunne hentes med en gang observasjonen har blitt sendt inn.
+    // Prøv derfor først å hente de hvis Large har feila.
+    if (attachment.UrlFormats.Large !== attachment.UrlFormats.Raw) {
+      attachment.UrlFormats.Large = attachment.UrlFormats.Raw;
+    } else {
+      attachment.UrlFormats.Large = 'assets/images/broken-image-w-bg.svg';
+      attachment.Alt = this.translateService.instant('REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE');
+    }
   }
 
   private fetchRegistrationBeforeEdit(

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -66,6 +66,7 @@ import { AppEventAction } from 'src/app/modules/analytics/enums/app-event-action
 import { REGISTRATION_VIEW_CONFIG } from '../registration-view-config';
 import { ObservationImageCarouselComponent } from '../observation-image-carousel/observation-image-carousel.component';
 import { ModalMapImagePage } from 'src/app/modules/map/pages/modal-map-image/modal-map-image.page';
+import { LogLevel } from 'src/app/modules/shared/services/logging/log-level.model';
 
 const DEBUG_TAG = 'ObservationComponent';
 const FETCH_OBS_TIMEOUT_MS = 5000;
@@ -198,8 +199,17 @@ export class ObservationComponent {
     // De bør derfor kunne hentes med en gang observasjonen har blitt sendt inn.
     // Prøv derfor først å hente de hvis Large har feila.
     if (attachment.UrlFormats.Large !== attachment.UrlFormats.Raw) {
+      this.logger.log('Loading image failed, trying Raw', null, LogLevel.Warning, DEBUG_TAG, {
+        id: attachment.AttachmentId,
+        img: attachment.UrlFormats.Large,
+        raw: attachment.UrlFormats.Raw,
+      });
       attachment.UrlFormats.Large = attachment.UrlFormats.Raw;
     } else {
+      this.logger.log('Loading image failed, setting fallback img', null, LogLevel.Error, DEBUG_TAG, {
+        id: attachment.AttachmentId,
+        img: attachment.UrlFormats.Large,
+      });
       attachment.UrlFormats.Large = 'assets/images/broken-image-w-bg.svg';
       attachment.Alt = this.translateService.instant('REGISTRATION.COULD_NOT_DOWNLOAD_IMAGE');
     }


### PR DESCRIPTION
Denne endringen legger til at appen prøver å laste "Raw"-bilder hvis "Large" eller "Url" feiler. Det legges også til logging.

Det fikses også noen småfeil, blant annet at det var satt opp trackBy på url, men når vi setter trackBy til samme fallback url, vet ikke angular hva den skal gjøre. Nå brukes AttachmentId som bør være unik.