### PR TITLE
RO-3007: fikse feil med henting bilder på store skjermer

### DIFF
--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -141,7 +141,7 @@ export class PagedSearchResult<TViewModel extends HasRegId> {
         this.allFetchedForCriteria.next(registrations.length >= (totalCount || 0));
         this.maxItemsFetched.next(registrations.length >= PagedSearchResult.MAX_ITEMS);
         this.count.set(totalCount);
-        this.attachmentCount.set(attachmentCount === undefined ? undefined : attachmentCount);
+        this.attachmentCount.set(attachmentCount);
       }),
       // Map to registrations
       map(([registrations]) => registrations),

--- a/src/app/core/services/search-registration/search-registration.service.ts
+++ b/src/app/core/services/search-registration/search-registration.service.ts
@@ -82,6 +82,7 @@ export class PagedSearchResult<TViewModel extends HasRegId> {
   isFetching$ = this.isFetching.asObservable();
   private forceUpdate = new Subject<void>();
   count = signal<number | undefined>(undefined);
+  attachmentCount = signal<number | undefined>(undefined);
 
   private countError = new ReplaySubject<Error | undefined>(1);
   private searchError = new ReplaySubject<Error | undefined>(1);
@@ -108,7 +109,8 @@ export class PagedSearchResult<TViewModel extends HasRegId> {
     // Not sure what is best here, provide SearchService to this class, or provide the flexibility to create these
     // functions outside
     fetchFunc: (criteria: SearchCriteriaRequestDto) => Observable<TViewModel[]>,
-    countFunc: (criteria: SearchCriteriaRequestDto) => Observable<number | undefined>
+    regCountFunc: (criteria: SearchCriteriaRequestDto) => Observable<number | undefined>,
+    attCountFunc?: (criteria: SearchCriteriaRequestDto) => Observable<number | undefined>
   ) {
     this.registrations$ = combineLatest([searchCriteria$, this.forceUpdate.pipe(startWith(null))]).pipe(
       // For every new search criteria, create a paged search and check what the total count is
@@ -116,20 +118,30 @@ export class PagedSearchResult<TViewModel extends HasRegId> {
       switchMap(([searchCriteria]) =>
         combineLatest([
           this.createPagedSearch(searchCriteria, fetchFunc),
-          countFunc(searchCriteria as SearchCriteriaRequestDto).pipe(
+          regCountFunc(searchCriteria as SearchCriteriaRequestDto).pipe(
             tap(() => this.countError.next(undefined)),
             catchError((err) => {
               this.countError.next(err);
               return of(0);
             })
           ),
+          attCountFunc
+            ? attCountFunc(searchCriteria as SearchCriteriaRequestDto).pipe(
+                tap(() => this.countError.next(undefined)),
+                catchError((err) => {
+                  this.countError.next(err);
+                  return of(0);
+                })
+              )
+            : of(undefined),
         ])
       ),
       // Save search state
-      tap(([registrations, totalCount]) => {
+      tap(([registrations, totalCount, attachmentCount]) => {
         this.allFetchedForCriteria.next(registrations.length >= (totalCount || 0));
         this.maxItemsFetched.next(registrations.length >= PagedSearchResult.MAX_ITEMS);
         this.count.set(totalCount);
+        this.attachmentCount.set(attachmentCount === undefined ? undefined : attachmentCount);
       }),
       // Map to registrations
       map(([registrations]) => registrations),
@@ -258,7 +270,9 @@ export class SearchRegistrationService {
     return new PagedSearchResult<SearchRegistrationsWithAttachments>(
       searchCriteria$,
       this.searchService.SearchAttachments.bind(this.searchService),
-      (searchCriteria) => this.searchService.SearchCount(searchCriteria).pipe(map((result) => result.TotalMatches))
+      (searchCriteria) => this.searchService.SearchCount(searchCriteria).pipe(map((result) => result.TotalMatches)),
+      (searchCriteria) =>
+        this.searchService.SearchAttachmentsCount(searchCriteria).pipe(map((result) => result.TotalMatches))
     );
   }
 }

--- a/src/app/modules/common-regobs-api/services/search.service.ts
+++ b/src/app/modules/common-regobs-api/services/search.service.ts
@@ -249,13 +249,51 @@ class SearchService extends __BaseService {
   }
 
   /**
-   * Search for images only
+   * Search for attachment count
    * @param criteria Search criteria
    * @return OK
    */
   SearchAttachments(criteria: SearchCriteriaRequestDto): __Observable<SearchRegistrationsWithAttachments[]> {
     return this.SearchAttachmentsResponse(criteria).pipe(
       __map(_r => _r.body as SearchRegistrationsWithAttachments[])
+    );
+  }
+
+    /**
+   * Returns search attachment count
+   * @param criteria Search criteria
+   * @return OK
+   */
+  SearchAttachmentsCountResponse(criteria: SearchCriteriaRequestDto): __Observable<__StrictHttpResponse<SearchCountResponseDto>> {
+    let __params = this.newParams();
+    let __headers = new HttpHeaders();
+    let __body: any = null;
+    __body = criteria;
+    let req = new HttpRequest<any>(
+      'POST',
+      this.rootUrl + `/Search/Attachments/Count`,
+      __body,
+      {
+        headers: __headers,
+        params: __params,
+        responseType: 'json'
+      });
+
+    return this.http.request<any>(req).pipe(
+      __filter(_r => _r instanceof HttpResponse),
+      __map((_r) => {
+        return _r as __StrictHttpResponse<SearchCountResponseDto>;
+      })
+    );
+  }
+  /**
+   * Returns search result count
+   * @param criteria Search criteria
+   * @return OK
+   */
+  SearchAttachmentsCount(criteria: SearchCriteriaRequestDto): __Observable<SearchCountResponseDto> {
+    return this.SearchAttachmentsCountResponse(criteria).pipe(
+      __map(_r => _r.body as SearchCountResponseDto)
     );
   }
 

--- a/src/app/modules/common-regobs-api/services/search.service.ts
+++ b/src/app/modules/common-regobs-api/services/search.service.ts
@@ -287,7 +287,7 @@ class SearchService extends __BaseService {
     );
   }
   /**
-   * Returns search result count
+   * Returns search attachment count
    * @param criteria Search criteria
    * @return OK
    */

--- a/src/app/pages/observation-list/image-list/image-list.component.html
+++ b/src/app/pages/observation-list/image-list/image-list.component.html
@@ -9,7 +9,7 @@
     <app-list-controls pageType="images"></app-list-controls>
   </div>
 
-  <div class="grid">
+  <div class="grid" #grid>
     @for (reg of registrations(); track reg.RegId) {
       @for (attachment of reg.Attachments; track attachment.AttachmentId) {
         <app-grid-image

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -1,5 +1,14 @@
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { afterRenderEffect, ChangeDetectionStrategy, Component, computed, inject, viewChild } from '@angular/core';
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  inject,
+  Injector,
+  viewChild,
+} from '@angular/core';
 import {
   IonContent,
   IonInfiniteScroll,
@@ -21,6 +30,9 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { UpdateObservationsService } from 'src/app/modules/side-menu/components/update-observations/update-observations.service';
 import { ObservationImageCarouselComponent } from 'src/app/components/observation/observation-image-carousel/observation-image-carousel.component';
 import { AttachmentViewModel, SearchService } from 'src/app/modules/common-regobs-api';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+
+const DEBUG_TAG = 'ImageList';
 
 /**
  * Bildesøk
@@ -53,23 +65,20 @@ export class ImageListComponent {
   private updateObservationsService = inject(UpdateObservationsService);
   private translateService = inject(TranslateService);
   private loadingController = inject(LoadingController);
+  private logger = inject(LoggingService);
+  private injector = inject(Injector);
 
   private searchHandler = this.searchRegistrations.searchAttachments(toObservable(this.searchCriteriaService.criteria));
   attCount = this.searchHandler.attachmentCount.asReadonly();
+
+  private gridElement = viewChild.required<ElementRef<HTMLDivElement>>('grid');
 
   constructor() {
     this.updateObservationsService.refreshRequested$?.pipe(takeUntilDestroyed()).subscribe(() => {
       this.refresh(); // oppfrisk sida når bruker trykker på oppfrisk-knappen i menyen
     });
-
-    afterRenderEffect({
-      // Kjører checkAndLoadMoreImages etter hver registration endring for å sikre at DOM er oppdatert før vi måler høyder
-      read: () => {
-        this.registrations();
-        this.checkAndLoadMoreImages();
-      },
-    });
   }
+
   /**
    * Sjekker om innholdet i grid er kortere enn vindushøyden, og laster i så fall flere bilder. Vi viser bilder kun fra
    * 10 observasjoner om gangen. Hvis bildene fra 10 observasjoner ikke dekker hele skjermen, vil infinite scroll
@@ -79,11 +88,13 @@ export class ImageListComponent {
     const attCount = this.attCount() || 0;
     // Sammenligner antall nedlastede vedlegg med totalt antall vedlegg
     if (this.currentlyDownloadedAttachments().length < attCount) {
-      const grid = document.querySelector('.grid');
-      if (!grid) return;
       const windowHeight = window.innerHeight;
-      const gridRect = grid.getBoundingClientRect();
-      if (gridRect.height < windowHeight && !this.disableInfiniteScroll()) {
+      const gridHeight = this.gridElement().nativeElement.getBoundingClientRect().height;
+      if (gridHeight < windowHeight && !this.disableInfiniteScroll()) {
+        this.logger.debug('image grid height < window height, loading more images', DEBUG_TAG, {
+          gridHeight,
+          windowHeight,
+        });
         this.loadNextPage();
       }
     }
@@ -95,6 +106,15 @@ export class ImageListComponent {
         this.infiniteScroll()?.complete();
         this.ionRefresher()?.complete();
         this.updateObservationsService.setLastFetched(new Date());
+        // Kjører checkAndLoadMoreImages etter grid er oppdatert i DOM for å sørge for at skjermen fylles opp
+        afterNextRender(
+          {
+            read: () => {
+              this.checkAndLoadMoreImages();
+            },
+          },
+          { injector: this.injector }
+        );
       })
     ),
     { initialValue: [] as SearchRegistrationsWithAttachments[] }

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -78,7 +78,7 @@ export class ImageListComponent {
   checkAndLoadMoreImages() {
     const attCount = this.attCount() || 0;
     // Sammenligner antall nedlastede vedlegg med totalt antall vedlegg
-    if (this.currentlyDownloadedAttachments().length <= attCount) {
+    if (this.currentlyDownloadedAttachments().length < attCount) {
       const grid = document.querySelector('.grid');
       if (!grid) return;
       const windowHeight = window.innerHeight;

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -1,13 +1,5 @@
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import {
-  afterRenderEffect,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  inject,
-  viewChild,
-} from '@angular/core';
+import { afterRenderEffect, ChangeDetectionStrategy, Component, computed, inject, viewChild } from '@angular/core';
 import {
   IonContent,
   IonInfiniteScroll,
@@ -29,7 +21,6 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { UpdateObservationsService } from 'src/app/modules/side-menu/components/update-observations/update-observations.service';
 import { ObservationImageCarouselComponent } from 'src/app/components/observation/observation-image-carousel/observation-image-carousel.component';
 import { AttachmentViewModel, SearchService } from 'src/app/modules/common-regobs-api';
-import { write } from 'fs';
 
 /**
  * Bildesøk

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, inject, viewChild } from '@angular/core';
 import {
   IonContent,
   IonInfiniteScroll,
@@ -55,24 +55,24 @@ export class ImageListComponent {
   private loadingController = inject(LoadingController);
 
   private searchHandler = this.searchRegistrations.searchAttachments(toObservable(this.searchCriteriaService.criteria));
-
+  attCount = this.searchHandler.attachmentCount.asReadonly();
   /**
    * Sjekker om innholdet i grid er kortere enn vindushøyden, og laster i så fall flere bilder. Vi viser bilder kun fra
    * 10 observasjoner om gangen. Hvis bildene fra 10 observasjoner ikke dekker hele skjermen, vil infinite scroll
    * aldri trigges ved scroll og derfor man kan ikke laste ned flere bilder.
    */
   checkAndLoadMoreImages() {
-    setTimeout(() => {
+    const attCount = this.attCount() || 0;
+    //compare number of currently downloaded attachments with total attachment count
+    if (this.currentlyDownloadedAttachments().length <= attCount) {
       const grid = document.querySelector('.grid');
       if (!grid) return;
-
       const windowHeight = window.innerHeight;
       const gridRect = grid.getBoundingClientRect();
-      // Sjekk om grid høyde er mindre enn vindushøyden, hvis ja, last flere bilder
       if (gridRect.height < windowHeight && !this.disableInfiniteScroll()) {
         this.loadNextPage();
       }
-    }, 100);
+    }
   }
 
   registrations = toSignal(
@@ -81,11 +81,14 @@ export class ImageListComponent {
         this.infiniteScroll()?.complete();
         this.ionRefresher()?.complete();
         this.updateObservationsService.setLastFetched(new Date());
+
         this.checkAndLoadMoreImages();
       })
     ),
     { initialValue: [] as SearchRegistrationsWithAttachments[] }
   );
+
+  currentlyDownloadedAttachments = computed(() => this.registrations().flatMap((reg) => reg.Attachments || []));
 
   disableInfiniteScroll = toSignal(
     combineLatest([this.searchHandler.allFetchedForCriteria$, this.searchHandler.maxItemsFetched$]).pipe(

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -1,5 +1,13 @@
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ChangeDetectionStrategy, Component, computed, inject, viewChild } from '@angular/core';
+import {
+  afterRenderEffect,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  viewChild,
+} from '@angular/core';
 import {
   IonContent,
   IonInfiniteScroll,
@@ -21,6 +29,7 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { UpdateObservationsService } from 'src/app/modules/side-menu/components/update-observations/update-observations.service';
 import { ObservationImageCarouselComponent } from 'src/app/components/observation/observation-image-carousel/observation-image-carousel.component';
 import { AttachmentViewModel, SearchService } from 'src/app/modules/common-regobs-api';
+import { write } from 'fs';
 
 /**
  * Bildesøk
@@ -56,6 +65,20 @@ export class ImageListComponent {
 
   private searchHandler = this.searchRegistrations.searchAttachments(toObservable(this.searchCriteriaService.criteria));
   attCount = this.searchHandler.attachmentCount.asReadonly();
+
+  constructor() {
+    this.updateObservationsService.refreshRequested$?.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.refresh(); // oppfrisk sida når bruker trykker på oppfrisk-knappen i menyen
+    });
+
+    afterRenderEffect({
+      // Kjører checkAndLoadMoreImages etter hver registration endring for å sikre at DOM er oppdatert før vi måler høyder
+      read: () => {
+        this.registrations();
+        this.checkAndLoadMoreImages();
+      },
+    });
+  }
   /**
    * Sjekker om innholdet i grid er kortere enn vindushøyden, og laster i så fall flere bilder. Vi viser bilder kun fra
    * 10 observasjoner om gangen. Hvis bildene fra 10 observasjoner ikke dekker hele skjermen, vil infinite scroll
@@ -81,8 +104,6 @@ export class ImageListComponent {
         this.infiniteScroll()?.complete();
         this.ionRefresher()?.complete();
         this.updateObservationsService.setLastFetched(new Date());
-
-        this.checkAndLoadMoreImages();
       })
     ),
     { initialValue: [] as SearchRegistrationsWithAttachments[] }
@@ -100,12 +121,6 @@ export class ImageListComponent {
   isLoading = toSignal(this.searchHandler.isFetching$, { initialValue: false });
   maxItemsFetched = toSignal(this.searchHandler.maxItemsFetched$, { initialValue: false });
   error = toSignal(this.searchHandler.error$, { initialValue: { hasError: false } });
-
-  constructor() {
-    this.updateObservationsService.refreshRequested$?.pipe(takeUntilDestroyed()).subscribe(() => {
-      this.refresh(); // oppfrisk sida når bruker trykker på oppfrisk-knappen i menyen
-    });
-  }
 
   loadNextPage() {
     this.searchHandler.increasePage();

--- a/src/app/pages/observation-list/image-list/image-list.component.ts
+++ b/src/app/pages/observation-list/image-list/image-list.component.ts
@@ -63,7 +63,7 @@ export class ImageListComponent {
    */
   checkAndLoadMoreImages() {
     const attCount = this.attCount() || 0;
-    //compare number of currently downloaded attachments with total attachment count
+    // Sammenligner antall nedlastede vedlegg med totalt antall vedlegg
     if (this.currentlyDownloadedAttachments().length <= attCount) {
       const grid = document.querySelector('.grid');
       if (!grid) return;


### PR DESCRIPTION
Vi skal nå bruke Search/Attachments/Count for å hente antall vedlegg i alle observasjoner. 
Den sjekker om det er flere vedlegg som må hentes i store skjermer. Den sjekker om grid med bilder er større enn et vindu, hvis ikke så fortsetter den å hente bilder (med mindre antall vedlegg er oppnådd). 

Kan testes med å zoome siden ut til ca 30%. Dere kan teste hvordan bilde liste visning oppfører seg når dere kommenterer this.checkAndLoadMoreImages() i registrations = toSignal(). 