### PR TITLE
RO-3090: Fikset kræsj når man prøver å hente lagdeling fra annen profil

### DIFF
--- a/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-modal/strat-profile-modal.page.ts
+++ b/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-modal/strat-profile-modal.page.ts
@@ -146,6 +146,9 @@ export class StratProfileModalPage {
       if (!this.layerModal) {
         this.layerModal = await this.modalController.create({
           component: StratProfileLayerHistoryModalPage,
+          componentProps: {
+            draft: this.draft(),
+          },
         });
         this.layerModal.present();
         await this.layerModal.onDidDismiss();


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/RO-3090
Vet ikke om denne løser hele problemet, men feilen jeg fant i Sentry som observatøren hadde hatt, greide jeg å gjenskape.
Appen kræsjer når jeg prøver å hente data fra en tidligere snøprofil uten denne fiksen.
Denne kan testes på web lokalt, krever innlogging i appen.
