### PR TITLE
RO-3007: forbedret håndtering av infinite scroll ved få observasjoner i bildevisning

### DIFF
--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -55,12 +55,33 @@ export class ImageListComponent {
   private loadingController = inject(LoadingController);
 
   private searchHandler = this.searchRegistrations.searchAttachments(this.searchCriteriaService.searchCriteria$);
+
+  /**
+   * Sjekker om innholdet i grid er kortere enn vindushøyden, og laster i så fall flere bilder. Vi viser bilder kun fra
+   * 10 observasjoner om gangen. Hvis bildene fra 10 observasjoner ikke dekker hele skjermen, vil infinite scroll
+   * aldri trigges ved scroll og derfor man kan ikke laste ned flere bilder.
+   */
+  checkAndLoadMoreImages() {
+    setTimeout(() => {
+      const grid = document.querySelector('.grid');
+      if (!grid) return;
+
+      const windowHeight = window.innerHeight;
+      const gridRect = grid.getBoundingClientRect();
+      // Sjekk om grid høyde er mindre enn vindushøyden, hvis ja, last flere bilder
+      if (gridRect.height < windowHeight && !this.disableInfiniteScroll()) {
+        this.loadNextPage();
+      }
+    }, 100);
+  }
+
   registrations = toSignal(
     this.searchHandler.registrations$.pipe(
       tap(() => {
         this.infiniteScroll()?.complete();
         this.ionRefresher()?.complete();
         this.updateObservationsService.setLastFetched(new Date());
+        this.checkAndLoadMoreImages();
       })
     ),
     { initialValue: [] as SearchRegistrationsWithAttachments[] }


### PR DESCRIPTION
Siden vi kun laster inn de 10 første observasjonene både i liste- og bildevisning, hender det noen ganger at bildene ikke fyller hele skjermen (spesielt på store skjermer).
Da vises ingen scrollbar, og infinite scroll blir derfor ikke trigget som forventet.

Løsningen sjekker nå om høyden på gridet er lavere enn skjermhøyden.
Hvis den er det, kjøres loadNextPage() gjentatte ganger til scrollbar vises.
Dette sikrer at bilder alltid lastes inn fortløpende når brukeren skroller ned.

Man kan teste dette ved å zoome ut bildevisning til 50% eller mer. Prøv å kommentere  
```this.checkAndLoadMoreImages(); ``` i 
```js
 registrations = toSignal(
    this.searchHandler.registrations$.pipe(
      tap(() => {
        this.infiniteScroll()?.complete();
        this.ionRefresher()?.complete();
        this.updateObservationsService.setLastFetched(new Date());
        this.checkAndLoadMoreImages();
      })
    ),
    { initialValue: [] as SearchRegistrationsWithAttachments[] }
  );
``` 
for å kjenne forskjell.