### PR TITLE
RO-3031: Import av GeoJSON-filer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@ngx-translate/core": "^16.0.4",
         "@ngx-translate/http-loader": "^16.0.1",
         "@openid/appauth": "^1.3.1",
+        "@placemarkio/check-geojson": "^0.1.14",
         "@sentry/browser": "^7.37.2",
         "@tmcw/togeojson": "^7.1.2",
         "@turf/turf": "^7.1.0",
@@ -7658,6 +7659,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@placemarkio/check-geojson": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@placemarkio/check-geojson/-/check-geojson-0.1.14.tgz",
+      "integrity": "sha512-PZvNKzt6STytUw21TUkqU+TG6dbwTWb1ACosvInBYTBm37zsr8C74J6crBTQ3BWkyd6YeitYd4HibJzBEyk6Aw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@ngx-translate/core": "^16.0.4",
     "@ngx-translate/http-loader": "^16.0.1",
     "@openid/appauth": "^1.3.1",
+    "@placemarkio/check-geojson": "^0.1.14",
     "@sentry/browser": "^7.37.2",
     "@tmcw/togeojson": "^7.1.2",
     "@turf/turf": "^7.1.0",

--- a/src/app/pages/plans/gpx.ts
+++ b/src/app/pages/plans/gpx.ts
@@ -1,10 +1,11 @@
 import { FileSystemEntry } from 'ngx-file-drop';
 import { assertIsFileEntry, toText } from './utils';
 import { gpx } from '@tmcw/togeojson';
+import { isGpxFile } from './utils';
 
 function assertIsGpxFile(fileEntry: FileSystemEntry): asserts fileEntry is FileSystemFileEntry {
   assertIsFileEntry(fileEntry);
-  if (!fileEntry.name.toLowerCase().endsWith('.gpx')) {
+  if (!isGpxFile(fileEntry)) {
     throw new Error('fileEntry is not GPX file');
   }
 }

--- a/src/app/pages/plans/plans.page.html
+++ b/src/app/pages/plans/plans.page.html
@@ -14,7 +14,7 @@
     <p>{{ item.name }} - {{ item.id }} - {{ item.date }}</p>
   }
 
-  <ngx-file-drop dropZoneClassName="drop-zone" [accept]="'.gpx'" (onFileDrop)="onFileDrop($event)">
+  <ngx-file-drop dropZoneClassName="drop-zone" [accept]="'.gpx, .geojson, .json'" (onFileDrop)="onFileDrop($event)">
     <ng-template ngx-file-drop-content-tmp let-openFileSelector="openFileSelector">
       <button type="button" (click)="openFileSelector()">
         <h1>{{ "PLANS.IMPORT_BUTTON.CAPTION" | translate }}</h1>

--- a/src/app/pages/plans/plans.page.ts
+++ b/src/app/pages/plans/plans.page.ts
@@ -7,7 +7,7 @@ import 'nve-designsystem/components/nve-button/nve-button.component.js';
 import 'nve-designsystem/components/nve-icon/nve-icon.component.js';
 import 'nve-designsystem/components/nve-message-card/nve-message-card.component.js';
 import { NgxFileDropEntry, NgxFileDropModule } from 'ngx-file-drop';
-import { toGeoJSON } from './gpx';
+import { toGeoJSON } from './utils';
 import { GeoJSONService } from 'src/app/core/services/geojson/geojson.service';
 import { GeoJSONItem } from 'src/app/core/services/geojson/geojson-item.model';
 import { generateShortRandomId } from './utils';

--- a/src/app/pages/plans/utils.ts
+++ b/src/app/pages/plans/utils.ts
@@ -1,9 +1,20 @@
 import { FileSystemEntry } from 'ngx-file-drop';
+import { toGeoJSON as gpxToGeoJSON } from './gpx';
+import { FeatureCollection } from 'geojson';
+import { check } from '@placemarkio/check-geojson';
 
 export function assertIsFileEntry(fileEntry: FileSystemEntry): asserts fileEntry is FileSystemFileEntry {
   if (!fileEntry.isFile) {
     throw new Error('fileEntry is not a file');
   }
+}
+
+export function isGpxFile(fileEntry: FileSystemEntry): boolean {
+  return fileEntry.name.toLowerCase().endsWith('.gpx');
+}
+
+function isGeoJSONFile(fileEntry: FileSystemEntry): boolean {
+  return fileEntry.name.toLowerCase().endsWith('.geojson') || fileEntry.name.toLowerCase().endsWith('.json');
 }
 
 export function toText(fileEntry: FileSystemFileEntry): Promise<string> {
@@ -24,4 +35,17 @@ export function generateShortRandomId(length = 6) {
   return Math.random()
     .toString(36)
     .substring(2, length + 2);
+}
+
+// leser en GPX- eller GeoJSON-fil og returnerer et GeoJSON-objekt
+export async function toGeoJSON(fileEntry: FileSystemEntry): Promise<FeatureCollection> {
+  assertIsFileEntry(fileEntry);
+  if (isGpxFile(fileEntry)) {
+    return await gpxToGeoJSON(fileEntry);
+  }
+  if (isGeoJSONFile(fileEntry)) {
+    const fileContent = await toText(fileEntry);
+    return check(fileContent) as FeatureCollection; // hvis denne blir for kresen, kan vi prøve scavenge i stedet
+  }
+  throw new Error('Unsupported file type. Only GPX and GeoJSON files are supported.');
 }


### PR DESCRIPTION
Ikke så mye å si om denne, annet enn at det nå skal gå an å importere GeoJSON-filer. Både filer som ender på .json og .geojson aksepteres.
Har tatt inn et ny bibliotek, @placemarkio/check-geojson, for å parse og validere GeoJSON-tekst, så husk `npm i`.
Jeg får ikke til å se inneholdet i Ionic Storage i Edge, men i Chrome kan jeg se GeoJSON vi har importert.
<img width="1256" height="388" alt="image" src="https://github.com/user-attachments/assets/1e79b9df-6e58-4042-9b8f-9111bad26d16" />