### PR TITLE
RO-2836: Fiks at kart ikke vises etter søk

### DIFF
--- a/src/app/modules/side-menu/components/side-menu.component.html
+++ b/src/app/modules/side-menu/components/side-menu.component.html
@@ -75,15 +75,15 @@
       labelPlacement="stacked"
     >
       <ion-select-option [value]="TopoMap.default">
-        {{ "MENU.TILES.ARC_GIS" | translate }} + {{ "MENU.TILES.KARTVERKET" | translate }} +
-        {{ "MENU.TILES.NORWEGIAN_POLAR_INSTITUTE" | translate }}
+        {{ "MENU.TILES.KARTVERKET" | translate }} + {{ "MENU.TILES.NORWEGIAN_POLAR_INSTITUTE" | translate }} +
+        {{ "MENU.TILES.ARC_GIS" | translate }}
       </ion-select-option>
       <ion-select-option [value]="TopoMap.mixOpenTopo">
-        {{ "MENU.TILES.OPEN_TOPO" | translate }} + {{ "MENU.TILES.KARTVERKET" | translate }} +
-        {{ "MENU.TILES.NORWEGIAN_POLAR_INSTITUTE" | translate }}
+        {{ "MENU.TILES.OPEN_TOPO" | translate }}
       </ion-select-option>
       <ion-select-option [value]="TopoMap.geoDataLandskap">
-        {{ "MENU.TILES.GEODATA_LANDSKAP" | translate }}
+        {{ "MENU.TILES.GEODATA_LANDSKAP" | translate }} + {{ "MENU.TILES.NORWEGIAN_POLAR_INSTITUTE" | translate }} +
+        {{ "MENU.TILES.ARC_GIS" | translate }}
       </ion-select-option>
     </ion-select>
   </ion-item>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -211,6 +211,10 @@ export const settings: ISettings = {
           options: {
             zIndex: MapLayerZIndex.OnlineBackgroundLayer,
             maxNativeZoom: 18,
+            bounds: [
+              [57.9, 4.626617431640625],
+              [71.15939141681443, 31.3],
+            ],
           },
         },
         openTopo: {
@@ -253,11 +257,9 @@ export const settings: ISettings = {
         mixOpenTopo: [
           {
             layer: 'openTopo',
-            options: {
-              zIndex: MapLayerZIndex.OnlineMixedBackgroundLayer,
-            },
-            excludeBounds: [NORWAY_BOUNDS, SVALBARD_BOUNDS],
           },
+        ],
+        geoDataLandskap: [
           {
             layer: 'npolarFkb',
           },
@@ -265,12 +267,14 @@ export const settings: ISettings = {
             layer: 'npolarBasiskart',
           },
           {
-            layer: 'statensKartverk',
-          },
-        ],
-        geoDataLandskap: [
-          {
             layer: 'geoDataLandskap',
+          },
+          {
+            layer: 'arcGisOnline',
+            options: {
+              zIndex: MapLayerZIndex.OnlineMixedBackgroundLayer,
+            },
+            excludeBounds: [NORWAY_BOUNDS, SVALBARD_BOUNDS],
           },
         ],
       },


### PR DESCRIPTION
Viser nå verdenskart (arcgis) + npolar for geodata landskap. Da bør kart vises uansett hvor man søker og uansett hvilke bakgrunnskart som er valgt.

Endrer også litt på hvordan valgene for bakgrunnskart ser ut i sidemenyen. Vises nå med "Norge. Svalbard, Verden"-rekkefølge, for å lettere tydeliggjøre hva forskjellene er for de fleste av brukerne våre..