### PR TITLE
RO-2690: Rettet url til jordskredvarsel på norsk og flomvarsel på engelsk

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -121,7 +121,7 @@ export const settings: ISettings = {
           en: floodLandslideBaseUrlEn,
         },
         webUrl: {
-          nb: `${floodLandslideBaseUrlNb}/warning/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=landslide`,
+          nb: `${floodLandslideBaseUrlNb}/varsel/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=landslide`,
           en: `${floodLandslideBaseUrlEn}/forecast/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=landslide`,
         },
         featureName: 'fylkesnummer',
@@ -134,7 +134,7 @@ export const settings: ISettings = {
         },
         webUrl: {
           nb: `${floodLandslideBaseUrlNb}/varsel/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=flood`,
-          en: `${floodLandslideBaseUrlNb}/forecast/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=flood`,
+          en: `${floodLandslideBaseUrlEn}/forecast/{regionName}/?date={day}&utm_source=regobs&utm_medium=app&utm_campaign=flood`,
         },
         featureName: 'fylkesnummer',
       },


### PR DESCRIPTION
Det var noen feil i url'ene til varsom.no i appen. Dette gjorde at man ikke fikk se disse varslene:
- jordskredvarsel på norsk
- flomvarsel på engelsk

Har testet på Android 12. Må testes i app, funker ikke på web.