### PR TITLE
Ikke marker midterste høyde når eksponert høyde er "øverst"

### DIFF
--- a/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.ts
+++ b/src/app/modules/registration/components/snow/exposed-height/exposed-height.component.ts
@@ -56,13 +56,13 @@ export class ExposedHeightComponent {
     if (this.exposedHeightComboTID() === 0) {
       this.heights.update(() => ({ top: true, middle: true, bottom: true }));
     } else if (this.exposedHeightComboTID() === 1) {
-      // Hvit nederst
-      this.heights.update((heights) => ({ ...heights, top: true, bottom: true }));
+      // Svart øverst
+      this.heights.update((heights) => ({ ...heights, top: true, bottom: false }));
     } else if (this.exposedHeightComboTID() === 2) {
       // Svart nederst
       this.heights.update((heights) => ({ ...heights, bottom: true }));
     } else if (this.exposedHeightComboTID() === 3) {
-      // Hvit i midten
+      // Svart øverst og nederst
       this.heights.update((heights) => ({ ...heights, top: true, bottom: true }));
     } else if (this.exposedHeightComboTID() === 4) {
       // Svart i midten


### PR DESCRIPTION
Pirke-endring som fikser slik at hvis man har valgt at utsatt høyde kun er over en viss grense (exposedHeightComboTid = 1), så viser vi det ved å markere kun den øverste delene av fjellet svart:
<img width="576" height="281" alt="image" src="https://github.com/user-attachments/assets/e4d4d826-9bad-4628-a17c-1ec56d37399f" />

Denne PR'en gjorde at både øverste og midterste del ble svart:  #812.
Har ingen praktisk betydning, verdiene blir lagret rikitg uansett.
Men nå er det slikt det var før, og det er mer i tråd med hvis man kun velger utsatt høyde under en viss grense.

Kan forstå at dette ble tolket annerledes i #812, da tekst-verdien for 
exposedHeightComboTid = 1 er "hvit nederst", Det burde nok stått "svart øverst", se regobs Admin:
<img width="482" height="401" alt="image" src="https://github.com/user-attachments/assets/89d90a37-ac07-4fc2-8317-cddca3c6f343" />

Kan testes ved å sette eksponert høyde øverst, og sette en høyde, lagre og gå inn i skjemaet igjen. Da skal kun øverste høyde markeres.
Det samme hvis man både velger øverste og midterste høyde.