### PR TITLE
Fiks RO-3095: Feil med refreshToken-kall som gir 401

### DIFF
--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -94,7 +94,9 @@ export class ApiInterceptor implements HttpInterceptor {
       catchError((err) => {
         this.loggerService.debug('Could not get valid token', DEBUG_TAG, { err });
         this.regobsAuthService.signIn();
-        return EMPTY; //TODO: Why this?
+        // .signIn trigger en login-flyt med navigering til b2c-login.
+        // EMPTY sørger for at denne requesten avbrytes uten å emitte noe videre.
+        return EMPTY;
       }),
       map((user) => {
         const headers = request.headers.set('Authorization', `Bearer ${user.token}`);

--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -18,8 +18,6 @@ import { ApiVersionService } from '../services/api-version/api-version.service';
 import { Capacitor } from '@capacitor/core';
 
 const DEBUG_TAG = 'ApiInterceptor';
-const RETRY_HEADER = 'X-Regobs-Retry';
-const MAX_RETRIES = 1; // Antall ganger vi prøver å kjøre kallet på nytt hvis vi får 401
 
 /**
  * Sender innloggings-token med kall til Regobs API der kallene krever at man er logget inn.
@@ -112,29 +110,18 @@ export class ApiInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<unknown>> {
     if (error instanceof HttpErrorResponse && error.status === 401) {
       // Vi er ikke autorisert, trolig fordi tokenet ikke er gyldig
-      const retryCount = Number(request.headers.get(RETRY_HEADER) ?? '0');
-      if (retryCount >= MAX_RETRIES) {
-        // Har allerede forsøkt å oppfriske token én gang, kast feilen videre
-        this.loggerService.debug('401 after token refresh, not retrying again.', DEBUG_TAG, {
-          retryCount,
-          url: request.url,
-          method: request.method,
-        });
-        throw error;
-      }
       this.loggerService.debug('Got 401 from API, trying to refresh token and repeat API-call...', DEBUG_TAG, {
-        retryCount,
         url: request.url,
         method: request.method,
       });
       return from(this.regobsAuthService.refreshToken()).pipe(
-        switchMap(() => this.addAuthHeader(request)),
-        map((req) =>
-          req.clone({
-            // legger på en header for å indikere at vi forsøker samme kall til API på nytt
-            headers: req.headers.set(RETRY_HEADER, String(retryCount + 1)),
+        tap(() =>
+          this.loggerService.debug('Token refreshed', DEBUG_TAG, {
+            url: request.url,
+            method: request.method,
           })
         ),
+        switchMap(() => this.addAuthHeader(request)),
         switchMap((req) => next.handle(req))
       );
     }

--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -121,6 +121,10 @@ export class ApiInterceptor implements HttpInterceptor {
             method: request.method,
           })
         ),
+        catchError((err) => {
+          this.loggerService.debug('Token refresh failed', DEBUG_TAG, { err, url: request.url });
+          throw error; // Rethrow original 401 error
+        }),
         switchMap(() => this.addAuthHeader(request)),
         switchMap((req) => next.handle(req))
       );

--- a/src/app/modules/auth/services/regobs-auth-service-override.ts
+++ b/src/app/modules/auth/services/regobs-auth-service-override.ts
@@ -51,9 +51,7 @@ export class RegobsAuthServiceOverride extends AuthService {
         this.notifyActionListers(AuthActionBuilder.RefreshFailed(error));
       }
 
-      // TODO: Lurer på om dette bør egentlig bør feile - sånn at feks ApiInterceptoren kan plukke opp feilen?
-      // Ved "No token defined" kastes jo uansett exception videre, se de første linjene i catch-blokka her
-      //throw error;
+      throw error;
     }
   }
 

--- a/src/app/modules/auth/services/regobs-auth-service-override.ts
+++ b/src/app/modules/auth/services/regobs-auth-service-override.ts
@@ -48,16 +48,12 @@ export class RegobsAuthServiceOverride extends AuthService {
       const shouldClearTokens = await this.shouldTokensBeCleared(error);
       if (shouldClearTokens) {
         await this.clearTokens();
-      }
-      // Error message: 'Unable to obtain server configuration' means we didn't reach B2C,
-      // but since we refresh pretty often and we might be offline, we just ignore it.
-      // If we trigger a RefreshFailed action the token will be cleared by the auth library
-      if (
-        error instanceof Error &&
-        error.message.toLowerCase().indexOf('unable to obtain server configuration') === -1
-      ) {
         this.notifyActionListers(AuthActionBuilder.RefreshFailed(error));
       }
+
+      // TODO: Lurer på om dette bør egentlig bør feile - sånn at feks ApiInterceptoren kan plukke opp feilen?
+      // Ved "No token defined" kastes jo uansett exception videre, se de første linjene i catch-blokka her
+      //throw error;
     }
   }
 

--- a/src/app/modules/auth/services/regobs-auth.service.spec.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.spec.ts
@@ -9,7 +9,7 @@ import { AuthService, Browser, DefaultBrowser } from 'ionic-appauth';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { httpFactory } from '../factories/http-factory';
 import { TokenResponseFullJson } from './token-response-full';
-import { filter, firstValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { RegobsAuthServiceOverride } from './regobs-auth-service-override';
 import { inject } from '@angular/core';
 import { ApiInterceptor } from 'src/app/core/http-interceptor/ApiInterceptor';
@@ -114,6 +114,11 @@ describe('RegobsAuthService', () => {
     storage = TestBed.inject(StorageBackend);
   });
 
+  beforeEach(async () => {
+    // Dette skjer i AppComponent
+    await authService.init();
+  });
+
   it('token age check should work', () => {
     const nowInSeconds = Date.now() / 1000;
     const tokenIssuedAt = nowInSeconds - 300; //5 minutes ago
@@ -123,14 +128,11 @@ describe('RegobsAuthService', () => {
   });
 
   it('auth service has token on startup', async () => {
-    await authService.init();
-    await firstValueFrom(authService.initComplete$.pipe(filter((v) => v === true)));
     const token = await firstValueFrom(authService.token$);
     expect(token.idToken).toBe(TOKEN_RESPONSE.id_token);
   });
 
   it('has loggedInUser$ on startup', async () => {
-    await authService.init();
     const loggedInUser = await firstValueFrom(service.loggedInUser$);
     expect(loggedInUser.email).toBe(TOKEN_INFO.email);
   });
@@ -145,9 +147,6 @@ describe('RegobsAuthService', () => {
           revocation_endpoint: '',
         })
     );
-
-    // Initialiser service
-    await authService.init();
 
     const refreshTokenPromise = service.refreshToken();
 
@@ -170,14 +169,14 @@ describe('RegobsAuthService', () => {
   }));
 
   it('failing to fetch b2c config should not reset token', async () => {
-    await authService.init();
-
     // Trigg token refresh som igjen trigger henting av config
     const refreshTokenPromise = service.refreshToken();
 
-    // Simuler en nettverksfeil under henting av config. Dette fungerer litt som å hente config uten nett, feks.
-    const req = httpTesting.expectOne('/test/.well-known/openid-configuration');
-    req.error(new ProgressEvent('network error!'));
+    // Simuler nettverksfeil under henting av config. Dette fungerer litt som å hente config uten nett, feks.
+    const reqs = httpTesting.match('/test/.well-known/openid-configuration');
+    for (const req of reqs) {
+      req.error(new ProgressEvent('network error!'));
+    }
 
     await expectAsync(refreshTokenPromise).toBeRejected();
 

--- a/src/app/modules/auth/services/regobs-auth.service.spec.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.spec.ts
@@ -159,7 +159,7 @@ describe('RegobsAuthService', () => {
     httpTesting.expectOne('/token').flush({}, { status: 401, statusText: 'Unauthorized' });
 
     // Vent på refreshToken
-    await refreshTokenPromise;
+    await expectAsync(refreshTokenPromise).toBeRejected();
 
     // Sjekk at alle relevante token-håndterings-ting er nullstilt
     expect(await storage.getItem(TOKEN_RESPONSE_KEY)).toBe(undefined);
@@ -170,13 +170,6 @@ describe('RegobsAuthService', () => {
   }));
 
   it('failing to fetch b2c config should not reset token', async () => {
-    // Siden bare henting av b2c-config feiler, så forventer vi at shouldTokensBeCleared skal returnere false.
-    // Spioner på denne så vi kan sjekke det.
-    const shouldTokensBeClearedSpy = spyOn(
-      authService as RegobsAuthServiceOverride,
-      'shouldTokensBeCleared'
-    ).and.callThrough();
-
     await authService.init();
 
     // Trigg token refresh som igjen trigger henting av config
@@ -186,12 +179,7 @@ describe('RegobsAuthService', () => {
     const req = httpTesting.expectOne('/test/.well-known/openid-configuration');
     req.error(new ProgressEvent('network error!'));
 
-    // TODO! Bør dette gå an, eller bør det feile? - ApiInterceptoren fortsetter sånn som det er nå
-    await refreshTokenPromise;
-
-    expect(shouldTokensBeClearedSpy).toHaveBeenCalled();
-    const shouldTokensBeCleared = await shouldTokensBeClearedSpy.calls.first().returnValue;
-    expect(shouldTokensBeCleared).toBe(false);
+    await expectAsync(refreshTokenPromise).toBeRejected();
 
     // Sjekk at innlogging fortsatt er gyldig
     expect(await storage.getItem(TOKEN_RESPONSE_KEY)).toBeDefined();

--- a/src/app/modules/auth/services/regobs-auth.service.spec.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.spec.ts
@@ -1,6 +1,5 @@
-import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import { fakeAsync, flush, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
 import { provideTranslateService } from '@ngx-translate/core';
 import { AuthorizationServiceConfiguration, Requestor, StorageBackend, TokenResponseJson } from '@openid/appauth';
 import { provideTestLogger } from '../../shared/services/logging/test-logging.service';
@@ -12,7 +11,6 @@ import { TokenResponseFullJson } from './token-response-full';
 import { firstValueFrom } from 'rxjs';
 import { RegobsAuthServiceOverride } from './regobs-auth-service-override';
 import { inject } from '@angular/core';
-import { ApiInterceptor } from 'src/app/core/http-interceptor/ApiInterceptor';
 
 const TOKEN_INFO = { email: 'test@test.no' };
 const TOKEN = `test.${btoa(JSON.stringify(TOKEN_INFO))}`;
@@ -62,9 +60,8 @@ describe('RegobsAuthService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClient(),
         provideHttpClientTesting(),
-        provideRouter([]),
         provideTranslateService(),
         provideTestLogger(),
         {
@@ -104,8 +101,10 @@ describe('RegobsAuthService', () => {
             return service;
           },
         },
-        // We rely on the HTTP_INTERCEPTORS token to register the AuthInterceptor as an HttpInterceptor
-        { provide: HTTP_INTERCEPTORS, useClass: ApiInterceptor, multi: true },
+        // NB! ApiInterceptor kjøres ikke i testene nå, prøver å ikke involvere mer enn nødvendig i testene
+        // { provide: HTTP_INTERCEPTORS, useClass: ApiInterceptor, multi: true },
+        // For å få interceptoren til å brukes i testene må denne også oppdateres:
+        // provideHttpClient(withInterceptorsFromDi())
       ],
     });
     service = TestBed.inject(RegobsAuthService);
@@ -115,7 +114,7 @@ describe('RegobsAuthService', () => {
   });
 
   beforeEach(async () => {
-    // Dette skjer i AppComponent
+    // Dette skjer i AppComponent i appen
     await authService.init();
   });
 

--- a/src/app/modules/auth/services/regobs-auth.service.spec.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.spec.ts
@@ -1,53 +1,117 @@
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { TestBed } from '@angular/core/testing';
+import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
-import { SafariViewController } from '@awesome-cordova-plugins/safari-view-controller/ngx';
 import { provideTranslateService } from '@ngx-translate/core';
-import { LocalStorageBackend, Requestor, StorageBackend } from '@openid/appauth';
-import { LoggingService } from '../../shared/services/logging/logging.service';
-import { TestLoggingService } from '../../shared/services/logging/test-logging.service';
-
-import { RegobsAuthService } from './regobs-auth.service';
+import { AuthorizationServiceConfiguration, Requestor, StorageBackend, TokenResponseJson } from '@openid/appauth';
+import { provideTestLogger } from '../../shared/services/logging/test-logging.service';
+import { RegobsAuthService, TOKEN_RESPONSE_FULL_KEY, TOKEN_RESPONSE_KEY } from './regobs-auth.service';
 import { AuthService, Browser, DefaultBrowser } from 'ionic-appauth';
-import { authFactory } from '../factories/auth-factory';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { httpFactory } from '../factories/http-factory';
+import { TokenResponseFullJson } from './token-response-full';
+import { filter, firstValueFrom } from 'rxjs';
+import { RegobsAuthServiceOverride } from './regobs-auth-service-override';
+import { inject } from '@angular/core';
+import { ApiInterceptor } from 'src/app/core/http-interceptor/ApiInterceptor';
+
+const TOKEN_INFO = { email: 'test@test.no' };
+const TOKEN = `test.${btoa(JSON.stringify(TOKEN_INFO))}`;
+const TOKEN_RESPONSE: Partial<TokenResponseJson> = {
+  id_token: TOKEN,
+  refresh_token: TOKEN,
+  scope: 'offline_access openid',
+  // NB! I Response fra b2c er token_type Bearer med stor B
+  token_type: 'bearer',
+  issued_at: 1764750552,
+};
+const TOKEN_RESPONSE_FULL: Partial<TokenResponseFullJson> = {
+  id_token: TOKEN,
+  // NB! I Response fra b2c er token_type Bearer med stor B
+  token_type: 'bearer',
+  // "not_before": 1764688915,
+  // "id_token_expires_in": 86400,
+  // "profile_info": "profileInfoTest",
+  scope: 'offline_access openid',
+  refresh_token: TOKEN,
+  refresh_token_expires_in: 1182,
+};
+
+class InMemoryStorageBackend extends StorageBackend {
+  db: any = {};
+
+  override async getItem(name: string): Promise<string | null> {
+    return this.db[name];
+  }
+  override async removeItem(name: string): Promise<void> {
+    delete this.db[name];
+  }
+  override async clear(): Promise<void> {
+    this.db = {};
+  }
+  override async setItem(name: string, value: string): Promise<void> {
+    this.db[name] = value;
+  }
+}
 
 describe('RegobsAuthService', () => {
   let service: RegobsAuthService;
+  let authService: AuthService;
+  let httpTesting: HttpTestingController;
+  let storage: StorageBackend;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
         provideRouter([]),
         provideTranslateService(),
-        { provide: LoggingService, useClass: TestLoggingService },
-        SafariViewController,
-        InAppBrowser,
-        provideHttpClient(withInterceptorsFromDi()),
+        provideTestLogger(),
         {
           provide: StorageBackend,
-          useFactory: () => new LocalStorageBackend(),
+          useFactory: () => {
+            const storage = new InMemoryStorageBackend();
+            storage.db[TOKEN_RESPONSE_KEY] = JSON.stringify(TOKEN_RESPONSE);
+            storage.db[TOKEN_RESPONSE_FULL_KEY] = JSON.stringify(TOKEN_RESPONSE_FULL);
+            return storage;
+          },
         },
         {
           provide: Browser,
           useClass: DefaultBrowser,
         },
         {
+          // Requestor håndterer http kall på vegne av openId app auth
           provide: Requestor,
           useFactory: httpFactory,
         },
         {
+          // authFactory initialiserer RegobsAuthServiceOverride over Ionic App Auth sin Auth Service
           provide: AuthService,
-          useFactory: authFactory,
+          useFactory: () => {
+            const browser = inject(Browser);
+            const storage = inject(StorageBackend);
+            const requestor = inject(Requestor);
+            const service = new RegobsAuthServiceOverride(browser, storage, requestor);
+            service.authConfig = {
+              server_host: '/test',
+              client_id: 'test-client-id',
+              redirect_url: '',
+              end_session_redirect_url: '',
+              scopes: '',
+              pkce: true,
+            };
+            return service;
+          },
         },
+        // We rely on the HTTP_INTERCEPTORS token to register the AuthInterceptor as an HttpInterceptor
+        { provide: HTTP_INTERCEPTORS, useClass: ApiInterceptor, multi: true },
       ],
     });
     service = TestBed.inject(RegobsAuthService);
-  });
-
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+    authService = TestBed.inject(AuthService);
+    httpTesting = TestBed.inject(HttpTestingController);
+    storage = TestBed.inject(StorageBackend);
   });
 
   it('token age check should work', () => {
@@ -56,5 +120,85 @@ describe('RegobsAuthService', () => {
     expect(service.isTokenOlderThan(tokenIssuedAt, 0)).toBeTrue();
     expect(service.isTokenOlderThan(tokenIssuedAt, 60)).toBeTrue();
     expect(service.isTokenOlderThan(tokenIssuedAt, 600)).toBeFalse();
+  });
+
+  it('auth service has token on startup', async () => {
+    await authService.init();
+    await firstValueFrom(authService.initComplete$.pipe(filter((v) => v === true)));
+    const token = await firstValueFrom(authService.token$);
+    expect(token.idToken).toBe(TOKEN_RESPONSE.id_token);
+  });
+
+  it('has loggedInUser$ on startup', async () => {
+    await authService.init();
+    const loggedInUser = await firstValueFrom(service.loggedInUser$);
+    expect(loggedInUser.email).toBe(TOKEN_INFO.email);
+  });
+
+  it('http response 401 during tokenRefresh resets token', fakeAsync(async () => {
+    // Returner testconfig for get authService.configuration
+    spyOnProperty(authService, 'configuration', 'get').and.callFake(
+      async () =>
+        new AuthorizationServiceConfiguration({
+          authorization_endpoint: '',
+          token_endpoint: `/token`,
+          revocation_endpoint: '',
+        })
+    );
+
+    // Initialiser service
+    await authService.init();
+
+    const refreshTokenPromise = service.refreshToken();
+
+    // OpenId AppAuth bruker nok noe async håndtering av token henting som krever at vi avanserer tiden
+    // for å få API-kallet til å kjøre.
+    flush();
+
+    // Simuler at /token-kallet gir status 401
+    httpTesting.expectOne('/token').flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    // Vent på refreshToken
+    await refreshTokenPromise;
+
+    // Sjekk at alle relevante token-håndterings-ting er nullstilt
+    expect(await storage.getItem(TOKEN_RESPONSE_KEY)).toBe(undefined);
+    expect(await firstValueFrom(authService.isAuthenticated$)).toBe(false);
+    expect(await firstValueFrom(authService.token$)).toBe(undefined);
+    const user = await firstValueFrom(service.loggedInUser$);
+    expect(user.isLoggedIn).toBe(false);
+  }));
+
+  it('failing to fetch b2c config should not reset token', async () => {
+    // Siden bare henting av b2c-config feiler, så forventer vi at shouldTokensBeCleared skal returnere false.
+    // Spioner på denne så vi kan sjekke det.
+    const shouldTokensBeClearedSpy = spyOn(
+      authService as RegobsAuthServiceOverride,
+      'shouldTokensBeCleared'
+    ).and.callThrough();
+
+    await authService.init();
+
+    // Trigg token refresh som igjen trigger henting av config
+    const refreshTokenPromise = service.refreshToken();
+
+    // Simuler en nettverksfeil under henting av config. Dette fungerer litt som å hente config uten nett, feks.
+    const req = httpTesting.expectOne('/test/.well-known/openid-configuration');
+    req.error(new ProgressEvent('network error!'));
+
+    // TODO! Bør dette gå an, eller bør det feile? - ApiInterceptoren fortsetter sånn som det er nå
+    await refreshTokenPromise;
+
+    expect(shouldTokensBeClearedSpy).toHaveBeenCalled();
+    const shouldTokensBeCleared = await shouldTokensBeClearedSpy.calls.first().returnValue;
+    expect(shouldTokensBeCleared).toBe(false);
+
+    // Sjekk at innlogging fortsatt er gyldig
+    expect(await storage.getItem(TOKEN_RESPONSE_KEY)).toBeDefined();
+    expect(await firstValueFrom(authService.isAuthenticated$)).toBe(true);
+    const token = await firstValueFrom(authService.token$);
+    expect(token.idToken).toBe(TOKEN);
+    const user = await firstValueFrom(service.loggedInUser$);
+    expect(user.isLoggedIn).toBe(true);
   });
 });

--- a/src/app/modules/auth/services/regobs-auth.service.spec.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.spec.ts
@@ -35,7 +35,7 @@ const TOKEN_RESPONSE_FULL: Partial<TokenResponseFullJson> = {
 };
 
 class InMemoryStorageBackend extends StorageBackend {
-  db: any = {};
+  db: Record<string, string> = {};
 
   override async getItem(name: string): Promise<string | null> {
     return this.db[name];

--- a/src/app/modules/auth/services/regobs-auth.service.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.ts
@@ -21,6 +21,13 @@ export const RETURN_URL_KEY = 'authreturnurl';
 export const TOKEN_RESPONSE_KEY = 'token_response';
 export const TOKEN_RESPONSE_FULL_KEY = 'token_response_full';
 
+/**
+ * Dette er en service som håndterer innlogging. Men oppsettet er komplisert og andre servicer/klasser er også i bruk:
+ *  - AuthService fra IonicAppAuth håndterer selve innlogginga og brukes her
+ *  - RegobsAuthServiceOverride overrider noen metoder på AuthService, og provides for AuthService i authFactory.
+ *  - Http-kall for innlogging gjøres av NgHttpService og initialiseres av httpFactory
+ *  - ApiInterceptor har kode som legger på token / trigger tokenRefresh / innlogging om nødvendig
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/src/app/modules/auth/services/regobs-auth.service.ts
+++ b/src/app/modules/auth/services/regobs-auth.service.ts
@@ -25,6 +25,8 @@ export const TOKEN_RESPONSE_FULL_KEY = 'token_response_full';
  * Dette er en service som håndterer innlogging. Men oppsettet er komplisert og andre servicer/klasser er også i bruk:
  *  - AuthService fra IonicAppAuth håndterer selve innlogginga og brukes her
  *  - RegobsAuthServiceOverride overrider noen metoder på AuthService, og provides for AuthService i authFactory.
+ *  - authFactory har noe kode som håndterer at miljøvariabler settes riktig
+ *  - Initialisering av AuthService / RegobsAuthServiceOverride skjer i AppComponent
  *  - Http-kall for innlogging gjøres av NgHttpService og initialiseres av httpFactory
  *  - ApiInterceptor har kode som legger på token / trigger tokenRefresh / innlogging om nødvendig
  */

--- a/src/app/modules/auth/services/token-response-full.ts
+++ b/src/app/modules/auth/services/token-response-full.ts
@@ -3,7 +3,9 @@ import { nowInSeconds, TokenResponse, TokenResponseJson } from '@openid/appauth'
 export const AUTH_EXPIRY_BUFFER = 10 * 60 * -1; // 10 mins in seconds
 
 export interface TokenResponseFullJson extends TokenResponseJson {
-  refresh_token_expires_in: string;
+  // Edit jolokv: La til "| number" her fordi jeg syns det ser ut som b2c returnerer
+  // denne som et heltall, ikke som string. parseInt takler det fint uansett.
+  refresh_token_expires_in: string | number;
 }
 
 export class TokenResponseFull extends TokenResponse {
@@ -23,7 +25,7 @@ export class TokenResponseFull extends TokenResponse {
   constructor(response: TokenResponseFullJson) {
     super(response);
     if (response.refresh_token_expires_in) {
-      this.refreshTokenExpiresIn = parseInt(response.refresh_token_expires_in, 10);
+      this.refreshTokenExpiresIn = parseInt(response.refresh_token_expires_in as string, 10);
     }
   }
 


### PR DESCRIPTION
Det er vanskelig å gjenskape det brukerne har opplevd skikkelig, men det er i alle fall lagt til en test som sjekker hva som skjer når b2c returnerer 401. 
Da jeg la til den testen så jeg etterpå at token ikke ble fjerna, bruker var fortsatt logga inn osv, selv om b2c sa i fra at token ikke var gyldig (401). 

Fiksen ligger i endringene i RegobsAuthServiceOverride og testene kunne nok heller vært lagt til i regobs-auth.service-override.spec.ts med et enklere oppsett, men som sagt, jeg la til testene først før jeg fant feilen og har ikke prioritert å endre på testene i ettertid. Men testene sånn de legges til her har nok et mer integrasjonstest-preg enn enhetstester kanskje bør ha.

Spesifikt er fiksen at `this.notifyActionListers(AuthActionBuilder.RefreshFailed(error));` tidligere bare ble kalt i noen tilfeller (blant annet ikke for nettverksfeil fra angular - HttpErrorResponse som kastes av HttpClient.

https://github.com/NVE/regObs4/blob/cd1aa792f7a6140f0e826c452bdd80da4ef485d4/src/app/modules/auth/services/regobs-auth-service-override.ts#L55-L60

Nå meldes det videre om at tokenRefresh feilet i alle tillfeller hvor tokenet ikke lenger bør være gyldig.

