### PR TITLE
RO-2981: Hindre at appen aldri gir opp å oppfriske token hvis vi får 401

### DIFF
--- a/src/app/core/http-interceptor/ApiInterceptor.spec.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed } from '@angular/core/testing';
+import { ApiInterceptor } from './ApiInterceptor';
+import { HttpHandler, HttpRequest, HttpErrorResponse, HttpEvent, HttpResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { StorageBackend } from '@openid/appauth';
+import { ApiVersionService } from '../services/api-version/api-version.service';
+
+describe('ApiInterceptor retry logic', () => {
+  let interceptor: ApiInterceptor;
+  let regobsAuthService: jasmine.SpyObj<RegobsAuthService>;
+  let loggerService: jasmine.SpyObj<LoggingService>;
+  let storage: jasmine.SpyObj<StorageBackend>;
+  let apiVersionService: jasmine.SpyObj<ApiVersionService>;
+
+  beforeEach(() => {
+    regobsAuthService = jasmine.createSpyObj('RegobsAuthService', ['refreshToken', 'signIn'], {
+      loggedInUser$: of({ token: 'token1' }),
+    });
+    regobsAuthService.refreshToken.and.returnValue(Promise.resolve());
+
+    loggerService = jasmine.createSpyObj('LoggingService', ['debug']);
+    storage = jasmine.createSpyObj('StorageBackend', ['setItem']);
+    apiVersionService = jasmine.createSpyObj('ApiVersionService', ['setSunsetDate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ApiInterceptor,
+        { provide: RegobsAuthService, useValue: regobsAuthService },
+        { provide: LoggingService, useValue: loggerService },
+        { provide: StorageBackend, useValue: storage },
+        { provide: ApiVersionService, useValue: apiVersionService },
+      ],
+    });
+
+    interceptor = TestBed.inject(ApiInterceptor);
+  });
+
+  it('sjekk at vi bare prøver å kjøre kall på nytt EN gang hvis vi får 401 fra Regobs-API', (done) => {
+    const url = 'https://api.regobs.no/v6/Search/MyRegistrations';
+    const req = new HttpRequest('GET', url);
+
+    // Spy som alltid returnerer 401
+    const handleSpy = jasmine.createSpy('handle').and.callFake((request: HttpRequest<any>) => {
+      return throwError(() => new HttpErrorResponse({ status: 401, statusText: 'Unauthorized' }));
+    });
+
+    const handler: HttpHandler = { handle: handleSpy };
+
+    interceptor.intercept(req, handler).subscribe({
+      next: () => {
+        fail('Skal feile hvis vi får 401 fra Regobs-API på nytt hvis vi gjentar kallet');
+        done();
+      },
+      error: (err) => {
+        // Forventet: kun to forsøk (original + ett retry)
+        expect(regobsAuthService.refreshToken).toHaveBeenCalledTimes(1);
+        expect(handleSpy).toHaveBeenCalledTimes(2);
+        expect(err).toEqual(jasmine.objectContaining({ status: 401 }));
+        done();
+      },
+    });
+  });
+
+  it('sjekk at vi ikke kjører kall på nytt hvis api returnerer 200 OK', (done) => {
+    const url = 'https://api.regobs.no/v6/Search/MyRegistrations';
+    const req = new HttpRequest('GET', url);
+
+    // Spy som returnerer 200 OK på første forsøk
+    const handleSpy = jasmine
+      .createSpy('handle')
+      .and.returnValue(of(new HttpResponse({ status: 200, body: { ok: true } })));
+
+    const handler: HttpHandler = { handle: handleSpy };
+
+    interceptor.intercept(req, handler).subscribe({
+      next: (event) => {
+        expect(event).toEqual(jasmine.objectContaining({ status: 200, body: { ok: true } }));
+        expect(handleSpy).toHaveBeenCalledTimes(1);
+        expect(regobsAuthService.refreshToken).not.toHaveBeenCalled();
+        done();
+      },
+      error: (err) => {
+        fail('Skal ikke feile: ' + err);
+        done();
+      },
+    });
+  });
+});

