### PR TITLE
RO-2850: Fiks feil knytta til at tiles ikke dukker opp

### DIFF
--- a/src/app/modules/map-image/map-image.component.ts
+++ b/src/app/modules/map-image/map-image.component.ts
@@ -1,9 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
-import { booleanWithin, point } from '@turf/turf';
+import { point } from '@turf/turf';
 import L from 'leaflet';
-import { NORWAY_BOUNDS } from 'src/app/core/helpers/leaflet/norway-bounds';
-import { SVALBARD_BOUNDS } from 'src/app/core/helpers/leaflet/svalbard-bounds';
-import { TopoMapLayer } from 'src/app/core/models/topo-map-layer.enum';
 import { GeoHazard } from 'src/app/modules/common-core/models';
 import { settings } from '../../../settings';
 import { ImageLocation, ImageLocationStartStop } from '../../core/models/image-location.model';
@@ -12,6 +9,8 @@ import { LeafletModule } from '@bluehalo/ngx-leaflet';
 import { TranslateService } from '@ngx-translate/core';
 import { map, Subject, switchMap, takeWhile, tap, timer } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MapLayersService, OfflineCapableMapLayersService } from '../static-map-image/static-tiles.service';
+import { isPlatform } from '@ionic/angular/standalone';
 
 export const START_ICON = '/assets/icon/map/GPS_start.svg';
 export const END_ICON = '/assets/icon/map/GPS_stop.svg';
