### PR TITLE
RO-3026: Fått knappen til å legge til lag øverst til å virke igjen

### DIFF
--- a/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-layer-modal/strat-profile-layer-modal.page.ts
+++ b/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-layer-modal/strat-profile-layer-modal.page.ts
@@ -74,7 +74,9 @@ export class StratProfileLayerModalPage implements OnInit {
   private translateService = inject(TranslateService);
   private draftRepository = inject(DraftRepositoryService);
 
+  // indeks for laget. Bruk -1 for å legge til lag øverst og index = antall lag for å legge til lag nederst
   readonly index = input.required<number>();
+
   readonly uuid = input.required<string>();
   draft = this.draftRepository.getDraftSignal(this.uuid);
   private readonly backupHandler = injectBackupHandler({ uuid: this.uuid });
@@ -82,7 +84,11 @@ export class StratProfileLayerModalPage implements OnInit {
   currentIndex = linkedSignal(() => this.index());
   okPressed = linkedSignal(() => this.currentIndex() === Infinity); // Start alltid false
   layers = linkedSignal(() => this.draft()?.registration.SnowProfile2?.StratProfile?.Layers || []);
-  layer = computed(() => this.layers()[this.currentIndex()]);
+  layer = computed(() => {
+    const i = this.currentIndex();
+    if (i < 0) return undefined;
+    return this.layers()[i];
+  });
   isNewLayer = computed(() => this.layer() == null);
 
   // Form values
@@ -174,7 +180,11 @@ export class StratProfileLayerModalPage implements OnInit {
   addOrUpdateLayer() {
     const layer = this.getEdit();
     if (this.isNewLayer()) {
-      this.layers.update((layers) => [...layers, layer]);
+      if (this.index() === -1) {
+        this.layers.update((layers) => [layer, ...layers]); // legg til øverst
+      } else {
+        this.layers.update((layers) => [...layers, layer]); // legg til nederst
+      }
     } else {
       const index = this.currentIndex();
       this.layers.update((layers) => layers.map((l, i) => (i === index ? layer : l)));
@@ -214,7 +224,12 @@ export class StratProfileLayerModalPage implements OnInit {
     await this.save();
 
     if (gotoIndex != null) {
-      this.currentIndex.update((i) => i + gotoIndex);
+      if (this.currentIndex() === -1) {
+        // vi la til et nytt lag øverst, som nå er lagret på index 0, derfor blir neste lag på index 1
+        this.currentIndex.set(1);
+      } else {
+        this.currentIndex.update((i) => i + gotoIndex);
+      }
     } else {
       this.modalController.dismiss();
     }

--- a/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-modal/strat-profile-modal.page.ts
+++ b/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-modal/strat-profile-modal.page.ts
@@ -127,7 +127,7 @@ export class StratProfileModalPage {
   }
 
   addLayerTop(): void {
-    this.addOrEditLayer(0);
+    this.addOrEditLayer(-1);
   }
 
   addLayerBottom(): void {


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/RO-3026
Nå skal det virke å legge til nytt lag over lagene som er lagt inn.

Jeg ser det også går an å navigere forbi alle lag som er lagt inn og legge til nye lag på denne måten, men jeg har ikke lagt inn støtte for å navigere "bakover/oppover" og forbi øverste lag.
