### PR TITLE
RO-3095: Bedre feilmelding når man får 401 ved innsending

### DIFF
--- a/src/app/core/helpers/http-error-response-helper.spec.ts
+++ b/src/app/core/helpers/http-error-response-helper.spec.ts
@@ -4,22 +4,21 @@ import { RegistrationDraftErrorCode } from '../services/draft/draft-model';
 
 describe('getHttpErrorResponseMessageAndCode', () => {
   it('should handle network error (status 0)', () => {
-    const error = new HttpErrorResponse({ status: 0, statusText: 'Unknown', error: null, url: 'test' });
+    const error = new HttpErrorResponse({ status: 0, statusText: 'Unknown', error: null, url: 'dummy-url' });
     const result = getHttpErrorResponseMessageAndCode(error);
     expect(result.code).toBe(RegistrationDraftErrorCode.NoNetworkOrTimedOut);
-    expect(result.message).toEqual('Http failure response for test: 0 Unknown');
+    expect(result.message).toEqual('Http failure response for dummy-url: 0 Unknown');
   });
 
   it('should handle BadRequest with ModelState', () => {
     const error = new HttpErrorResponse({
       status: HttpStatusCode.BadRequest,
-
       statusText: 'Bad Request',
       error: {
         Message: 'Invalid input', 
         ModelState: { field1: 'Field1 is required', field2: ['Field2 is invalid'] }
       },
-      url: 'test'
+      url: 'dummy-url'
     });
     const result = getHttpErrorResponseMessageAndCode(error);
     expect(result.code).toBe(RegistrationDraftErrorCode.RegistrationError);
@@ -28,32 +27,56 @@ describe('getHttpErrorResponseMessageAndCode', () => {
     expect(result.message).toContain('Field2 is invalid');
   });
 
+  it('should handle BadRequest without Message or ModelState', () => {
+    const error = new HttpErrorResponse({
+      status: HttpStatusCode.BadRequest,
+      statusText: 'Bad Request',
+      error: {},
+      url: 'dummy-url'
+    });
+    const result = getHttpErrorResponseMessageAndCode(error);
+    expect(result.code).toBe(RegistrationDraftErrorCode.RegistrationError);
+    expect(result.message).toEqual('Http failure response for dummy-url: 400 Bad Request');
+  });
+
   it('should handle Conflict', () => {
-    const error = new HttpErrorResponse({ status: HttpStatusCode.Conflict, statusText: 'Conflict', error: null, url: 'test' });
+    const error = new HttpErrorResponse({ status: HttpStatusCode.Conflict, statusText: 'Conflict', error: null, url: 'dummy-url' });
     const result = getHttpErrorResponseMessageAndCode(error);
     expect(result.code).toBe(RegistrationDraftErrorCode.ConflictError);
-    expect(result.message).toEqual('Http failure response for test: 409 Conflict');
+    expect(result.message).toEqual('Http failure response for dummy-url: 409 Conflict');
   });
 
   it('should handle Gone', () => {
-    const error = new HttpErrorResponse({ status: HttpStatusCode.Gone, statusText: 'Gone', error: null, url: 'test' });
+    const error = new HttpErrorResponse({ status: HttpStatusCode.Gone, statusText: 'Gone', error: null, url: 'dummy-url' });
     const result = getHttpErrorResponseMessageAndCode(error);
     expect(result.code).toBe(RegistrationDraftErrorCode.GoneError);
-    expect(result.message).toEqual('Http failure response for test: 410 Gone');
+    expect(result.message).toEqual('Http failure response for dummy-url: 410 Gone');
   });
 
   it('should handle Unauthorized', () => {
-    const error = new HttpErrorResponse({ status: HttpStatusCode.Unauthorized, statusText: 'Unauthorized', error: null, url: 'test' });
+    const error = new HttpErrorResponse({ status: HttpStatusCode.Unauthorized, statusText: 'Unauthorized', error: null, url: 'dummy-url' });
     const result = getHttpErrorResponseMessageAndCode(error);
     expect(result.code).toBe(RegistrationDraftErrorCode.Unauthorized);
-    expect(result.message).toEqual('Http failure response for test: 401 Unauthorized');
+    expect(result.message).toEqual('Http failure response for dummy-url: 401 Unauthorized');
+  });
+
+  it('should handle server error (status >= 500)', () => {
+    const error = new HttpErrorResponse({ 
+      status: 500, 
+      statusText: 'Internal Server Error', 
+      error: null, 
+      url: 'dummy-url'
+    });
+    const result = getHttpErrorResponseMessageAndCode(error);
+    expect(result.code).toBe(RegistrationDraftErrorCode.ServerError);
+    expect(result.message).toEqual('Http failure response for dummy-url: 500 Internal Server Error');
   });
 
   it('should handle unknown error', () => {
-    const error = new HttpErrorResponse({ status: 123, statusText: 'Unknown', error: null, url: 'test' });
+    const error = new HttpErrorResponse({ status: 123, statusText: 'Unknown', error: null, url: 'dummy-url' });
     const result = getHttpErrorResponseMessageAndCode(error);
     expect(result.code).toBe(RegistrationDraftErrorCode.Unknown);
-    expect(result.message).toEqual('Http failure response for test: 123 Unknown');
+    expect(result.message).toEqual('Http failure response for dummy-url: 123 Unknown');
   });
 });
 

--- a/src/app/core/helpers/http-error-response-helper.spec.ts
+++ b/src/app/core/helpers/http-error-response-helper.spec.ts
@@ -1,0 +1,59 @@
+import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
+import { getHttpErrorResponseMessageAndCode } from './http-error-response-helper';
+import { RegistrationDraftErrorCode } from '../services/draft/draft-model';
+
+describe('getHttpErrorResponseMessageAndCode', () => {
+  it('should handle network error (status 0)', () => {
+    const error = new HttpErrorResponse({ status: 0, statusText: 'Unknown', error: null, url: 'test' });
+    const result = getHttpErrorResponseMessageAndCode(error);
+    expect(result.code).toBe(RegistrationDraftErrorCode.NoNetworkOrTimedOut);
+    expect(result.message).toEqual('Http failure response for test: 0 Unknown');
+  });
+
+  it('should handle BadRequest with ModelState', () => {
+    const error = new HttpErrorResponse({
+      status: HttpStatusCode.BadRequest,
+
+      statusText: 'Bad Request',
+      error: {
+        Message: 'Invalid input', 
+        ModelState: { field1: 'Field1 is required', field2: ['Field2 is invalid'] }
+      },
+      url: 'test'
+    });
+    const result = getHttpErrorResponseMessageAndCode(error);
+    expect(result.code).toBe(RegistrationDraftErrorCode.RegistrationError);
+    expect(result.message).toContain('Invalid input');
+    expect(result.message).toContain('Field1 is required');
+    expect(result.message).toContain('Field2 is invalid');
+  });
+
+  it('should handle Conflict', () => {
+    const error = new HttpErrorResponse({ status: HttpStatusCode.Conflict, statusText: 'Conflict', error: null, url: 'test' });
+    const result = getHttpErrorResponseMessageAndCode(error);
+    expect(result.code).toBe(RegistrationDraftErrorCode.ConflictError);
+    expect(result.message).toEqual('Http failure response for test: 409 Conflict');
+  });
+
+  it('should handle Gone', () => {
+    const error = new HttpErrorResponse({ status: HttpStatusCode.Gone, statusText: 'Gone', error: null, url: 'test' });
+    const result = getHttpErrorResponseMessageAndCode(error);
+    expect(result.code).toBe(RegistrationDraftErrorCode.GoneError);
+    expect(result.message).toEqual('Http failure response for test: 410 Gone');
+  });
+
+  it('should handle Unauthorized', () => {
+    const error = new HttpErrorResponse({ status: HttpStatusCode.Unauthorized, statusText: 'Unauthorized', error: null, url: 'test' });
+    const result = getHttpErrorResponseMessageAndCode(error);
+    expect(result.code).toBe(RegistrationDraftErrorCode.Unauthorized);
+    expect(result.message).toEqual('Http failure response for test: 401 Unauthorized');
+  });
+
+  it('should handle unknown error', () => {
+    const error = new HttpErrorResponse({ status: 123, statusText: 'Unknown', error: null, url: 'test' });
+    const result = getHttpErrorResponseMessageAndCode(error);
+    expect(result.code).toBe(RegistrationDraftErrorCode.Unknown);
+    expect(result.message).toEqual('Http failure response for test: 123 Unknown');
+  });
+});
+

--- a/src/app/core/helpers/http-error-response-helper.ts
+++ b/src/app/core/helpers/http-error-response-helper.ts
@@ -10,16 +10,7 @@ function extractBadRequestMessage(error: HttpErrorResponse): string {
     messages.push(...Object.values(modelState as Record<string, string | string[]>).flat());
   }
 
-  return messages.length > 0
-    ? messages.join(' ')
-    : error.message || `Response failed with ${error.status} - ${error.statusText}`;
-}
-
-function formatMessage(error: HttpErrorResponse, fallbackMessage: string): string {
-  if (error.message) {
-    return error.message;
-  }
-  return `${fallbackMessage} ${error.status} - ${error.statusText}`;
+  return messages.length > 0 ? messages.join(' ') : error.message;
 }
 
 /**
@@ -33,38 +24,28 @@ export const getHttpErrorResponseMessageAndCode = (
   error: HttpErrorResponse
 ): { message: string; code: RegistrationDraftErrorCode } => {
   let code: RegistrationDraftErrorCode;
-  let message: string;
 
   switch (error.status) {
     case 0:
       code = RegistrationDraftErrorCode.NoNetworkOrTimedOut;
-      message = formatMessage(error, 'Response failed with status code 0, probably no network?');
       break;
     case HttpStatusCode.BadRequest:
       code = RegistrationDraftErrorCode.RegistrationError;
-      message = extractBadRequestMessage(error);
-      break;
+      return { code, message: extractBadRequestMessage(error) };
     case HttpStatusCode.Conflict:
       code = RegistrationDraftErrorCode.ConflictError;
-      message = formatMessage(error, 'Registration conflict');
       break;
     case HttpStatusCode.Gone:
       code = RegistrationDraftErrorCode.GoneError;
-      message = formatMessage(error, 'Registration is deleted in Regobs');
       break;
     case HttpStatusCode.Unauthorized:
       code = RegistrationDraftErrorCode.Unauthorized;
-      message = formatMessage(error, 'Unauthorized');
       break;
     default:
-      if (error.status > HttpStatusCode.BadRequest) {
-        code = RegistrationDraftErrorCode.ServerError;
-        message = formatMessage(error, 'Response failed with server error');
-      } else {
-        code = RegistrationDraftErrorCode.Unknown;
-        message = formatMessage(error, 'Got an unknown http error');
-      }
+      code = error.status >= HttpStatusCode.InternalServerError
+        ? RegistrationDraftErrorCode.ServerError
+        : RegistrationDraftErrorCode.Unknown;
   }
 
-  return { code, message };
+  return { code, message: error.message };
 };

--- a/src/app/core/helpers/http-error-response-helper.ts
+++ b/src/app/core/helpers/http-error-response-helper.ts
@@ -1,6 +1,27 @@
 import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { RegistrationDraftErrorCode } from '../services/draft/draft-model';
 
+function extractBadRequestMessage(error: HttpErrorResponse): string {
+  const messages: string[] = [];
+  if (error.error?.Message) messages.push(error.error.Message);
+
+  const modelState = error.error?.ModelState;
+  if (modelState && typeof modelState === 'object' && modelState !== null) {
+    messages.push(...Object.values(modelState as Record<string, string | string[]>).flat());
+  }
+
+  return messages.length > 0
+    ? messages.join(' ')
+    : error.message || `Response failed with ${error.status} - ${error.statusText}`;
+}
+
+function formatMessage(error: HttpErrorResponse, fallbackMessage: string): string {
+  if (error.message) {
+    return error.message;
+  }
+  return `${fallbackMessage} ${error.status} - ${error.statusText}`;
+}
+
 /**
  * Create a formatted message for an angular HttpErrorResponse
  *
@@ -14,37 +35,35 @@ export const getHttpErrorResponseMessageAndCode = (
   let code: RegistrationDraftErrorCode;
   let message: string;
 
-  if (error.status === 0) {
-    code = RegistrationDraftErrorCode.NoNetworkOrTimedOut;
-    message = error.message || 'Response failed with status code 0, probably no network?';
-  } else if (error.status === HttpStatusCode.BadRequest) {
-    code = RegistrationDraftErrorCode.RegistrationError;
-    // Regobs api returns additional info for bad requests.
-    // Put this info into a readable error message.
-    let messages = [];
-    if (error.error?.Message) {
-      messages.push(error.error.Message);
-    }
-    if (error.error?.ModelState) {
-      messages = [...messages, ...Object.values(error.error.ModelState)];
-    }
-    if (messages.length > 0) {
-      message = messages.join(' ');
-    } else {
-      message = error.message || `Response failed with ${error.status} - ${error.statusText}`;
-    }
-  } else if (error.status === HttpStatusCode.Conflict) {
-    code = RegistrationDraftErrorCode.ConflictError;
-    message = error.message || `Registration conflict ${error.status} - ${error.statusText}`;
-  } else if (error.status === HttpStatusCode.Gone) {
-    code = RegistrationDraftErrorCode.GoneError;
-    message = error.message || `Registration is deleted in Regobs ${error.status} - ${error.statusText}`;
-  } else if (error.status > HttpStatusCode.BadRequest) {
-    code = RegistrationDraftErrorCode.ServerError;
-    message = error.message || `Response failed with ${error.status} - ${error.statusText}`;
-  } else {
-    code = RegistrationDraftErrorCode.Unknown;
-    message = error.message || `Got an unknown http error: ${error.status} - ${error.statusText}`;
+  switch (error.status) {
+    case 0:
+      code = RegistrationDraftErrorCode.NoNetworkOrTimedOut;
+      message = formatMessage(error, 'Response failed with status code 0, probably no network?');
+      break;
+    case HttpStatusCode.BadRequest:
+      code = RegistrationDraftErrorCode.RegistrationError;
+      message = extractBadRequestMessage(error);
+      break;
+    case HttpStatusCode.Conflict:
+      code = RegistrationDraftErrorCode.ConflictError;
+      message = formatMessage(error, 'Registration conflict');
+      break;
+    case HttpStatusCode.Gone:
+      code = RegistrationDraftErrorCode.GoneError;
+      message = formatMessage(error, 'Registration is deleted in Regobs');
+      break;
+    case HttpStatusCode.Unauthorized:
+      code = RegistrationDraftErrorCode.Unauthorized;
+      message = formatMessage(error, 'Unauthorized');
+      break;
+    default:
+      if (error.status > HttpStatusCode.BadRequest) {
+        code = RegistrationDraftErrorCode.ServerError;
+        message = formatMessage(error, 'Response failed with server error');
+      } else {
+        code = RegistrationDraftErrorCode.Unknown;
+        message = formatMessage(error, 'Got an unknown http error');
+      }
   }
 
   return { code, message };


### PR DESCRIPTION
Vi hadde allerede en feilkode for innloggingsfeil ved innsending, men den tror jeg ikke ble brukt. Har forsøkt å fikse det nå, slik at man får litt mer hjelp til å løse situasjonen når man får 401 fra API'et ved innsending:

<img width="767" height="427" alt="image" src="https://github.com/user-attachments/assets/2bae31f8-8937-4cdc-96da-17cc153b9d09" />

