### PR TITLE
RO-1987: Test av alfa-versjon av plugin for å hente posisjon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@capacitor/core": "^7.4.0",
         "@capacitor/device": "^7.0.0",
         "@capacitor/filesystem": "^7.0.0",
-        "@capacitor/geolocation": "^7.0.0",
+        "@capacitor/geolocation": "8.0.0-next.3",
         "@capacitor/ios": "^7.4.0",
         "@capacitor/keyboard": "^7.0.0",
         "@capacitor/network": "^7.0.0",
@@ -4404,15 +4404,15 @@
       }
     },
     "node_modules/@capacitor/geolocation": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-7.1.2.tgz",
-      "integrity": "sha512-J++OuOpn6Bjweo7SZ+jwI/dhVF9DNw6Wx0UHgQ4qfrATqmNKGNZ/BUljGhXiKJceSx2GIhfrYS7BYqo3uWibgQ==",
+      "version": "8.0.0-next.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-8.0.0-next.3.tgz",
+      "integrity": "sha512-Za29JaX5kGSChWE/wrPLzPxd8NX+DOjlCLCdav7KpLDW8Qg7H1SEs71sLXIYokHOuKWscejvXYEIkjT3qUrD/A==",
       "license": "MIT",
       "dependencies": {
-        "@capacitor/synapse": "^1.0.1"
+        "@capacitor/synapse": "^1.0.4"
       },
       "peerDependencies": {
-        "@capacitor/core": ">=7.0.0"
+        "@capacitor/core": ">=8.0.0-alpha.2"
       }
     },
     "node_modules/@capacitor/ios": {
@@ -4470,9 +4470,9 @@
       }
     },
     "node_modules/@capacitor/synapse": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.2.tgz",
-      "integrity": "sha512-ynq39s4D2rhk+aVLWKfKfMCz9SHPKijL9tq8aFL5dG7ik7/+PvBHmg9cPHbqdvFEUSMmaGzL6cIjzkOruW7vGA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
       "license": "ISC"
     },
     "node_modules/@chevrotain/cst-dts-gen": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@capacitor/core": "^7.4.0",
     "@capacitor/device": "^7.0.0",
     "@capacitor/filesystem": "^7.0.0",
-    "@capacitor/geolocation": "^7.0.0",
+    "@capacitor/geolocation": "8.0.0-next.3",
     "@capacitor/ios": "^7.4.0",
     "@capacitor/keyboard": "^7.0.0",
     "@capacitor/network": "^7.0.0",


### PR DESCRIPTION
**Denne endringen er bare en test og bør ikke flettes inn i develop.**

Se kommentarer på saken: https://nveprojects.atlassian.net/browse/RO-2987
For å teste denne PR'en må du kjøre `npm install --force`, fordi plugin'en har avhengigheter til andre pakker som vi ikke har.
Det er nok derfor PR-bygget feiler, så vi trenger ikke gjøre noe med bygget.

Capacitor har nå laget en løsning for å hente GPS-posisjon på Android-telefoner i flymodus: 
https://github.com/ionic-team/capacitor-geolocation/pull/53

Jeg har testet en alfa-versjon av geolocation-pluginen for å sjekke at det virket. 
Her er release notes:
https://github.com/ionic-team/capacitor-geolocation/releases/tag/v8.0.0-next.3

Det ser ut som det virker. Jeg får ikke feilmeldinga jeg fikk før når jeg prøver å bruke appen i flymodus, og jeg får posisjon fra Android.
Det som er litt rart er at det ser ut som [npm-pakka for plugin'en](https://www.npmjs.com/package/@capacitor/geolocation/v/8.0.0-next.3) ikke inneholder den endringen i kildekoden som ble lagt til i Capacitor sin PR.
Godt mulig jeg har misforstått hvordan dette henger sammen, for jeg har sammenlignet versjon 7.0.0 og 8.0.0-next.3 flere ganger nå, og feilen virker å være fiksa i 8.0.0-next.3.

Jeg har prøvd å finne ut når Capacitor slipper versjon 8, men har ikke funnet noe. Men håper det ikke blir lenge til.
