### PR TITLE
Vise flomområde i kart-popup

### DIFF
--- a/src/app/components/observation/observation-location-map/observation-location-map.component.ts
+++ b/src/app/components/observation/observation-location-map/observation-location-map.component.ts
@@ -68,6 +68,11 @@ function getStartStopLocation(obs: RegistrationViewModel): ImageLocationStartSto
       endPolygon: extent2Polygon(obs.LandSlideObs.StopExtent, settings.map.endExtentColor),
     };
   }
+  if (obs.WaterLevel2) {
+    return {
+      totalPolygon: extent2Polygon(obs.WaterLevel2.Extent, settings.map.extentColor),
+    };
+  }
   return undefined;
 }
 

--- a/src/app/modules/map-image/map-image.component.ts
+++ b/src/app/modules/map-image/map-image.component.ts
@@ -72,7 +72,9 @@ export class MapImageComponent {
     }
 
     if (locationInfo?.startStopLocation) {
-      markers.push(...createStartStopMarkers(locationInfo.startStopLocation, this.translations));
+      markers.push(
+        ...createStartStopMarkers(locationInfo.startStopLocation, locationInfo.geoHazard, this.translations)
+      );
     }
 
     if (locationInfo?.damageLocations) {
@@ -126,7 +128,11 @@ function createStartStopIcon(iconUrl: string) {
   });
 }
 
-function createStartStopMarkers(location: ImageLocationStartStop, translations: TranslateService): L.Layer[] {
+function createStartStopMarkers(
+  location: ImageLocationStartStop,
+  geoHazard: GeoHazard,
+  translations: TranslateService
+): L.Layer[] {
   const markers = [];
 
   if (location.start) {
@@ -159,7 +165,18 @@ function createStartStopMarkers(location: ImageLocationStartStop, translations: 
   }
 
   if (location.totalPolygon) {
-    const label = translations.instant('REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_AREA');
+    let label = '';
+    switch (geoHazard) {
+      case GeoHazard.Snow:
+        label = translations.instant('REGISTRATION.SNOW.AVALANCHE_OBS.AVALANCHE_AREA');
+        break;
+      case GeoHazard.Soil:
+        label = translations.instant('REGISTRATION.DIRT.LAND_SLIDE_OBS.AREA_TOTAL');
+        break;
+      case GeoHazard.Water:
+        label = translations.instant('REGISTRATION.WATER.WATER_LEVEL.FLOOD_AREA');
+        break;
+    }
     markers.push(location.totalPolygon.bindTooltip(label));
   }
 

--- a/src/app/modules/registration/pages/set-avalanche-position/set-avalanche-position.page.ts
+++ b/src/app/modules/registration/pages/set-avalanche-position/set-avalanche-position.page.ts
@@ -223,6 +223,9 @@ export class SetAvalanchePositionPage implements OnInit {
     } else if (geoHazard == GeoHazard.Soil) {
       this.confirmLocationText = this.translations['REGISTRATION.DIRT.LAND_SLIDE_OBS.CONFIRM_LANDSLIDE_AREA'];
       this.locationText = this.translations['REGISTRATION.DIRT.LAND_SLIDE_OBS.LANDSLIDE_AREA'];
+    } else if (geoHazard == GeoHazard.Water) {
+      this.confirmLocationText = this.translations['REGISTRATION.WATER.WATER_LEVEL.SET_FLOOD_POSITION_CONFIRM'];
+      this.locationText = this.translations['REGISTRATION.WATER.WATER_LEVEL.FLOOD_AREA'];
     }
   }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -850,6 +850,7 @@
         "DESCRIBE_HEIGHT": "Describe height",
         "DESCRIBE_SITUATION": "How would you describe the situation?",
         "DT_REQUIRED_TEXT": "Time is required!",
+        "FLOOD_AREA": "Flood area",
         "HOW_DO_YOU_READ": "How do you read the water level?",
         "MARKED_WITH": "I have marked the water level with",
         "MARKING": "Marking",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -439,7 +439,7 @@
     },
     "DIRT": {
       "LAND_SLIDE_OBS": {
-        "AREA_TOTAL": "Tegn hele skredarealet",
+        "AREA_TOTAL": "Hele skredarealet",
         "AVAL_TRIGGER": "Skredutløser",
         "CONFIRM_END_POSITION": "Bekreft sluttpunkt",
         "CONFIRM_LANDSLIDE_AREA": "Bekreft skredområde",
@@ -641,9 +641,9 @@
         "TITLE": "Skredfarevurdering"
       },
       "AVALANCHE_OBS": {
-        "AREA_END": "Tegn utløpsområde",
-        "AREA_START": "Tegn løsneområde",
-        "AREA_TOTAL": "Tegn hele skredområdet",
+        "AREA_END": "Utløpsområde",
+        "AREA_START": "Løsneområde",
+        "AREA_TOTAL": "Totalt skredområde",
         "AVALANCHE_AREA": "Skredområde",
         "RELEASE_AREA": "Løsneområde",
         "RUNOUT_AREA": "Utløpsområde",
@@ -856,6 +856,7 @@
         "DESCRIBE_HEIGHT": "Beskriv høyde",
         "DESCRIBE_SITUATION": "Hvordan vil du beskrive situasjonen?",
         "DT_REQUIRED_TEXT": "Tidspunkt er obligatorisk!",
+        "FLOOD_AREA": "Flomområde",
         "HOW_DO_YOU_READ": "Hvordan leser du av vannstanden?",
         "MARKED_WITH": "Jeg har markert vannstanden med",
         "MARKING": "Markering",
@@ -869,7 +870,7 @@
         "RELATIVE": "Høyden er relativ til",
         "SET_FLOOD_POSITION_CONFIRM": "Bekreft flomområde",
         "SET_FLOOD_POSITION_SUMMARY_TITLE": "Inntegning av område",
-        "SET_FLOOD_POSITION_TITLE": "Sett flomposisjon",
+        "SET_FLOOD_POSITION_TITLE": "Sett flomområde",
         "TITLE": "Vannstand",
         "WATER_LEVEL_METERS": "Vannstand i meter",
         "WATER_MARKING": "Vannstandsmarkering",


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/RO-2816
Når jeg skulle prøve å gjenskape problemet viste det seg at markering av flomområde ikke funket lengre. Dette forsvant ved fullføring av denne: #836, så det er en ganske ny feil.

Jeg har tryllet fram visning av polygonet igjen og lagt til egen bildetekst for flomområde.
Fikset også litt på bildetekster og beskrivelse ved tegning av områder for alle skjema hvor man kan legge inn polygon: Vann-observasjon, Snøskredhendelse og Jordskredhendelse.

Test:
1. Vis vannobservasjon med flomområde i listevisning / detaljvisning. Polygon med "tooltip" = "Flomområde vises i interaktivt kart når du klikker på kartet
2. Snø- og jordobservasjon har fått justert litt på tooltips
3. Tekster som vises når du skal tegne flom-, snøskred- og jordskredområde er også justert noe.