--- a/src/app/core/http-interceptor/ApiInterceptor.spec.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { ApiInterceptor } from './ApiInterceptor';
-import { HttpHandler, HttpRequest, HttpErrorResponse, HttpEvent, HttpResponse } from '@angular/common/http';
+import { HttpHandler, HttpRequest, HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { of, throwError } from 'rxjs';
 import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
@@ -42,7 +42,7 @@ describe('ApiInterceptor retry logic', () => {
     const req = new HttpRequest('GET', url);
 
     // Spy som alltid returnerer 401
-    const handleSpy = jasmine.createSpy('handle').and.callFake((request: HttpRequest<any>) => {
+    const handleSpy = jasmine.createSpy('handle').and.callFake(() => {
       return throwError(() => new HttpErrorResponse({ status: 401, statusText: 'Unauthorized' }));
     });
 

--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -17,6 +17,10 @@ import { StorageBackend } from '@openid/appauth';
 import { ApiVersionService } from '../services/api-version/api-version.service';
 import { Capacitor } from '@capacitor/core';
 
+const DEBUG_TAG = 'ApiInterceptor';
+const RETRY_HEADER = 'X-Regobs-Retry';
+const MAX_RETRIES = 1; // Antall ganger vi prøver å kjøre kallet på nytt hvis vi får 401
+
 /**
  * Sender innloggings-token med kall til Regobs API der kallene krever at man er logget inn.
  * Hvis api-kallet feiler pga. innloggingsfeil (HTTP 401), prøver vi å fornye tokenet og kjører kallet en gang til.
@@ -90,7 +94,7 @@ export class ApiInterceptor implements HttpInterceptor {
       // take(1) makes the observable complete after getting the first loggedInUser.
       take(1),
       catchError((err) => {
-        this.loggerService.debug('Could not get valid token', 'API interceptor', { err });
+        this.loggerService.debug('Could not get valid token', DEBUG_TAG, { err });
         this.regobsAuthService.signIn();
         return EMPTY; //TODO: Why this?
       }),
@@ -108,9 +112,22 @@ export class ApiInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<unknown>> {
     if (error instanceof HttpErrorResponse && error.status === 401) {
       // Vi er ikke autorisert, trolig fordi tokenet ikke er gyldig
-      this.loggerService.debug('Got 401 from API, trying to refresh token and repeat API-call...');
+      const retryCount = Number(request.headers.get(RETRY_HEADER) ?? '0');
+      if (retryCount >= MAX_RETRIES) {
+        // Har allerede forsøkt å oppfriske token én gang, kast feilen videre
+        console.log('ApiInterceptor: MAX_RETRIES reached, not retrying');
+        this.loggerService.debug('401 after token refresh, not retrying again.', DEBUG_TAG);
+        throw error;
+      }
+      this.loggerService.debug('Got 401 from API, trying to refresh token and repeat API-call...', DEBUG_TAG);
       return from(this.regobsAuthService.refreshToken()).pipe(
         switchMap(() => this.addAuthHeader(request)),
+        map((req) =>
+          req.clone({
+            // legger på en header for å indikere at vi forsøker samme kall til API på nytt
+            headers: req.headers.set(RETRY_HEADER, String(retryCount + 1)),
+          })
+        ),
         switchMap((req) => next.handle(req))
       );
     }

--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -115,11 +115,18 @@ export class ApiInterceptor implements HttpInterceptor {
       const retryCount = Number(request.headers.get(RETRY_HEADER) ?? '0');
       if (retryCount >= MAX_RETRIES) {
         // Har allerede forsøkt å oppfriske token én gang, kast feilen videre
-        console.log('ApiInterceptor: MAX_RETRIES reached, not retrying');
-        this.loggerService.debug('401 after token refresh, not retrying again.', DEBUG_TAG);
+        this.loggerService.debug('401 after token refresh, not retrying again.', DEBUG_TAG, {
+          retryCount,
+          url: request.url,
+          method: request.method,
+        });
         throw error;
       }
-      this.loggerService.debug('Got 401 from API, trying to refresh token and repeat API-call...', DEBUG_TAG);
+      this.loggerService.debug('Got 401 from API, trying to refresh token and repeat API-call...', DEBUG_TAG, {
+        retryCount,
+        url: request.url,
+        method: request.method,
+      });
       return from(this.regobsAuthService.refreshToken()).pipe(
         switchMap(() => this.addAuthHeader(request)),
         map((req) =>


### PR DESCRIPTION
Se https://nveprojects.atlassian.net/browse/RO-2981
Appen har fått store problemer og mye rart har skjedd pga. feil konfig av autentisering i API v.6. Nå ser det ut som vi har løst det i API'et, men denne PR'en tror jeg vil hindre at appen oppfører seg rart hvis noe tilsvarende skulle skje igjen.
Uansett vil mange brukere få 401 på obstur-api-kallet, og nå vil i hvert fall appen nøye seg med å oppfriske tokenet _en_ gang for dette kallet.
Blir litt vanskelig å teste skikkelig, men jeg (med god hjelp fra copilot) har laget enhetstester på det.
Man kan teste å logge seg på web og sjekke i konsollet at den oppfrisker tokenet for obstur-kallet _en_ gang når man logger inn, om man ikke har tilgang. Dessverre går det ikke an å teste PR-bygget, fordi dette ikke støtter innlogging, så man må bygge selv.