### PR TITLE
Legg til vasking av koordinater og egenskaper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,8 @@
         "@placemarkio/check-geojson": "^0.1.14",
         "@sentry/browser": "^7.37.2",
         "@tmcw/togeojson": "^7.1.2",
+        "@turf/clean-coords": "^7.2.0",
+        "@turf/truncate": "^7.2.0",
         "@turf/turf": "^7.1.0",
         "@types/leaflet-draw": "^1.0.6",
         "angular-svg-icon": "^16.1.0",
@@ -10175,36 +10177,42 @@
       }
     },
     "node_modules/@turf/clean-coords": {
-      "version": "7.1.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.2.0.tgz",
+      "integrity": "sha512-+5+J1+D7wW7O/RDXn46IfCHuX1gIV1pIAQNSA7lcDbr3HQITZj334C4mOGZLEcGbsiXtlHWZiBtm785Vg8i+QQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^7.1.0",
-        "@turf/invariant": "^7.1.0",
+        "@turf/helpers": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/clean-coords/node_modules/@turf/helpers": {
-      "version": "7.1.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/clean-coords/node_modules/@turf/invariant": {
-      "version": "7.1.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.2.0.tgz",
+      "integrity": "sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^7.1.0",
+        "@turf/helpers": "^7.2.0",
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -11950,6 +11958,19 @@
         "@turf/square": "^6.5.0",
         "@turf/truncate": "^6.5.0",
         "geojson-rbush": "3.x"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split/node_modules/@turf/truncate": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-6.5.0.tgz",
+      "integrity": "sha512-pFxg71pLk+eJj134Z9yUoRhIi8vqnnKvCYwdT4x/DQl/19RVdq1tV3yqOT3gcTQNfniteylL5qV1uTBDV5sgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -13807,11 +13828,41 @@
       }
     },
     "node_modules/@turf/truncate": {
-      "version": "6.5.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.2.0.tgz",
+      "integrity": "sha512-jyFzxYbPugK4XjV5V/k6Xr3taBjjvo210IbPHJXw0Zh7Y6sF+hGxeRVtSuZ9VP/6oRyqAOHKUrze+OOkPqBgUg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/helpers": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate/node_modules/@turf/helpers": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate/node_modules/@turf/meta": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
+      "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -14152,19 +14203,6 @@
       "dependencies": {
         "@turf/distance": "^7.1.0",
         "@turf/helpers": "^7.1.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/turf/node_modules/@turf/truncate": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@turf/helpers": "^7.1.0",
-        "@turf/meta": "^7.1.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "@placemarkio/check-geojson": "^0.1.14",
     "@sentry/browser": "^7.37.2",
     "@tmcw/togeojson": "^7.1.2",
+    "@turf/clean-coords": "^7.2.0",
+    "@turf/truncate": "^7.2.0",
     "@turf/turf": "^7.1.0",
     "@types/leaflet-draw": "^1.0.6",
     "angular-svg-icon": "^16.1.0",

--- a/src/app/core/services/geojson/geojson.service.ts
+++ b/src/app/core/services/geojson/geojson.service.ts
@@ -4,6 +4,7 @@ import { FeatureCollection } from 'geojson';
 import { GeoJSONItem } from './geojson-item.model';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
 import { toObservable } from '@angular/core/rxjs-interop';
+import { cleanFeatureCollection } from 'src/app/pages/plans/geojson';
 
 const DEBUG_TAG = 'GeoJSON';
 
@@ -54,6 +55,12 @@ export class GeoJSONService {
    */
   async save(metadata: GeoJSONItem, geojson: FeatureCollection): Promise<void> {
     this.logger.debug('Save', DEBUG_TAG, { metadata });
+    try {
+      cleanFeatureCollection(geojson);
+    } catch (error) {
+      this.logger.error(error, DEBUG_TAG, 'Error in cleaning process, but object may be mutated - half cleaned');
+    }
+
     try {
       await this.db.set(`geojson:${metadata.id}`, geojson);
       this.metadata.update((items) => [...items, metadata]);

--- a/src/app/pages/plans/geojson.spec.ts
+++ b/src/app/pages/plans/geojson.spec.ts
@@ -1,0 +1,173 @@
+import { cleanFeatureCollection } from './geojson';
+import { FeatureCollection, Point, LineString } from 'geojson';
+
+describe('cleanFeatureCollection', () => {
+  it('should remove all properties from features', () => {
+    const fc: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [10, 60, 100] },
+          properties: { foo: 'bar', keep: 123 },
+        },
+      ],
+    };
+    cleanFeatureCollection(fc);
+    expect(fc.features[0].properties).toEqual({});
+  });
+
+  it('should handle all geometry types', () => {
+    const fc: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [1.1234567, 2.2345678, 3.3456789] },
+          properties: { a: 1 },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            coordinates: [
+              [1.1234567, 2.2345678, 3.3],
+              [4.4, 5.5, 6.6],
+            ],
+          },
+          properties: { b: 2 },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [1.1234567, 2.2345678, 3.3],
+                [4.4, 5.5, 6.6],
+                [7.7, 8.8, 9.9],
+                [1.1234567, 2.2345678, 3.3],
+              ],
+            ],
+          },
+          properties: { c: 3 },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'MultiPoint',
+            coordinates: [
+              [1.1, 2.2, 3.3],
+              [4.4, 5.5, 6.6],
+            ],
+          },
+          properties: { d: 4 },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'MultiLineString',
+            coordinates: [
+              [
+                [1.1, 2.2, 3.3],
+                [4.4, 5.5, 6.6],
+              ],
+              [
+                [7.7, 8.8, 9.9],
+                [10.1, 11.2, 12.3],
+              ],
+            ],
+          },
+          properties: { e: 5 },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'MultiPolygon',
+            coordinates: [
+              [
+                [
+                  [1.1, 2.2, 3.3],
+                  [4.4, 5.5, 6.6],
+                  [7.7, 8.8, 9.9],
+                  [1.1, 2.2, 3.3],
+                ],
+              ],
+            ],
+          },
+          properties: { f: 6 },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'GeometryCollection',
+            geometries: [
+              { type: 'Point', coordinates: [1.1234567, 2.2345678, 3.3] },
+              {
+                type: 'LineString',
+                coordinates: [
+                  [1.1, 2.2, 3.3],
+                  [4.4, 5.5, 6.6],
+                ],
+              },
+            ],
+          },
+          properties: { g: 7 },
+        },
+      ],
+    };
+    expect(() => cleanFeatureCollection(fc)).not.toThrow();
+    // For nå tester denne bare at egenskapene er nullstilt
+    // (og at ikke cleanFeatureCollection kræsjer for en eller flere av geometritypene)
+    for (const feature of fc.features) {
+      expect(feature.properties).toEqual({});
+    }
+  });
+
+  it('should truncate coordinates to 6 decimals and remove height', () => {
+    const fc: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [10.123456789, 60.987654321, 123.456] },
+          properties: {},
+        },
+      ],
+    };
+    cleanFeatureCollection(fc);
+    const coords = (fc.features[0].geometry as Point).coordinates;
+    expect(coords.length).toBe(2);
+    expect(coords[0]).toBeCloseTo(10.123457, 6);
+    expect(coords[1]).toBeCloseTo(60.987654, 6);
+  });
+
+  it('should handle LineString and remove all properties', () => {
+    const fc: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            coordinates: [
+              [10.123456789, 60.987654321, 123.456],
+              [11.123456789, 61.987654321, 223.456],
+            ],
+          },
+          properties: { foo: 'bar' },
+        },
+      ],
+    };
+    cleanFeatureCollection(fc);
+    const coords = (fc.features[0].geometry as LineString).coordinates;
+    expect(coords[0].length).toBe(2);
+    expect(coords[1].length).toBe(2);
+    expect(fc.features[0].properties).toEqual({});
+  });
+
+  it('should not throw on empty FeatureCollection', () => {
+    const fc: FeatureCollection = { type: 'FeatureCollection', features: [] };
+    expect(() => cleanFeatureCollection(fc)).not.toThrow();
+  });
+});

