### PR TITLE
Bruk blur events under lagring

### DIFF
--- a/src/app/modules/registration/components/edit-images/edit-images.component.html
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.html
@@ -81,7 +81,7 @@
 
     <app-text-comment
       [value]="attachment.Comment"
-      (valueChange)="setNewAttachmentComment(attachment, $event)"
+      (blur)="setNewAttachmentComment(attachment, $event)"
       label="{{ pictureCommentText() | translate }}"
       [rows]="2"
       placeholder="{{ pictureCommentPlaceholder() | translate }}"
@@ -103,7 +103,7 @@
           <ion-item>
             <ion-input
               [value]="attachment.Photographer || userSettings()?.photographer"
-              (ionChange)="addNewAttachmentPhotographer(attachment, $event)"
+              (ionBlur)="addNewAttachmentPhotographer(attachment, $event)"
               [label]="('MY_PROFILE.PHOTOGRAPHER' | translate).toUpperCase()"
               labelPlacement="stacked"
               [placeholder]="'MY_PROFILE.PHOTOGRAPHER' | translate"
@@ -113,7 +113,7 @@
           <ion-item>
             <ion-input
               [value]="attachment.Copyright || userSettings()?.copyright || myPage()?.NickName"
-              (ionChange)="addNewAttachmentCopyright(attachment, $event)"
+              (ionBlur)="addNewAttachmentCopyright(attachment, $event)"
               [label]="('MY_PROFILE.COPYRIGHT' | translate).toUpperCase()"
               labelPlacement="stacked"
               [placeholder]="'MY_PROFILE.COPYRIGHT' | translate"

--- a/src/app/modules/registration/components/edit-images/edit-images.component.ts
+++ b/src/app/modules/registration/components/edit-images/edit-images.component.ts
@@ -192,10 +192,13 @@ export class EditImagesComponent implements OnInit {
     );
   }
 
-  addNewAttachmentPhotographer(attachment: AttachmentUploadEditModel, event: InputCustomEvent) {
-    const photographer = event.detail.value;
+  addNewAttachmentPhotographer(attachment: AttachmentUploadEditModel, event: InputCustomEvent<FocusEvent>) {
+    const photographer = event.target.value;
     if (photographer == null || photographer == undefined) return;
-    this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Photographer: photographer });
+    this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), {
+      ...attachment,
+      Photographer: photographer as string,
+    });
   }
 
   updateExistingAttachmentPhotographer(attachment: RemoteOrLocalAttachmentEditModel, event: InputCustomEvent) {
@@ -208,10 +211,10 @@ export class EditImagesComponent implements OnInit {
     );
   }
 
-  addNewAttachmentCopyright(attachment: AttachmentUploadEditModel, event: InputCustomEvent) {
-    const copyRight = event.detail.value;
+  addNewAttachmentCopyright(attachment: AttachmentUploadEditModel, event: InputCustomEvent<FocusEvent>) {
+    const copyRight = event.target.value;
     if (copyRight == null || copyRight == undefined) return;
-    this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Copyright: copyRight });
+    this.newAttachmentService.saveAttachmentMeta$(this.draftUuid(), { ...attachment, Copyright: copyRight as string });
   }
 
   updateExistingAttachmentCopyright(attachment: RemoteOrLocalAttachmentEditModel, event: InputCustomEvent) {

--- a/src/app/modules/registration/components/text-comment/text-comment.component.ts
+++ b/src/app/modules/registration/components/text-comment/text-comment.component.ts
@@ -1,5 +1,5 @@
 import { IonItem, IonTextarea } from '@ionic/angular/standalone';
-import { Component, input, model } from '@angular/core';
+import { Component, input, model, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { UpperCasePipe } from '@angular/common';
@@ -17,8 +17,13 @@ export class TextCommentComponent {
   readonly rows = input(4);
   readonly disabled = input(false);
   readonly max = input(1024);
+  /**
+   * Emiter kommentar ved blur på kommentarfelt
+   */
+  readonly blur = output<string | undefined>();
 
   onBlur() {
     this.value.update((v) => (v ? v.trim() : v));
+    this.blur.emit(this.value());
   }
 }


### PR DESCRIPTION
Før lagret vi metadata til bildet på fil hver gang man skrev inn et tegn i feltene for beskrivelse, fotograg og rettighetsinnehaver.
Dette førte til problemer med lagring, kanskje fordi appen ikke rakk å oppdatere feltene med lagrede data før neste lagring.

Nå lagrer vi metadata til bildet på fil først når man forlater disse feltene.
Fordelen er at data lagres mye sjeldnere, og sjansen for konflikter blir mye mindre.
Ulempen er at man kan miste det man har skrevet i feltet om appen kræsjer eller om du bytter til en annen app mens du har fokus i feltet.