@@ -23,9 +22,17 @@ export const DAMAGE_ICON = '/assets/icon/map/damage-location.svg';
   styleUrls: ['./map-image.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [LeafletModule],
+  providers: [
+    {
+      provide: MapLayersService,
+      useClass: isPlatform('hybrid') ? OfflineCapableMapLayersService : MapLayersService,
+    },
+  ],
 })
 export class MapImageComponent {
-  translations = inject(TranslateService);
+  private translations = inject(TranslateService);
+  private mapLayers = inject(MapLayersService);
+
   readonly locationInfo = input<ImageLocation>();
 
   settings = computed(() => {
@@ -34,18 +41,27 @@ export class MapImageComponent {
     if (!loc) return undefined;
 
     const feature = point([loc.latLng.lng, loc.latLng.lat]);
-    const baseLayer = getBaseLayer(feature);
-    return {
+    const layersConfig = this.mapLayers.getMapLayerForLocation(feature);
+    const layers = layersConfig.map((x) =>
+      L.tileLayer(x.layerConfig.url, {
+        minZoom: settings.map.tiles.minZoom,
+        maxZoom: settings.map.tiles.maxZoom,
+        updateWhenIdle: settings.map.tiles.updateWhenIdle,
+        ...x.layerConfig.options,
+      })
+    );
+    const mapSettings: L.MapOptions = {
       zoom: settings.map.tiles.zoomLevelObservationList,
       maxZoom: settings.map.tiles.maxZoom,
       minZoom: 8,
       bounceAtZoomLimits: false,
       attributionControl: false,
       zoomControl: false,
-      trackResize: false,
+      // trackResize: false,
       center: loc.latLng,
-      layers: [L.tileLayer(baseLayer.url, { ...baseLayer.options })],
+      layers,
     };
+    return mapSettings;
   });
 
   markers = computed(() => {
@@ -91,16 +107,6 @@ export class MapImageComponent {
   onLeafletMapReady(map: L.Map) {
     this.map$.next(map);
   }
-}
-
-function getBaseLayer(location: GeoJSON.Feature<GeoJSON.Point>) {
-  if (location && booleanWithin(location, NORWAY_BOUNDS)) {
-    return settings.map.tiles.topoMapLayers[TopoMapLayer.statensKartverk];
-  }
-  if (location && booleanWithin(location, SVALBARD_BOUNDS)) {
-    return settings.map.tiles.topoMapLayers[TopoMapLayer.npolarBasiskart];
-  }
-  return settings.map.tiles.topoMapLayers[TopoMapLayer.arcGisOnline];
 }
 
 function createObsLocationMarker(pos: L.LatLng, geoHazard: GeoHazard) {

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -366,7 +366,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     this.userSettingService.userSetting$.pipe(takeUntil(this.ngDestroy$)).subscribe((userSetting) => {
-      this.configureTileLayers(userSetting);
+      this.configureTileLayers(userSetting, map);
     });
 
     this.mapService.followMode$.pipe(takeUntil(this.ngDestroy$)).subscribe((val) => {
@@ -611,13 +611,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     };
   }
 
-  private configureTileLayers(userSetting: UserSetting) {
-    if (this.map == null) {
-      throw new Error('Map needs to be initialized');
-    }
-
-    const map = this.map;
-
+  private configureTileLayers(userSetting: UserSetting, map: L.Map) {
     const useRetinaMap = userSetting.useRetinaMap && L.Browser.retina;
 
     this.zone.runOutsideAngular(() => {

--- a/src/app/modules/map/pages/modal-map-image/modal-map-image.page.spec.ts
+++ b/src/app/modules/map/pages/modal-map-image/modal-map-image.page.spec.ts
@@ -10,6 +10,7 @@ import { provideIonicAngular } from '@ionic/angular/standalone';
 import { ImageLocation } from '../../../../core/models/image-location.model';
 import L from 'leaflet';
 import { GeoHazard } from 'src/app/modules/common-core/models';
+import { provideTestLogger } from 'src/app/modules/shared/services/logging/test-logging.service';
 
 describe('ModalMapImagePage', () => {
   let component: ModalMapImagePage;
@@ -21,6 +22,7 @@ describe('ModalMapImagePage', () => {
         provideIonicAngular(),
         provideTranslateService(),
         importProvidersFrom([CommonModule, FormsModule, LeafletModule]),
+        provideTestLogger(),
       ],
       imports: [ModalMapImagePage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/src/app/modules/static-map-image/static-map-image.component.html
+++ b/src/app/modules/static-map-image/static-map-image.component.html
@@ -1,20 +1,18 @@
 <div class="container" #container>
   <!-- We could add some error handling here, using onerror or (error) to reset the src to something else -->
-  <img
-    *ngFor="let props of tiles; trackBy: trackByImgProps"
-    class="tile"
-    [style.top]="props.top"
-    [style.left]="props.left"
-    [src]="props.src"
-    loading="lazy"
-    alt="Map tile"
-    decoding="async"
-  />
+  @for (tile of tiles(); track tile.src) {
+    <img
+      class="tile"
+      [style.top.px]="tile.top"
+      [style.left.px]="tile.left"
+      [src]="tile.src"
+      loading="lazy"
+      alt="Map tile"
+      decoding="async"
+    />
+  }
 
-  <div
-    class="graphic"
-    *ngFor="let graphic of graphics; trackBy: trackByGraphic"
-    [innerHTML]="graphic.svg"
-    [ngStyle]="graphic.style"
-  ></div>
+  @for (graphic of graphics(); track graphic.id) {
+    <div class="graphic" [innerHTML]="graphic.svg" [style.left.px]="graphic.left" [style.top.px]="graphic.top"></div>
+  }
 </div>

--- a/src/app/modules/static-map-image/static-map-image.component.ts
+++ b/src/app/modules/static-map-image/static-map-image.component.ts
@@ -23,14 +23,13 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   AfterViewInit,
   ElementRef,
-  TrackByFunction,
   HostListener,
   inject,
   viewChild,
   input,
+  signal,
 } from '@angular/core';
 import {
   debounceTime,
@@ -56,23 +55,41 @@ import { NgDestoryBase } from 'src/app/core/helpers/observable-helper';
 import { END_ICON, START_ICON } from '../map-image/map-image.component';
 import { LoggingService } from '../shared/services/logging/logging.service';
 import { LatLng } from 'leaflet';
-import { NgFor, NgStyle } from '@angular/common';
 import type { Feature, Polygon } from 'geojson';
 
-interface TileProps {
+/**
+ * Element in static map, either a tile or a graphic
+ */
+interface MapElement {
+  /**
+   * Position in pixels from top
+   */
+  top: number;
+
+  /**
+   * Position in pixels from left
+   */
+  left: number;
+}
+
+interface TileProps extends MapElement {
+  /**
+   * Map tile img src
+   */
   src: SafeUrl;
-  top: string;
-  left: string;
 }
 
-interface Graphic {
+interface Graphic extends MapElement {
+  /**
+   * Id used for change detection tracking in for loop
+   */
   id: string;
-  svg: SafeHtml;
-  style: { [styleDesc: string]: number };
-}
 
-const trackByImgProps: TrackByFunction<TileProps> = (index, item) => item.src;
-const trackByGraphic: TrackByFunction<Graphic> = (index, item) => item.id;
+  /**
+   * Svg to display in map
+   */
+  svg: SafeHtml;
+}
 
 // We only have map services with 256px tiles at the moment.
 const TILE_SIZE = 256;
@@ -135,11 +152,9 @@ const createGeojsonBounds = ({ minLng, minLat, maxLng, maxLat }: LatLngBounds): 
       useClass: isPlatform('hybrid') ? OfflineCapableMapLayersService : MapLayersService,
     },
   ],
-  imports: [NgFor, NgStyle],
 })
 export class StaticMapImageComponent extends NgDestoryBase implements AfterViewInit {
   private sanitizer = inject(DomSanitizer);
-  private cdr = inject(ChangeDetectorRef);
   private mapLayerService = inject(MapLayersService);
   private logger = inject(LoggingService);
 
@@ -153,8 +168,8 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
     this.componentCreatedOrResized.next();
   }
 
-  tiles?: TileProps[];
-  graphics: Graphic[] = [];
+  tiles = signal([] as TileProps[]);
+  graphics = signal([] as Graphic[]);
 
   private componentCreatedOrResized = new Subject<void>();
   private size = new ReplaySubject<{ w: number; h: number }>(1);
@@ -171,14 +186,6 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
     map(({ w, h }) => ({ w: +w, h: +h })),
     share()
   );
-
-  get trackByImgProps() {
-    return trackByImgProps;
-  }
-
-  get trackByGraphic() {
-    return trackByGraphic;
-  }
 
   private mercator = new SphericalMercator({ size: TILE_SIZE });
 
@@ -221,8 +228,8 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
 
         result.push({
           src: this.sanitizer.bypassSecurityTrustUrl(url),
-          left: `${tileX * tileSize - x0}px`,
-          top: `${tileY * tileSize - y0}px`,
+          left: tileX * tileSize - x0,
+          top: tileY * tileSize - y0,
         });
       }
     }
@@ -345,7 +352,7 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
     return polygons;
   }
 
-  private async createMap(w: number, h: number) {
+  private createMap(w: number, h: number) {
     const positions = this.getPositionsToPlot();
     const polygons = this.getPolygons();
     //add all positions together to find max and min latlng
@@ -358,17 +365,19 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
     ];
 
     const { latLngBounds, geojsonBounds } = this.getLatLngBounds(positionsAndPolygonsLatLngs);
-    const mapLayers = await this.mapLayerService.getMapLayerForLocation(geojsonBounds);
+    const mapLayers = this.mapLayerService.getMapLayerForLocation(geojsonBounds);
     const mercatorBounds = this.getMercatorBounds(latLngBounds, w, h);
 
     // Map tiles
-    this.tiles = mapLayers
-      .map(({ layerId, layerConfig }) => this.getTileProperties(layerId, layerConfig, mercatorBounds, w, h, TILE_SIZE))
-      .flat();
+    this.tiles.set(
+      mapLayers
+        .map(({ layerId, layerConfig }) =>
+          this.getTileProperties(layerId, layerConfig, mercatorBounds, w, h, TILE_SIZE)
+        )
+        .flat()
+    );
 
     this.createGraphics(positions, polygons, mercatorBounds);
-
-    this.cdr.detectChanges(); // Async operation, so we must notify angular that changes has occured
   }
 
   private createGraphics(
@@ -377,7 +386,7 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
     { w: x0, n: y0, zoom }: MercatorBounds
   ) {
     // Reset map graphics
-    this.graphics = [];
+    this.graphics.set([]);
     let start = null;
     let stop = null;
     for (const { pos, type } of positions) {
@@ -429,9 +438,10 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
       .flat()
       .join(',');
 
-    this.graphics.unshift({
-      id: 'start-stop-line',
-      svg: this.sanitizer.bypassSecurityTrustHtml(`
+    this.graphics.update((graphics) => [
+      {
+        id: 'start-stop-line',
+        svg: this.sanitizer.bypassSecurityTrustHtml(`
       <svg pointer-events="none" viewBox="0 0 ${width} ${height}" width=${width} height=${height}>
         <polyline points="${polylinesPointsToString}"
           stroke="${fill}"
@@ -443,11 +453,11 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
           fill-opacity="0.2"
           fill-rule="evenodd" />
       </svg>`),
-      style: {
-        'left.px': svg_x0 - w,
-        'top.px': svg_y0 - n,
+        left: svg_x0 - w,
+        top: svg_y0 - n,
       },
-    });
+      ...graphics,
+    ]);
   }
 
   private getMercatorPointsFromPolygonsLtLng(polygons: LatLng[], zoom: number): LatLng[] {
@@ -473,35 +483,38 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
     // TODO: Can we extract width and height from svg?
     const svgWidth = 26;
     const svgHeight = 37;
-    const style = { 'left.px': leftPx - svgWidth / 2, 'top.px': topPx - svgHeight };
-    this.graphics.push({ svg, style, id: 'centerMarker' });
+    const style = { left: leftPx - svgWidth / 2, top: topPx - svgHeight };
+
+    this.graphics.update((graphics) => [...graphics, { svg, ...style, id: 'centerMarker' }]);
   }
 
   private createStartGraphic(topPx: number, leftPx: number) {
     const w = 18;
     const h = 28;
 
-    this.graphics.push({
-      id: 'start',
-      svg: `<img src="${START_ICON}">`,
-      style: {
-        'left.px': leftPx - w / 2,
-        'top.px': topPx - h,
+    this.graphics.update((graphics) => [
+      ...graphics,
+      {
+        id: 'start',
+        svg: `<img src="${START_ICON}">`,
+        left: leftPx - w / 2,
+        top: topPx - h,
       },
-    });
+    ]);
   }
   private createStopGraphic(topPx: number, leftPx: number) {
     const w = 18;
     const h = 28;
 
-    this.graphics.push({
-      id: 'start',
-      svg: `<img src="${END_ICON}">`,
-      style: {
-        'left.px': leftPx - w / 2,
-        'top.px': topPx - h,
+    this.graphics.update((graphics) => [
+      ...graphics,
+      {
+        id: 'start',
+        svg: `<img src="${END_ICON}">`,
+        left: leftPx - w / 2,
+        top: topPx - h,
       },
-    });
+    ]);
   }
 
   private createStartStopLine(start: { x: number; y: number }, stop: { x: number; y: number }, x0: number, y0: number) {
@@ -510,10 +523,11 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
     const w = Math.ceil(Math.abs(start.x - stop.x)) + SVG_PADDING * 2;
     const h = Math.ceil(Math.abs(start.y - stop.y)) + SVG_PADDING * 2;
 
-    this.graphics.unshift({
-      id: 'start-stop-line',
-      // width and height on svg?
-      svg: this.sanitizer.bypassSecurityTrustHtml(`
+    this.graphics.update((graphics) => [
+      {
+        id: 'start-stop-line',
+        // width and height on svg?
+        svg: this.sanitizer.bypassSecurityTrustHtml(`
       <svg pointer-events="none" viewBox="0 0 ${w} ${h}" width="${w}" height="${h}">
         <path
           stroke="red"
@@ -524,11 +538,11 @@ export class StaticMapImageComponent extends NgDestoryBase implements AfterViewI
           fill="none"
           d="M${start.x - svg_x0} ${start.y - svg_y0}L${stop.x - svg_x0} ${stop.y - svg_y0}"></path>
       </svg>`),
-      style: {
-        'left.px': svg_x0 - x0,
-        'top.px': svg_y0 - y0,
+        left: svg_x0 - x0,
+        top: svg_y0 - y0,
       },
-    });
+      ...graphics,
+    ]);
   }
 
   private createDamageGraphic() {

--- a/src/app/modules/static-map-image/static-tiles.service.ts
+++ b/src/app/modules/static-map-image/static-tiles.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { bbox, bboxPolygon, booleanWithin, lineString } from '@turf/turf';
 import type { Feature } from 'geojson';
 import { LatLngTuple } from 'leaflet';
-import { firstValueFrom } from 'rxjs';
+import { TopoMap } from 'src/app/core/models/topo-map.enum';
 import { OfflineMapService } from 'src/app/core/services/offline-map/offline-map.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { settings } from 'src/settings';
@@ -64,16 +65,15 @@ function formatTileUrl(urlTemplate: string, tileX: number, tileY: number, tileZo
  */
 @Injectable()
 export class MapLayersService {
-  private userSettings = inject(UserSettingService);
+  private userSettings = toSignal(inject(UserSettingService).userSetting$);
 
-  private async getUserSelectedMapConfig() {
-    const { topoMap: userSelectedMap } = await firstValueFrom(this.userSettings.userSetting$);
-    const mapConfig = settings.map.tiles.topoMaps[userSelectedMap];
-    return mapConfig;
-  }
+  mapConfig = computed(() => {
+    const topoMap = this.userSettings()?.topoMap || TopoMap.default;
+    return settings.map.tiles.topoMaps[topoMap];
+  });
 
-  async getMapLayerForLocation(location: Feature) {
-    const mapConfig = await this.getUserSelectedMapConfig();
+  getMapLayerForLocation(location: Feature) {
+    const mapConfig = this.mapConfig();
     const mapLayers = getMapLayersWithMatchingBoundsForLocation(mapConfig, location);
     return mapLayers;
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -177,7 +177,7 @@ export const settings: ISettings = {
               [57.9, 4.626617431640625],
               [71.15939141681443, 31.3],
             ],
-            maxNativeZoom: 19,
+            maxNativeZoom: 18,
           },
           supportsOffline: true,
         },


### PR DESCRIPTION
Feilen i Jira-saken skyldtes at kartet i popup / modal brukte en egen config som ikke tok hensyn til max zoom nivå / native zoom osv.

Endringen gjør at alle kart bruker "samme konfig". Det er fortsatt en del å gå på for å samle all konfig ett sted, men kartene bruker i hvert fall _litt_ likere config nå. Det gjør at ikke det skal være mulig å få "grå" tiles, med mindre tiles ikke klarer å bli henta fra karttjenesten.

Endringen rydder også litt opp i noen av filene. Endringene i static-map-image er bare opprydning, de trenger ikke review.