### PR TITLE
RO-3089: Bruke nytt proxy-endepunkt for å kunne logge inn i PR-bygg

### DIFF
--- a/src/app/modules/auth/factories/auth-factory.ts
+++ b/src/app/modules/auth/factories/auth-factory.ts
@@ -6,8 +6,10 @@ import { UserSettingService } from '../../../core/services/user-setting/user-set
 import { settings } from '../../../../settings';
 import { AppMode } from 'src/app/modules/common-core/models';
 import { RegobsAuthServiceOverride } from '../services/regobs-auth-service-override';
+import { LoggingService } from '../../shared/services/logging/logging.service';
 
 export const AUTH_CALLBACK_PATH = 'auth/callback';
+const DEBUG_TAG = 'AuthFactory';
 
 export const authFactory = (): AuthService => {
   const platform = inject(Platform);
@@ -15,6 +17,7 @@ export const authFactory = (): AuthService => {
   const browser = inject(Browser);
   const storage = inject(StorageBackend);
   const userSettingService = inject(UserSettingService);
+  const logger = inject(LoggingService);
 
   const authService = new RegobsAuthServiceOverride(browser, storage, requestor);
   userSettingService.appMode$.subscribe((appMode: AppMode) => {
@@ -23,6 +26,14 @@ export const authFactory = (): AuthService => {
       const url = `${window.location.origin}/${AUTH_CALLBACK_PATH}`;
       authService.authConfig.redirect_url = url;
       authService.authConfig.end_session_redirect_url = url;
+    }
+    if (appMode === AppMode.Test && window.location.href.startsWith(settings.previewEnvironment.urlPrefix)) {
+      // vi er i en test-app bygd på bakgrunn av en PR i github
+      // da bytter vi endepunktet for server_host i authConfig slik at vi kaller proxyen i stedet for B2C direkte
+      // etter innlogging i B2C vil proxyen sende redirect fra B2C tilbake til oss
+      const serverHostProxy = `${settings.services.regObs.apiUrl[AppMode.Test]}${settings.previewEnvironment.serverHostProxyPath}`;
+      settings.authConfig[AppMode.Test].server_host = serverHostProxy;
+      logger.debug(`Kaller B2C via proxy ved innlogging: ${settings.authConfig[AppMode.Test].server_host}`, DEBUG_TAG);
     }
   });
   return authService;

--- a/src/settings.model.ts
+++ b/src/settings.model.ts
@@ -131,4 +131,10 @@ export interface ISettings {
     nb: string;
     en: string;
   };
+  previewEnvironment: {
+    /** Start på URL til PR-bygg */
+    urlPrefix: string;  
+    /** Bruk dette endepunktet i stedet for server_host i authConfig. Kun path-delen, ikke hele URL */
+    serverHostProxyPath: string;
+  };
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,11 +1,9 @@
 /* eslint-disable max-len */
 
-import { env } from 'process';
 import { NORWAY_BOUNDS } from './app/core/helpers/leaflet/norway-bounds';
 import { SVALBARD_BOUNDS } from './app/core/helpers/leaflet/svalbard-bounds';
 import { MapLayerZIndex } from './app/core/models/maplayer-zindex.enum';
 import { ISettings } from './settings.model';
-import { environment } from './environments/environment';
 
 const snowBaseUrlNb = 'https://www.varsom.no/snoskred/varsling';
 const snowBaseUrlEn = 'https://www.varsom.no/en/snow/forecast';

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,9 +1,11 @@
 /* eslint-disable max-len */
 
+import { env } from 'process';
 import { NORWAY_BOUNDS } from './app/core/helpers/leaflet/norway-bounds';
 import { SVALBARD_BOUNDS } from './app/core/helpers/leaflet/svalbard-bounds';
 import { MapLayerZIndex } from './app/core/models/maplayer-zindex.enum';
 import { ISettings } from './settings.model';
+import { environment } from './environments/environment';
 
 const snowBaseUrlNb = 'https://www.varsom.no/snoskred/varsling';
 const snowBaseUrlEn = 'https://www.varsom.no/en/snow/forecast';
@@ -46,7 +48,7 @@ export const settings: ISettings = {
       getObserverUrl: 'https://api.regobs.no/v6/Account/GetObserver',
       myPageUrl: 'https://konto.nve.no/User',
       updateObserverUrl: 'https://api.regobs.no/v6/Account/UpdateObserver',
-    },
+    }
   },
   observations: {
     maxObservationsToFetch: 5000,
@@ -481,5 +483,9 @@ export const settings: ISettings = {
   userCompetence: {
     nb: 'https://www.varsom.no/om-varsom/varsom-app-regobs/kompetanse/',
     en: 'https://www.varsom.no/en/about/regobs/regobs-competence/',
+  },
+  previewEnvironment: {
+    urlPrefix: 'https://victorious-water-056410803',
+    serverHostProxyPath: '/pullrequest',
   },
 };


### PR DESCRIPTION
Se https://nveprojects.atlassian.net/browse/RO-3089
Når vi er i PR-miljø vil innlogging gå via en proxy med en URL som B2C kjenner, slik at B2C vil akseptere innloggingen.
Se https://dev.azure.com/NVE-devops/Varsom%20Regobs/_git/regobs/pullrequest/15613 hvis du vil se hvordan proxyen virker.

Denne endringer bytter i praksis kun ut URL til B2C-innloggings-tjenesten med vår proxy.
En god måte å teste det på er å prøve å logge inn i PR-bygget.
NB! Det er kun innlogging i testmiljø som støttes.

Hvis du vil teste lokalt, bytt ut previewEnvironment.urlPrefix i settings.ts med URL til appen, f.eks. "localhost:8100".