### PR TITLE
Minimer minnebruken i listevisninga

### DIFF
--- a/src/app/components/observation/observation/observation.component.css
+++ b/src/app/components/observation/observation/observation.component.css
@@ -43,12 +43,6 @@ swiper-slide {
   height: 100%;
   width: fit-content;
   cursor: pointer;
-
-  /*
-    Uten fast bredde på slidesene ble de ofte tegnet med bredde 0 etter at vi la til bruk av IntersectionObserver for å
-    tegne swiperen.
-  */
-  width: 100%;
 }
 
 swiper-slide .img-desc {

--- a/src/app/components/observation/observation/observation.component.css
+++ b/src/app/components/observation/observation/observation.component.css
@@ -5,21 +5,50 @@
   margin-top: 16px;
   background-color: white;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  /**
+   * Denne komponenten brukes i listevisninga som har ytelsesproblemer på iOS.
+   * contain: layout paint; hjelper trolig.
+   **/
+  contain: layout paint;
 
   --slide-height: 400px;
   --swiper-theme-color: var(--ion-color-secondary);
 }
 
-swiper-container {
+.swiper-wrapper {
+  /*
+    Viktig at høyde og bredde er satt fast her, siden det er en if-setning som rendrer selve swiperen, inni denne.
+    Uten fast bredde og høyde vil innholdet hoppe.
+  */
+  height: var(--slide-height);
+  width: 100%;
+  /*
+    Siden .swiper-wrapper har en if-setning som kun rendrer swiperen vha IntersectionObserver,
+    sjekk om contain layout paint git bedre ytelse.
+    Da trenger forhåpentligvis ikke mer enn bare det inni if-setningen tegnes opp på nytt.
+  */
+  contain: layout paint;
+
+  /* Bakgrunnsfarge for å fylle swiperen med noe før selwe swiperen, bildene og kartet laster. */
   background-color: rgba(var(--ion-color-primary-rgb), 0.2);
+}
+
+swiper-container {
+  height: 100%;
+  width: 100%;
 }
 
 swiper-slide {
   position: relative;
-  background-color: lightgray;
-  height: var(--slide-height);
+  height: 100%;
   width: fit-content;
   cursor: pointer;
+
+  /*
+    Uten fast bredde på slidesene ble de ofte tegnet med bredde 0 etter at vi la til bruk av IntersectionObserver for å
+    tegne swiperen.
+  */
+  width: 100%;
 }
 
 swiper-slide .img-desc {
@@ -102,6 +131,7 @@ derfor vises ikke riktig cursor når hover over stjerner */
 .competence-chip {
   pointer-events: auto;
 }
+
 .competence-chip:hover {
   background-color: rgba(0, 66, 95, 0.08);
 }

--- a/src/app/components/observation/observation/observation.component.html
+++ b/src/app/components/observation/observation/observation.component.html
@@ -1,34 +1,38 @@
 <!-- Et observasjonskort. Viser data fra en observasjon, et miniatyrkart over posisjonen og bilder i en karusell -->
-<swiper-container
-  slides-per-view="auto"
-  loop="false"
-  css-mode="false"
-  navigation="true"
-  pagination="true"
-  space-between="0"
-  centered-slides="false"
-  center-insufficient-slides="false"
-  zoom="true"
-  keyboard="false"
->
-  <!-- Map -->
-  <swiper-slide (click)="openMapModal()">
-    <app-static-map-image [location]="location()"></app-static-map-image>
-  </swiper-slide>
+<div class="swiper-wrapper">
+  @if (isVisible()) {
+    <swiper-container
+      slides-per-view="auto"
+      loop="false"
+      css-mode="false"
+      navigation="true"
+      pagination="true"
+      space-between="0"
+      centered-slides="false"
+      center-insufficient-slides="false"
+      zoom="true"
+      keyboard="false"
+    >
+      <!-- Map -->
+      <swiper-slide (click)="openMapModal()">
+        <app-static-map-image [location]="location()"></app-static-map-image>
+      </swiper-slide>
 
-  <!-- lazy-preload-prev-next="2" -->
-  @for (attachment of attachments(); track attachment.AttachmentId; let index = $index) {
-    <swiper-slide (click)="openImageCarousel(index)" lazy="true">
-      <img
-        [src]="attachment.UrlFormats?.Large"
-        [alt]="attachment.Comment"
-        loading="lazy"
-        decoding="async"
-        (error)="setFallbackImage(attachment)"
-      />
-    </swiper-slide>
+      <!-- lazy-preload-prev-next="2" -->
+      @for (attachment of attachments(); track attachment.AttachmentId; let index = $index) {
+        <swiper-slide (click)="openImageCarousel(index)" lazy="true">
+          <img
+            [src]="attachment.UrlFormats?.Large"
+            [alt]="attachment.Comment"
+            loading="lazy"
+            decoding="async"
+            (error)="setFallbackImage(attachment)"
+          />
+        </swiper-slide>
+      }
+    </swiper-container>
   }
-</swiper-container>
+</div>
 
 <div class="content">
   <h2>

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -1,11 +1,14 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   computed,
   CUSTOM_ELEMENTS_SCHEMA,
+  ElementRef,
   inject,
   input,
+  OnDestroy,
   signal,
   Signal,
 } from '@angular/core';
@@ -45,7 +48,17 @@ import { StaticMapImageComponent } from 'src/app/modules/static-map-image/static
 import { ImageLocation, ImageLocationStartStop } from '../../../core/models/image-location.model';
 import L from 'leaflet';
 import { getAllAttachmentsFromViewModel } from 'src/app/modules/common-registration/registration.helpers';
-import { catchError, firstValueFrom, Observable, of, switchMap, timeout, TimeoutError } from 'rxjs';
+import {
+  catchError,
+  debounceTime,
+  firstValueFrom,
+  Observable,
+  of,
+  Subject,
+  switchMap,
+  timeout,
+  TimeoutError,
+} from 'rxjs';
 import { Router, RouterLink } from '@angular/router';
 import {
   ConfirmationModalService,
@@ -88,7 +101,7 @@ const FETCH_OBS_TIMEOUT_MS = 5000;
   changeDetection: ChangeDetectionStrategy.OnPush,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-export class ObservationComponent {
+export class ObservationComponent implements AfterViewInit, OnDestroy {
   private userSettingService = inject(UserSettingService);
   private cdr = inject(ChangeDetectorRef);
   private analyticService = inject(AnalyticService);
@@ -101,6 +114,7 @@ export class ObservationComponent {
   private toastController = inject(ToastController);
   private translateService = inject(TranslateService);
   private confirmationModalService = inject(ConfirmationModalService);
+  private elementRef = inject(ElementRef);
   modalController = inject(ModalController);
 
   readonly registration = input.required<RegistrationViewModel>();
@@ -122,6 +136,7 @@ export class ObservationComponent {
   private userSettings = toSignal(this.userSettingService.userSetting$, { requireSync: true });
   private baseUrl = settings.services.regObs.webUrl[this.userSettings().appMode];
   private registrationUrl = computed(() => `${this.baseUrl}/Registration/${this.registration().RegId}`);
+  private intersectionObserver?: IntersectionObserver;
 
   registrationViews = computed(() => getRegistrationViews(this.registration()));
 
@@ -186,6 +201,32 @@ export class ObservationComponent {
       chatbubbleEllipses,
       shareSocial,
     });
+  }
+
+  // For å håndtere veldig kjapp scrolling oppover sluser vi eventene via en subject med en debounce
+  // Da vil forhåpentligvis de observasjonskortene som bare scrolles superkjapt forbi ikke rendre swiper
+  // i det hele tatt.
+  // Etter å ha lagt til dette fikk jeg ikke lenger sporadiske kræsj ved superhurtig scrolling,
+  // men bør sikkert testes mer.
+  private isVisible$ = new Subject<boolean>();
+  isVisible = toSignal(this.isVisible$.pipe(debounceTime(100)), { initialValue: false });
+
+  ngAfterViewInit(): void {
+    this.intersectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        this.isVisible$.next(entry.isIntersecting);
+      },
+      {
+        root: null,
+        threshold: 0.1,
+      }
+    );
+
+    this.intersectionObserver.observe(this.elementRef.nativeElement);
+  }
+
+  ngOnDestroy(): void {
+    this.intersectionObserver?.disconnect(); // Vet ikke om denne er nødvendig
   }
 
   userCompetenceUrl = toSignal(this.userSettingService.userCompetenceUrl$, { initialValue: '' });


### PR DESCRIPTION
Endringen gjør at alle observasjonskortene bruker Intersection Observer API for å kun tegne bildekarusellen dersom den vises på skjermen. Når man scroller nedover lista fjernes altså de man har scrolla forbi. Det bør hjelpe på ytelsen. Enda bedre hadde det vært med en virtuell liste, men det er litt vanskeligere å få til siden observasjonskortene har forskjellige høyder avhengig av hva de inneholder.

Dette minker minneforbruket i listevisninga fordi vi bare har de bildekarusellene som er synlige i domen.
Etter å ha lagt til dette opplever jeg ikke kræsjing i listevisninga på min iPhone. Test gjerne dere også, om dere får kræsj fortsatt.

En del av koden er basert på forslag fra chat-gpt, men ikke kopiert direkte.
Dette gjelder både forslag om bruk av Intersection Observer API, men også bruken av `contain: layout paint`.
De eventuelle ytelsesforbedringene knytta til `contain: layout paint` er jeg mer usikre på, men logikken er at det skal hjelpe browseren til å ikke tegne hele siden på nytt hvis man bruker det fornuftig. Men misbruk av regelen er dumt, for alle komponenter med denne regelen får et eget lag i minnet til gpu-en, hvis jeg skjønner det riktig. Så overdreven bruk kan være negativt. Men jeg har bare såvidt satt meg litt inn i dette.

I denne endringen lager hvert eneste observasjonskort sin egen instans av IntersectionObserver. Det hadde vært bedre om selve lista lagde en instans og sjekket observasjskortene selv. Og sendte inn til hvert obskort om de var synlige eller ikke. Da hadde trolig minnebruken og ytelsen blitt enda litt bedre. Men det er litt vanskeligere å få til siden lista bygges opp dynamisk (laster 10 og 10 obser av gangen). Det går fint an, men virker som det uansett funker bra nok sånn som det er satt opp her.