### PR TITLE
RO-3081: Fikset visning av tidspunkt

### DIFF
--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, NgZone, OnInit, inject } from '@angular/core';
-import { firstValueFrom, from, map, Observable, switchMap, takeUntil } from 'rxjs';
+import { firstValueFrom, map, Observable, of, switchMap, takeUntil } from 'rxjs';
 import { RegistrationTid, SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { UserGroupService } from '../../../../core/services/user-group/user-group.service';
 import { ISummaryItem } from '../../components/summary-item/summary-item.model';
@@ -107,7 +107,7 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
   summaryItems$: Observable<Array<ISummaryItem>> = this.draft$.pipe(
     switchMap((draft) => {
       if (this.showSimpleSnowMode(draft) || this.showSimpleWaterMode(draft)) {
-        return from(this.getLocationAndTimeSummaryItem(draft));
+        return of(this.getLocationAndTimeSummaryItem(draft));
       } else {
         return this.summaryItemService.getSummaryItems$(this.uuid);
       }
@@ -137,8 +137,8 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
     return this.draftHasStatusSync(draft) ? !!draft.error : false;
   }
 
-  private async getLocationAndTimeSummaryItem(draft: RegistrationDraft): Promise<ISummaryItem[]> {
-    return [await this.summaryItemService.getLocationAndTimeSummaryItem(draft)];
+  private getLocationAndTimeSummaryItem(draft: RegistrationDraft): ISummaryItem[] {
+    return [this.summaryItemService.getLocationAndTimeSummaryItem(draft)];
   }
 
   showSimpleSnowMode(draft: RegistrationDraft): boolean {

--- a/src/app/modules/registration/services/summary-item.service.ts
+++ b/src/app/modules/registration/services/summary-item.service.ts
@@ -126,7 +126,7 @@ export class SummaryItemService {
     );
   }
 
-  async getLocationAndTimeSummaryItem(draft: RegistrationDraft): Promise<ISummaryItem> {
+  getLocationAndTimeSummaryItem(draft: RegistrationDraft): ISummaryItem {
     const reg = draft.registration;
     const locSummary = reg.ObsLocation?.LocationName || reg.ObsLocation?.LocationDescription || '';
     const timeSummary = reg.DtObsTime ? this.dateHelperService.formatDateString(reg.DtObsTime) : '';

--- a/src/app/modules/registration/services/summary-item.service.ts
+++ b/src/app/modules/registration/services/summary-item.service.ts
@@ -129,7 +129,7 @@ export class SummaryItemService {
   async getLocationAndTimeSummaryItem(draft: RegistrationDraft): Promise<ISummaryItem> {
     const reg = draft.registration;
     const locSummary = reg.ObsLocation?.LocationName || reg.ObsLocation?.LocationDescription || '';
-    const timeSummary = reg.DtObsTime ? await this.dateHelperService.formatDateString(reg.DtObsTime) : '';
+    const timeSummary = reg.DtObsTime ? this.dateHelperService.formatDateString(reg.DtObsTime) : '';
     return {
       uuid: draft.uuid,
       href: '/registration/obs-location',

--- a/src/app/modules/shared/services/date-helper/date-helper.service.spec.ts
+++ b/src/app/modules/shared/services/date-helper/date-helper.service.spec.ts
@@ -1,8 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { DateHelperService } from './date-helper.service';
 import { provideTranslateService, TranslateService } from '@ngx-translate/core';
-import moment from 'moment';
-import 'moment-timezone';
 import { firstValueFrom } from 'rxjs';
 
 describe('DateHelperService', () => {
@@ -14,16 +12,24 @@ describe('DateHelperService', () => {
     });
 
     service = TestBed.inject(DateHelperService);
-    await firstValueFrom(TestBed.inject(TranslateService).use('en'));
+
+    // setter språk for å få norsk datoformat
+    await firstValueFrom(TestBed.inject(TranslateService).use('no'));
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
 
-  it('show basic date', () => {
-    const result = service.formatMoment(moment(new Date(2019, 0, 1)));
-    expect(result).toEqual('Jan 1, 2019, 12:00 AM');
+  it('should format ISO date string as Norwegian date and time', () => {
+    const result = service.formatDateString('2024-06-01T14:30:00');
+    expect(result).toBe('1. juni 2024, 14:30');
+  });
+
+  it('should format Date object as Norwegian date and time', () => {
+    const date = new Date('2024-06-01T14:30:00');
+    const result = service.formatDate(date);
+    expect(result).toBe('1. juni 2024, 14:30');
   });
 
   // Vet ikke helt hvorfor det var veldig viktig å vise hvilken tidssone observasjoner er lagt inn i.

--- a/src/app/modules/shared/services/date-helper/date-helper.service.ts
+++ b/src/app/modules/shared/services/date-helper/date-helper.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, inject } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import moment from 'moment';
 
 @Injectable({
   providedIn: 'root',
@@ -8,10 +7,13 @@ import moment from 'moment';
 export class DateHelperService {
   private translateService = inject(TranslateService);
 
+  /** Formaterer en lokal dato-tekst på ISO-format som lokal dato- og tid */
   formatDateString(dateString: string) {
-    return this.formatMoment(moment.parseZone(dateString));
+    const date = new Date(dateString);
+    return this.formatDate(date);
   }
 
+  /** Formaterer dato og tid som lokal dato- og tid */
   formatDate(date: Date) {
     const locale = this.translateService.currentLang;
     const formatter = new Intl.DateTimeFormat(locale, {
@@ -19,9 +21,5 @@ export class DateHelperService {
       timeStyle: 'short',
     });
     return formatter.format(date);
-  }
-
-  formatMoment(date: moment.Moment) {
-    return this.formatDate(date.toDate());
   }
 }


### PR DESCRIPTION
Se https://nveprojects.atlassian.net/browse/RO-3081
Observasjons-tidspunkt ble vist med en time for mye. Skyldes at datoen ble parset med `moment.parseZone()`, som gikk ut fra at dato-teksten var i UTC.
Har også fjernet noe bruk av `async` som ikke var nødvendig.
NB! Pga. [feilen med at vi ikke alltid henter lokasjon](https://nveprojects.atlassian.net/browse/RO-3086), vises ikke alltid lokasjon foran tidspunkt:
<img width="827" height="302" alt="image" src="https://github.com/user-attachments/assets/4de71c83-ae87-47f5-a637-992ebd39963e" />
