### PR TITLE
RO-3102: Fikset problem med visning av datofelt i skjema for skredaktivitet

### DIFF
--- a/src/app/components/datetime-picker/datetime-picker.component.html
+++ b/src/app/components/datetime-picker/datetime-picker.component.html
@@ -1,9 +1,11 @@
-<ion-datetime-button [datetime]="id">
-  @if (!dateTime()) {
-    <span slot="date-target">-</span>
-    <span slot="time-target">-</span>
-  }
-</ion-datetime-button>
+@if (dateTimeMounted()) {
+  <ion-datetime-button [datetime]="id">
+    @if (!dateTime()) {
+      <span slot="date-target">-</span>
+      <span slot="time-target">-</span>
+    }
+  </ion-datetime-button>
+}
 <ion-modal [keepContentsMounted]="true">
   <ng-template>
     <ion-datetime

--- a/src/app/components/datetime-picker/datetime-picker.component.scss
+++ b/src/app/components/datetime-picker/datetime-picker.component.scss
@@ -6,7 +6,10 @@
 }
 
 ion-datetime {
+  --background: white;
+  --background-rgb: 255, 255, 255;
   --wheel-highlight-background: var(--ion-color-primary-contrast, rgb(218, 216, 255));
+  --wheel-fade-background-rgb: 255, 255, 255;
 }
 
 ion-datetime-button {
@@ -15,4 +18,11 @@ ion-datetime-button {
 
 ion-datetime-button::part(native) {
   background: none;
+}
+
+// Denne komponenten har en egen modal, men brukes også inne i en modal (avalanche-activity-modal.page)
+// For å sørge for at datovelgerens backdrop dukker opp over bakenforliggende modal trenger vi dette
+ion-modal::part(backdrop) {
+  --backdrop-opacity: 0.32;
+  background-color: var(--ion-backdrop-color, #000);
 }

--- a/src/app/components/datetime-picker/datetime-picker.component.ts
+++ b/src/app/components/datetime-picker/datetime-picker.component.ts
@@ -45,12 +45,9 @@ export class DatetimePickerComponent {
     minute: '2-digit',
   });
 
-  id: string;
+  id = `app-datetime-picker-${counter++}`;
 
   constructor() {
-    counter++;
-    this.id = 'app-datetime-picker-' + counter;
-
     // Fant ikke noe enkel annen måte å oppdatere tiden på hvis max endres.
     // Det er egentlig ikke anbefalt å oppdatere state fra effect.
     effect(() => {

--- a/src/app/components/datetime-picker/datetime-picker.component.ts
+++ b/src/app/components/datetime-picker/datetime-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, viewChild, input, model, effect, untracked } from '@angular/core';
+import { Component, inject, viewChild, input, model, effect, untracked, computed } from '@angular/core';
 import { IonDatetime, IonDatetimeButton, IonModal, Platform } from '@ionic/angular/standalone';
 import { DatetimePresentation } from '@ionic/core/components';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -24,6 +24,9 @@ let counter = 0;
 export class DatetimePickerComponent {
   private platform = inject(Platform);
   private modal = viewChild(IonModal);
+  private ionDatetimeElement = viewChild(IonDatetime);
+
+  dateTimeMounted = computed(() => this.ionDatetimeElement() != undefined);
 
   readonly dateTime = model<string>(); // Supports Date.prototype.toISOString() format (YYYY-MM-DDTHH:mm:ss.sssZ)
   readonly language = input<string>(); // Automatically sets formatting of Ionic Datetime component. Can be manually overridden.
@@ -45,9 +48,11 @@ export class DatetimePickerComponent {
     minute: '2-digit',
   });
 
-  id = `app-datetime-picker-${counter++}`;
+  id: string;
 
   constructor() {
+    this.id = `app-datetime-picker-${counter++}`;
+
     // Fant ikke noe enkel annen måte å oppdatere tiden på hvis max endres.
     // Det er egentlig ikke anbefalt å oppdatere state fra effect.
     effect(() => {


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/RO-3102

Her er Copilot sin forklaring av problemet og forklaring til løsning:
_Problemet var at `id` ble satt i konstruktøren, men Angular trenger ID-verdien tilgjengelig før komponenten rendres første gang. Ved å initialisere `id` direkte ved deklarasjon sikrer vi at verdien er tilgjengelig umiddelbart når templaten rendres._

Jeg har testet gjennom alle andre komponenter som bruker DatetimePickerComponent, og det var kun skredaktivitet-modalen som hadde problemer, virker det som.