--- a/src/app/pages/plans/geojson.ts
+++ b/src/app/pages/plans/geojson.ts
@@ -1,0 +1,46 @@
+import { FeatureCollection, Geometry, GeometryCollection } from 'geojson';
+import { cleanCoords } from '@turf/clean-coords';
+import { truncate } from '@turf/truncate';
+
+/**
+ * For nå fjerner denne bare alle properties fra hver feature.
+ * Vi må sikkert legge til noen tillatte egenskaper her etter hvert som vi kan bruke.
+ * Denne endrer objektet som sendes inn.
+ */
+function removeProperties(fc: FeatureCollection) {
+  for (const feature of fc.features) {
+    feature.properties = {};
+  }
+}
+
+function isGeometryCollection(geometry: Geometry): geometry is GeometryCollection {
+  return geometry.type === 'GeometryCollection';
+}
+
+/**
+ * Fjerner eventuelle unødvendige koordinatpar fra geometriene.
+ */
+function cleanCoordinates(geometry: Geometry) {
+  if (isGeometryCollection(geometry)) {
+    for (const g of geometry.geometries) {
+      cleanCoordinates(g);
+    }
+  } else {
+    cleanCoords(geometry, { mutate: true });
+  }
+}
+
+/**
+ * Fjerner unødvendige koordinater/desimaler og egenskaper.
+ * Endrer objektet som sendes inn (dette er raskest).
+ */
+export function cleanFeatureCollection(fc: FeatureCollection) {
+  // NB: coordinates: 2 fjerner høydekoordinat.
+  // Vi bruker ikke høyde til noe enda, derfor fjernes den.
+  // Tror ikke vi kan anta at alle importerte geojson / gpx har høyde, tenker derfor det er like greit å fjerne den.
+  truncate(fc, { mutate: true, precision: 6, coordinates: 2 });
+  for (const feature of fc.features) {
+    cleanCoordinates(feature.geometry);
+  }
+  removeProperties(fc);
+}


### PR DESCRIPTION
Fjerner alle properties fra importerte gpx-filer, og vasker/trunkerer koordinater.

Dette er nok litt for strengt, men vi kan heller tillate noen feature properties etter hvert, når vi trenger de til noe.