### PR TITLE
RO-3059: Offlinekart med sas-token

### DIFF
--- a/src/app/core/services/offline-map/offline-map.service.spec.ts
+++ b/src/app/core/services/offline-map/offline-map.service.spec.ts
@@ -27,7 +27,7 @@ describe('OfflineMapService', () => {
       'PackageIndexService',
       {},
       {
-        packages$: packages.asObservable(),
+        map$: packages,
       }
     );
 
@@ -53,11 +53,12 @@ describe('OfflineMapService', () => {
 
   it('get needed diskspace adds compression factor', async () => {
     const cp = new CompoundPackage({
-      bbox: [1, 2, 3, 4],
-      id: 'test',
-      xyz: [1, 2, 3],
-      sizeInMib: 1.0,
-      maps: [],
+      Bbox: [1, 2, 3, 4],
+      Id: 'test',
+      Xyz: [1, 2, 3],
+      SizeInMib: 1.0,
+      ZMax: 0,
+      Maps: [],
     });
 
     const compressionFactor = 1.5;
@@ -68,11 +69,12 @@ describe('OfflineMapService', () => {
 
   it('get needed diskspace also sums up items in queue and currently downloading', async () => {
     const cp = new CompoundPackage({
-      bbox: [1, 2, 3, 4],
-      id: 'test',
-      xyz: [1, 2, 3],
-      sizeInMib: 1.0,
-      maps: [],
+      Bbox: [1, 2, 3, 4],
+      Id: 'test',
+      Xyz: [1, 2, 3],
+      SizeInMib: 1.0,
+      ZMax: 0,
+      Maps: [],
     });
 
     offlineMapService.downloadAndUnzipProgress$ = of([

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -86,7 +86,7 @@ export class OfflineMapService implements OnReset {
         this.loggingService.error(err, DEBUG_TAG, 'Failed to get map packages');
       });
 
-    combineLatest([this.packageIndex.packages$, this.packages$])
+    combineLatest([this.packageIndex.map$, this.packages$])
       .pipe(takeUntil(this.hasOutdatedPackages$))
       .subscribe(([packageIndex, downloadedPackages]) => {
         for (const downloadedPackage of downloadedPackages) {
@@ -203,13 +203,19 @@ export class OfflineMapService implements OnReset {
     }
   }
 
-  private startDownloadPackage(offlineMapPackage: OfflineMapPackage) {
+  private async startDownloadPackage(offlineMapPackage: OfflineMapPackage) {
     if (offlineMapPackage.compoundPackageMetadata == null) {
       throw new Error('compoundPackageMetadata are required when downloading packages');
     }
 
+    const queryParams = await this.packageIndex.getSasQueryParams();
+
     // Find all zip-files (urls) to download and unzip
-    const parts = offlineMapPackage.compoundPackageMetadata.getParts();
+    // Attach query params to all urls
+    const parts = offlineMapPackage.compoundPackageMetadata.getParts().map((part) => ({
+      ...part,
+      url: part.url + queryParams,
+    }));
 
     // Start recursive download and unzip
     this.downloadAndUnzipPart(parts[0], parts, offlineMapPackage, 0);

--- a/src/app/core/services/offline-map/offline-map.service.ts
+++ b/src/app/core/services/offline-map/offline-map.service.ts
@@ -208,7 +208,13 @@ export class OfflineMapService implements OnReset {
       throw new Error('compoundPackageMetadata are required when downloading packages');
     }
 
-    const queryParams = await this.packageIndex.getSasQueryParams();
+    let queryParams: string;
+    try {
+      queryParams = await this.packageIndex.getSasQueryParams();
+    } catch (error) {
+      this.onUnzipOrDownloadError(offlineMapPackage, error, true, 'Could not fetch sas query params');
+      return;
+    }
 
     // Find all zip-files (urls) to download and unzip
     // Attach query params to all urls

--- a/src/app/core/services/offline-map/package-index.service.ts
+++ b/src/app/core/services/offline-map/package-index.service.ts
@@ -56,7 +56,7 @@ export class PackageIndexService {
   map = computed(() => new Map(this.index().map((pkg) => [pkg.getName(), pkg])));
   map$ = toObservable(this.map);
 
-  async getSasQueryParams() {
+  getSasQueryParams() {
     const url = `${this.apiUrl()}/OfflineMap/QueryString`;
     return firstValueFrom(this.httpClient.get(url, { headers: { accept: 'text/plain' }, responseType: 'text' }));
   }

--- a/src/app/core/services/offline-map/package-index.service.ts
+++ b/src/app/core/services/offline-map/package-index.service.ts
@@ -1,32 +1,63 @@
-import { HttpClient } from '@angular/common/http';
-import { Injectable, inject } from '@angular/core';
-import { Observable, map, shareReplay } from 'rxjs';
+import { HttpClient, httpResource } from '@angular/common/http';
+import { Injectable, computed, inject } from '@angular/core';
+import { firstValueFrom, map } from 'rxjs';
 import { CompoundPackage, CompoundPackageMetadata } from 'src/app/pages/offline-map/metadata.model';
+import { UserSettingService } from '../user-setting/user-setting.service';
+import { settings } from 'src/settings';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 
-type PackageIndex = CompoundPackageMetadata[];
-
-const PACKAGE_INDEX_URL = 'https://offlinemap.blob.core.windows.net/metadata/packageIndex_v5.json';
+interface ApiResponse {
+  Items: CompoundPackageMetadata[];
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class PackageIndexService {
-  packages$: Observable<Map<string, CompoundPackage>>;
+  private userSettings = inject(UserSettingService);
+  private httpClient = inject(HttpClient);
 
-  constructor() {
-    const http = inject(HttpClient);
+  private apiUrl = toSignal(
+    this.userSettings.appMode$.pipe(map((appMode) => settings.services.regObs.apiUrl[appMode] as string | undefined))
+  );
 
-    // Download package index from azure
-    this.packages$ = http.get<PackageIndex>(PACKAGE_INDEX_URL).pipe(
-      // Map downloaded package index to a packageName => package map
-      map((packageIndex) => {
-        const nameAndPkg: [string, CompoundPackage][] = packageIndex.map((p) => [
-          CompoundPackage.GetNameFromXYZ(...p.xyz),
-          new CompoundPackage(p),
-        ]);
-        return new Map(nameAndPkg);
-      }),
-      shareReplay()
-    );
+  private indexResource = httpResource<ApiResponse>(() => `${this.apiUrl()}/OfflineMap/PackageIndex`);
+
+  /**
+   * true mens api-responsen laster.
+   */
+  isLoading = this.indexResource.isLoading;
+
+  /**
+   * Signal med error, hvis noe med api-responsen har feila.
+   */
+  error = this.indexResource.error;
+
+  /**
+   * Kartpakke-indeksen
+   */
+  index = computed(
+    () => {
+      if (!this.indexResource.hasValue()) {
+        return [];
+      }
+      const response = this.indexResource.value();
+      if (!response) {
+        return [];
+      }
+      return response.Items.map((mapPackage) => new CompoundPackage(mapPackage));
+    },
+    { equal: (a, b) => a.length === b.length }
+  );
+
+  /**
+   * Map med kartpakkenavn som nøkkel: "name" -> "DownloadableMapPackage"
+   */
+  map = computed(() => new Map(this.index().map((pkg) => [pkg.getName(), pkg])));
+  map$ = toObservable(this.map);
+
+  async getSasQueryParams() {
+    const url = `${this.apiUrl()}/OfflineMap/QueryString`;
+    return firstValueFrom(this.httpClient.get(url, { headers: { accept: 'text/plain' }, responseType: 'text' }));
   }
 }

--- a/src/app/core/services/offline-map/utils.spec.ts
+++ b/src/app/core/services/offline-map/utils.spec.ts
@@ -4,22 +4,23 @@ import { isPackageOutdated } from './utils';
 
 describe('isPackageOutdated', () => {
   const packageOnServer = new CompoundPackage({
-    bbox: [1, 2, 3, 4],
-    id: 'pakke-1',
-    xyz: [1, 2, 3],
-    sizeInMib: 1.0,
-    maps: [
+    Bbox: [1, 2, 3, 4],
+    Id: 'pakke-1',
+    Xyz: [1, 2, 3],
+    SizeInMib: 1.0,
+    ZMax: 0,
+    Maps: [
       {
-        name: '1',
-        lastModified: '2021-01-01T00:00:01Z',
-        urls: [],
-        sizeInMib: 0,
+        Name: '1',
+        LastModified: '2021-01-01T00:00:01Z',
+        Urls: [],
+        SizeInMib: 0,
       },
       {
-        name: '2',
-        lastModified: '2021-01-03T00:00:01Z',
-        urls: [],
-        sizeInMib: 0,
+        Name: '2',
+        LastModified: '2021-01-03T00:00:01Z',
+        Urls: [],
+        SizeInMib: 0,
       },
     ],
   });

--- a/src/app/pages/offline-map/metadata.model.ts
+++ b/src/app/pages/offline-map/metadata.model.ts
@@ -5,19 +5,20 @@ type XYZ = [number, number, number];
 
 /** Opplysninger om et offlinekart for et begrenset område */
 export interface PackageMetadata {
-  name: string;
-  lastModified: string; // in UTC
-  urls: string[];
-  sizeInMib: number;
+  Name: string;
+  LastModified: string; // in UTC
+  Urls: string[];
+  SizeInMib: number;
 }
 
 /** Opplysninger om en sammensatt kartpakke. Består gjerne av både bakgrunnskart og hjelpekart (f.eks. svekket is) */
 export interface CompoundPackageMetadata {
-  id: string;
-  xyz: XYZ;
-  bbox: BBox;
-  sizeInMib: number;
-  maps: PackageMetadata[];
+  Id: string;
+  Xyz: XYZ;
+  Bbox: BBox;
+  SizeInMib: number;
+  Maps: PackageMetadata[];
+  ZMax: number;
 }
 
 export interface Part {
@@ -43,11 +44,11 @@ export class CompoundPackage {
   }
 
   getFeature(): CompoundPackageFeature {
-    const [xMin, yMin, xMax, yMax] = this.metadata.bbox;
+    const [xMin, yMin, xMax, yMax] = this.metadata.Bbox;
     return {
       type: 'Feature',
       geometry: {
-        bbox: this.metadata.bbox,
+        bbox: this.metadata.Bbox,
         type: 'Polygon',
         coordinates: [
           [
@@ -60,25 +61,25 @@ export class CompoundPackage {
         ],
       },
       properties: null,
-      id: CompoundPackage.GetFeatureId(...this.metadata.xyz),
+      id: CompoundPackage.GetFeatureId(...this.metadata.Xyz),
     };
   }
 
   getSizeInMiB(): number {
-    return this.metadata.sizeInMib;
+    return this.metadata.SizeInMib;
   }
 
   getName(): string {
-    const [x, y, z] = this.metadata.xyz;
+    const [x, y, z] = this.metadata.Xyz;
     return CompoundPackage.GetNameFromXYZ(x, y, z);
   }
 
   /** Returnerer produksjonstidspunkt for den nyeste pakka. Hvis produksjonstidspunkt mangler, returneres 01.01.1970 00:00 */
   getLastModified(): Date {
     let latestDate = moment(0);
-    for (const map of this.metadata.maps) {
-      if (map.lastModified) {
-        latestDate = moment.max(latestDate, moment(map.lastModified));
+    for (const map of this.metadata.Maps) {
+      if (map.LastModified) {
+        latestDate = moment.max(latestDate, moment(map.LastModified));
       }
     }
     return latestDate.toDate();
@@ -86,15 +87,15 @@ export class CompoundPackage {
 
   getParts(): Part[] {
     return (
-      this.metadata.maps
+      this.metadata.Maps
         // Hent name / url for alle pakker
-        .map((p) => p.urls.map((url) => ({ name: p.name, url })))
+        .map((p) => p.Urls.map((url) => ({ name: p.Name, url })))
         // Flatten array
         .reduce((a, b) => a.concat(b), [])
     );
   }
 
   getXYZ(): XYZ {
-    return this.metadata.xyz;
+    return this.metadata.Xyz;
   }
 }

--- a/src/app/pages/offline-map/offline-map.page.html
+++ b/src/app/pages/offline-map/offline-map.page.html
@@ -44,11 +44,11 @@
         class="expand-icon"
       ></ion-icon>
     </ion-item>
-    <ng-container *ngIf="nPackagesToUpdate$ | async as nPackagesToUpdate">
-      <ion-item *ngIf="nPackagesToUpdate" lines="full" color="warning" (click)="expanded = !expanded">
-        <ion-label>{{ "OFFLINE_MAP.N_PACKAGES_TO_UPDATE" | translate: { n: nPackagesToUpdate } }}</ion-label>
+    @if (nPackagesToUpdate() > 0) {
+      <ion-item lines="full" color="warning" (click)="expanded = !expanded">
+        <ion-label>{{ "OFFLINE_MAP.N_PACKAGES_TO_UPDATE" | translate: { n: nPackagesToUpdate() } }}</ion-label>
       </ion-item>
-    </ng-container>
+    }
     <div class="footer">
       <ng-container *ngIf="expanded">
         <ion-item (click)="showPackageModalForPackage(item)" *ngFor="let item of allPackages$ | async" lines="full">

--- a/src/app/pages/offline-map/offline-map.page.ts
+++ b/src/app/pages/offline-map/offline-map.page.ts
@@ -1,4 +1,4 @@
-import { Component, NgZone, inject } from '@angular/core';
+import { Component, NgZone, inject, signal } from '@angular/core';
 import { OfflineMapService } from '../../core/services/offline-map/offline-map.service';
 import { OfflineMapPackage } from '../../core/services/offline-map/offline-map.model';
 import { HelperService } from '../../core/services/helpers/helper.service';
@@ -107,7 +107,7 @@ export class OfflineMapPage extends NgDestoryBase {
   featureMap = new Map<string, { feature: CompoundPackageFeature; layer: L.Layer }>();
   expanded = false; //show list of downloads if this is true
 
-  nPackagesToUpdate$ = new Subject<number>();
+  nPackagesToUpdate = signal(0);
 
   constructor() {
     super();
@@ -148,7 +148,7 @@ export class OfflineMapPage extends NgDestoryBase {
         n++;
       }
     }
-    this.nPackagesToUpdate$.next(n);
+    this.nPackagesToUpdate.set(n);
   }
 
   onMapReady(map: L.Map) {
@@ -174,13 +174,13 @@ export class OfflineMapPage extends NgDestoryBase {
 
     map.addLayer(this.tilesLayer);
 
-    this.packageIndex.packages$.subscribe((packages) => {
+    this.packageIndex.map$.subscribe((packages) => {
       packages.forEach((mapPackage) => {
         this.tilesLayer?.addData(mapPackage.getFeature());
       });
     });
 
-    combineLatest([this.installedPackages$, this.packageIndex.packages$])
+    combineLatest([this.installedPackages$, this.packageIndex.map$])
       .pipe(takeUntil(this.ngDestroy$))
       .subscribe(([installedPackages, packageIndex]) => {
         this.installedPackages = installedPackages;


### PR DESCRIPTION
Bør ikke tas inn før API-endringen er tatt inn.

Appen henter nå kartpakkeindeks fra apiet, og henter nøkkel fra apiet før nedlasting.