### PR TITLE
RO-3107: Sett button-attributt på alle ion-item som oppfører seg som knapper

### DIFF
--- a/src/app/modules/map/pages/modal-search/modal-search.page.html
+++ b/src/app/modules/map/pages/modal-search/modal-search.page.html
@@ -17,7 +17,7 @@
 </ion-header>
 <ion-content>
   <ion-list lines="full" class="search-result">
-    <ion-item *ngFor="let item of searchResults()" (click)="searchItemClicked(item)">
+    <ion-item *ngFor="let item of searchResults()" (click)="searchItemClicked(item)" button>
       <ion-label>
         <ion-text class="search-result-name" [innerHTML]="item.name | startsWithHighlight: searchText()"></ion-text>
         <ion-text color="medium" class="search-description">{{ item.description }}</ion-text>
@@ -28,7 +28,7 @@
     <ion-list-header class="ion-text-uppercase">
       <ion-label>{{ "MAP_SEARCH.SEARCH_HISTORY_HEADER" | translate }}</ion-label>
     </ion-list-header>
-    <ion-item *ngFor="let item of searchHistory()" (click)="searchItemClicked(item)">
+    <ion-item *ngFor="let item of searchHistory()" (click)="searchItemClicked(item)" button>
       <ion-icon slot="start" name="time"></ion-icon>
       <ion-label>
         <ion-text class="search-result-name">{{ item.name }}</ion-text>

--- a/src/app/modules/registration/components/add-web-url-item/add-web-url-item.component.html
+++ b/src/app/modules/registration/components/add-web-url-item/add-web-url-item.component.html
@@ -1,10 +1,12 @@
 <ion-item>
   <h2 class="ion-label-fat">{{ "REGISTRATION.ADD_WEB_URL.LABEL" | translate }}</h2>
-  <div (click)="addOrEdit(i)" *ngFor="let url of weburls(); let i = index">
-    <span class="url">{{ url.UrlDescription && url.UrlDescription + " -" }} {{ url.UrlLine }}</span>
-  </div>
-  <div class="add-button" (click)="addOrEdit()">
+  @for (url of weburls(); track $index) {
+    <ion-button (click)="addOrEdit($index)" fill="clear">
+      <span class="url">{{ url.UrlDescription && url.UrlDescription + " -" }} {{ url.UrlLine }}</span>
+    </ion-button>
+  }
+  <ion-button fill="clear" (click)="addOrEdit()">
     <ion-icon [color]="iconColor()" name="add-circle-outline" slot="start"></ion-icon>
-    <span>{{ title() | translate }}</span>
-  </div>
+    {{ title() | translate }}
+  </ion-button>
 </ion-item>

--- a/src/app/modules/registration/components/add-web-url-item/add-web-url-item.component.scss
+++ b/src/app/modules/registration/components/add-web-url-item/add-web-url-item.component.scss
@@ -18,8 +18,3 @@ ion-item {
 span {
   font-size: 14px;
 }
-
-.add-button {
-  display: flex;
-  align-items: center;
-}

--- a/src/app/modules/registration/components/add-web-url-item/add-web-url-item.component.ts
+++ b/src/app/modules/registration/components/add-web-url-item/add-web-url-item.component.ts
@@ -2,16 +2,16 @@ import { ChangeDetectionStrategy, Component, inject, input, model } from '@angul
 import { IonIcon, IonItem, ModalController } from '@ionic/angular/standalone';
 import { AddWebUrlModalPage } from '../../pages/add-web-url-modal/add-web-url-modal.page';
 import { UrlViewModel } from 'src/app/modules/common-regobs-api/models';
-import { NgFor } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
 import { addCircleOutline } from 'ionicons/icons';
+import { IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-add-web-url-item',
   templateUrl: './add-web-url-item.component.html',
   styleUrls: ['./add-web-url-item.component.scss'],
-  imports: [IonIcon, IonItem, NgFor, TranslatePipe],
+  imports: [IonIcon, IonItem, TranslatePipe, IonButton],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AddWebUrlItemComponent {

--- a/src/app/modules/registration/components/failed-registration/failed-registration.component.html
+++ b/src/app/modules/registration/components/failed-registration/failed-registration.component.html
@@ -40,13 +40,13 @@
         {{ "REGISTRATION.FAILED.REFERENCE" | translate }} ID: {{ draft().uuid }}
       </ion-label>
     </ion-item>
-    <ion-item (click)="sendEmail()">
+    <ion-item (click)="sendEmail()" button>
       <ion-icon slot="start" name="mail"></ion-icon>
       <ion-label class="ion-text-wrap">
         {{ "REGISTRATION.FAILED.SEND_EMAIL" | translate }}
       </ion-label>
     </ion-item>
-    <ion-item (click)="openForEdit()">
+    <ion-item (click)="openForEdit()" button>
       <ion-icon slot="start" name="create"></ion-icon>
       <ion-label class="ion-text-wrap">
         {{ "REGISTRATION.FAILED.EDIT_OBSERVATION" | translate }}

--- a/src/app/modules/registration/components/gone-registration/gone-registration.component.html
+++ b/src/app/modules/registration/components/gone-registration/gone-registration.component.html
@@ -2,13 +2,13 @@
   <ion-item>
     <ion-label class="ion-text-wrap" [innerHTML]="'REGISTRATION.FAILED.GONE' | translate"></ion-label>
   </ion-item>
-  <ion-item (click)="abandon()">
+  <ion-item (click)="abandon()" button>
     <ion-icon slot="start" name="refresh"></ion-icon>
     <ion-label class="ion-text-wrap">
       {{ "REGISTRATION.FAILED.ABANDON" | translate }}
     </ion-label>
   </ion-item>
-  <ion-item (click)="submitAsNew()">
+  <ion-item (click)="submitAsNew()" button>
     <ion-icon slot="start" name="warning"></ion-icon>
     <ion-label class="ion-text-wrap">
       {{ "REGISTRATION.FAILED.SUBMIT_NEW" | translate }}

--- a/src/app/modules/registration/components/snow/compression-test-list/compression-test-list.component.html
+++ b/src/app/modules/registration/components/snow/compression-test-list/compression-test-list.component.html
@@ -10,7 +10,7 @@
       tabindex="0"
       detail="true"
       (click)="addOrEditCompressionTest(i)"
-      (keyup.enter)="addOrEditCompressionTest(i)"
+      (keyup.enter)="addOrEditCompressionTest(i)" button
     >
       <ion-label>
         @if (test.PropagationTID) {
@@ -32,7 +32,7 @@
     </ion-item>
   }
 
-  <ion-item tabindex="0" (click)="addOrEditCompressionTest()" (keyup.enter)="addOrEditCompressionTest()">
+  <ion-item tabindex="0" (click)="addOrEditCompressionTest()" (keyup.enter)="addOrEditCompressionTest()" button>
     <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
     <ion-label>{{ "REGISTRATION.SNOW.COMPRESSION_TEST.ADD_NEW" | translate }}</ion-label>
   </ion-item>

--- a/src/app/modules/registration/components/snow/snow-profile/compression-test/compression-test.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/compression-test/compression-test.component.html
@@ -1,18 +1,17 @@
 <ion-item tabindex="0" class="summary-item" (click)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.TITLE" | translate }}</h2>
-    <ion-item lines="none" class="ion-no-padding ion-no-margin">
-      @if(nTests() > 0) {
+    <p>
+      @if (nTests() > 0) {
         {{ connectedTests().length }} / {{ nTests() }}
         {{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.MULTIPLE_TESTS" | translate }}
         {{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.ATTACHED" | translate }}
-      }
-      @else {
+      } @else {
         {{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.EMPTY" | translate }}
       }
-    </ion-item>
+    </p>
   </ion-label>
-  @if(!isEmpty()) {
+  @if (!isEmpty()) {
     <ion-icon slot="end" color="success" name="checkmark-circle"></ion-icon>
   }
 </ion-item>

--- a/src/app/modules/registration/components/snow/snow-profile/compression-test/compression-test.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/compression-test/compression-test.component.html
@@ -1,4 +1,4 @@
-<ion-item tabindex="0" class="summary-item" (click)="openModal()" button>
+<ion-item class="summary-item" (click)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.TITLE" | translate }}</h2>
     <p>

--- a/src/app/modules/registration/components/snow/snow-profile/compression-test/compression-test.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/compression-test/compression-test.component.html
@@ -1,16 +1,18 @@
-<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()">
+<ion-item tabindex="0" class="summary-item" (click)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.TITLE" | translate }}</h2>
-    <p>
-      <ion-text>
-        <ng-container *ngIf="nTests() > 0; else empty"> {{ connectedTests().length }} / {{ nTests() }} </ng-container>
+    <ion-item lines="none" class="ion-no-padding ion-no-margin">
+      @if(nTests() > 0) {
+        {{ connectedTests().length }} / {{ nTests() }}
         {{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.MULTIPLE_TESTS" | translate }}
         {{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.ATTACHED" | translate }}
-      </ion-text>
-    </p>
+      }
+      @else {
+        {{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.EMPTY" | translate }}
+      }
+    </ion-item>
   </ion-label>
-  <ion-icon *ngIf="!isEmpty()" slot="end" color="success" name="checkmark-circle"></ion-icon>
+  @if(!isEmpty()) {
+    <ion-icon slot="end" color="success" name="checkmark-circle"></ion-icon>
+  }
 </ion-item>
-<ng-template #empty>
-  {{ "REGISTRATION.SNOW.SNOW_PROFILE.COMPRESSION_TEST.EMPTY" | translate }}
-</ng-template>

--- a/src/app/modules/registration/components/snow/snow-profile/compression-test/compression-test.component.ts
+++ b/src/app/modules/registration/components/snow/snow-profile/compression-test/compression-test.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { CompressionTestListModalPage } from './compression-test-list-modal/compression-test-list-modal.page';
-import { IonIcon, IonItem, IonLabel, IonText, ModalController } from '@ionic/angular/standalone';
-import { NgIf } from '@angular/common';
+import { IonIcon, IonItem, IonLabel, ModalController } from '@ionic/angular/standalone';
 import { TranslatePipe } from '@ngx-translate/core';
 import { addIcons } from 'ionicons';
 import { checkmarkCircle } from 'ionicons/icons';
@@ -11,7 +10,7 @@ import { RegistrationDraft } from 'src/app/core/services/draft/draft-model';
   selector: 'app-compression-test',
   templateUrl: './compression-test.component.html',
   styleUrls: ['./compression-test.component.scss'],
-  imports: [IonIcon, IonItem, IonLabel, IonText, NgIf, TranslatePipe],
+  imports: [IonIcon, IonItem, IonLabel, TranslatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CompressionTestComponent {

--- a/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-modal/snow-density-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density-modal/snow-density-modal.page.html
@@ -45,7 +45,7 @@
         <ion-label> {{ "REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.LAYER" | translate }} </ion-label>
       </ion-list-header>
       <ng-container *ngIf="hasLayers; else noLayers">
-        <ion-item tabindex="0" (click)="addLayerTop()" (keyup.enter)="addLayerTop()">
+        <ion-item tabindex="0" (click)="addLayerTop()" (keyup.enter)="addLayerTop()" button>
           <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
           <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.ADD_LAYER_TOP" | translate }}</ion-label>
         </ion-item>
@@ -55,6 +55,7 @@
             (click)="addOrEditLayer(i, layer)"
             (keyup.enter)="addOrEditLayer(i, layer)"
             *ngFor="let layer of profile.Layers; let i = index"
+            button
           >
             <ion-label>
               <ion-text *ngIf="layer.Thickness !== undefined"> {{ layer.Thickness | metersToCm }}cm </ion-text>
@@ -67,7 +68,7 @@
             <ion-reorder slot="end"></ion-reorder>
           </ion-item>
         </ion-reorder-group>
-        <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()">
+        <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()" button>
           <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
           <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.ADD_LAYER_BOTTOM" | translate }}</ion-label>
         </ion-item>
@@ -85,7 +86,7 @@
   </form>
 </ion-content>
 <ng-template #noLayers>
-  <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()">
+  <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()" button>
     <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
     <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.ADD_LAYER" | translate }}</ion-label>
   </ion-item>

--- a/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density.component.html
@@ -1,4 +1,4 @@
-<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()" button>
+<ion-item class="summary-item" (click)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.TITLE" | translate }}</h2>
     <p>

--- a/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-density/snow-density.component.html
@@ -1,4 +1,4 @@
-<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()">
+<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.SNOW_DENSITY.TITLE" | translate }}</h2>
     <p>

--- a/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp-modal/snow-temp-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp-modal/snow-temp-modal.page.html
@@ -13,14 +13,14 @@
         <ion-label> {{ "REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.TITLE" | translate }} </ion-label>
       </ion-list-header>
       @for (layer of layers(); let i = $index; track $index) {
-        <ion-item tabindex="0" (click)="addOrEditLayer(i)" (keyup.enter)="addOrEditLayer(i)">
+        <ion-item tabindex="0" (click)="addOrEditLayer(i)" (keyup.enter)="addOrEditLayer(i)" button>
           <ion-label>
             <ng-container *ngIf="layer.Depth !== undefined"> {{ layer.Depth | metersToCm }}cm </ng-container>
             <ng-container *ngIf="layer.SnowTemp !== undefined"> {{ layer.SnowTemp }}°C </ng-container>
           </ion-label>
         </ion-item>
       }
-      <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()">
+      <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()" button>
         <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
         <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.ADD_LAYER_BOTTOM" | translate }}</ion-label>
       </ion-item>

--- a/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp.component.html
@@ -1,4 +1,4 @@
-<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()">
+<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.TITLE" | translate }}</h2>
     <p>

--- a/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/snow-temp/snow-temp.component.html
@@ -1,4 +1,4 @@
-<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()" button>
+<ion-item class="summary-item" (click)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.SNOW_TEMP.TITLE" | translate }}</h2>
     <p>

--- a/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-modal/strat-profile-modal.page.html
+++ b/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile-modal/strat-profile-modal.page.html
@@ -13,7 +13,7 @@
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.FROM_OTHER_PROFILE" | translate }} </ion-label>
       </ion-list-header>
-      <ion-item tabindex="0" (click)="getPrevousUsedLayers()" (keyup.enter)="getPrevousUsedLayers()">
+      <ion-item tabindex="0" (click)="getPrevousUsedLayers()" (keyup.enter)="getPrevousUsedLayers()" button>
         <ion-icon color="dark" name="cloud-download" slot="start"></ion-icon>
         <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.OTHER_PROFILE_ITEM_TEXT" | translate }}</ion-label>
       </ion-item>
@@ -26,7 +26,7 @@
         <ion-label> {{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.TITLE" | translate }} </ion-label>
       </ion-list-header>
       <ng-container *ngIf="hasLayers(); else noLayers">
-        <ion-item tabindex="0" (click)="addLayerTop()" (keyup.enter)="addLayerTop()">
+        <ion-item tabindex="0" (click)="addLayerTop()" (keyup.enter)="addLayerTop()" button>
           <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
           <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.ADD_LAYER_TOP" | translate }}</ion-label>
         </ion-item>
@@ -36,6 +36,7 @@
             (click)="addOrEditLayer(i)"
             (keyup.enter)="addOrEditLayer(i)"
             *ngFor="let layer of layers(); let i = index"
+            button
           >
             <ion-label [color]="(layer.CriticalLayerTID || 0) > 0 ? 'danger' : 'dark'">
               <ng-container *ngIf="layer.Thickness !== undefined"> {{ layer.Thickness | metersToCm }}cm </ng-container>
@@ -55,7 +56,7 @@
             <ion-reorder slot="end"></ion-reorder>
           </ion-item>
         </ion-reorder-group>
-        <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()">
+        <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()" button>
           <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
           <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.ADD_LAYER_BOTTOM" | translate }}</ion-label>
         </ion-item>
@@ -86,7 +87,7 @@
   </form>
 </ion-content>
 <ng-template #noLayers>
-  <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()">
+  <ion-item tabindex="0" (click)="addLayerBottom()" (keyup.enter)="addLayerBottom()" button>
     <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
     <ion-label>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.ADD_LAYER" | translate }}</ion-label>
   </ion-item>

--- a/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile.component.html
@@ -1,4 +1,4 @@
-<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()">
+<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.TITLE" | translate }}</h2>
     <p>

--- a/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile.component.html
+++ b/src/app/modules/registration/components/snow/snow-profile/strat-profile/strat-profile.component.html
@@ -1,4 +1,4 @@
-<ion-item tabindex="0" class="summary-item" (click)="openModal()" (keyup.enter)="openModal()" button>
+<ion-item class="summary-item" (click)="openModal()" button>
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2>{{ "REGISTRATION.SNOW.SNOW_PROFILE.STRAT_PROFILE.TITLE" | translate }}</h2>
     <p>

--- a/src/app/modules/registration/components/summary-item/summary-item.component.html
+++ b/src/app/modules/registration/components/summary-item/summary-item.component.html
@@ -1,4 +1,4 @@
-<ion-item class="summary-item" (click)="navigate()" [detail]="!readonly()" *ngIf="!(readonly() && !item().hasData)">
+<ion-item class="summary-item" (click)="navigate()" [detail]="!readonly()" *ngIf="!(readonly() && !item().hasData)" [button]="!readonly()">
   <ion-label class="ion-padding-vertical ion-padding-end">
     <h2 [ngClass]="{ 'ion-label-fat': simpleObsMode() }">{{ item().title | translate }}</h2>
     <p *ngIf="item().subTitle as subTitle" [ngClass]="{ 'simple-mode-sub': simpleObsMode() }">

--- a/src/app/modules/registration/components/summary-item/summary-item.component.scss
+++ b/src/app/modules/registration/components/summary-item/summary-item.component.scss
@@ -7,11 +7,6 @@ img {
   display: inline-block;
 }
 
-.summary-item:hover {
-  cursor: pointer;
-  --background: var(--ion-color-varsom-blue-light-3);
-}
-
 .simple-mode-sub {
   font-weight: 400;
   font-size: 18px;

--- a/src/app/modules/registration/components/version-conflict/version-conflict.component.html
+++ b/src/app/modules/registration/components/version-conflict/version-conflict.component.html
@@ -2,13 +2,13 @@
   <ion-item>
     <ion-label class="ion-text-wrap" [innerHTML]="'REGISTRATION.FAILED.CONFLICT' | translate"></ion-label>
   </ion-item>
-  <ion-item (click)="abandon()">
+  <ion-item (click)="abandon()" button>
     <ion-icon slot="start" name="refresh"></ion-icon>
     <ion-label class="ion-text-wrap">
       {{ "REGISTRATION.FAILED.ABANDON" | translate }}
     </ion-label>
   </ion-item>
-  <ion-item (click)="overwrite()">
+  <ion-item (click)="overwrite()" button>
     <ion-icon slot="start" name="warning"></ion-icon>
     <ion-label class="ion-text-wrap">
       {{ "REGISTRATION.FAILED.OVERWRITE" | translate }}

--- a/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
+++ b/src/app/modules/registration/components/water/simple-water-obs/simple-water-obs.component.html
@@ -9,7 +9,7 @@
 
   <app-add-web-url-item [(weburls)]="urls"></app-add-web-url-item>
 
-  <ion-item (click)="nav()">
+  <ion-item (click)="nav()" button>
     <ion-label>
       <h2 class="ion-label-fat">
         {{ "REGISTRATION.WATER.WATER_LEVEL.SET_FLOOD_POSITION_SUMMARY_TITLE" | translate }}

--- a/src/app/modules/registration/pages/danger-obs/danger-obs.page.html
+++ b/src/app/modules/registration/pages/danger-obs/danger-obs.page.html
@@ -12,10 +12,10 @@
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ "REGISTRATION.DANGER_OBS.TITLE" | translate }} </ion-label>
       </ion-list-header>
-      <ion-item (click)="addOrEdit(i)" *ngFor="let danger of dangerObs; let i = index">
+      <ion-item (click)="addOrEdit(i)" *ngFor="let danger of dangerObs; let i = index" button>
         <ion-label>{{ getSummaryText(danger) }}</ion-label>
       </ion-item>
-      <ion-item (click)="addOrEdit()">
+      <ion-item (click)="addOrEdit()" button>
         <ion-icon color="dark" name="add-circle-outline" slot="start"></ion-icon>
         <ion-label>{{ "REGISTRATION.DANGER_OBS.NEW_DANGER_OBS" | translate }}</ion-label>
       </ion-item>

--- a/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.html
+++ b/src/app/modules/registration/pages/dirt/landslide-obs/landslide-obs.page.html
@@ -18,7 +18,7 @@
       <ion-list-header class="ion-text-uppercase">
         <ion-label> {{ "REGISTRATION.DIRT.LAND_SLIDE_OBS.TITLE" | translate }} </ion-label>
       </ion-list-header>
-      <ion-item detail="false" (click)="setLandslidePosition()">
+      <ion-item detail="false" (click)="setLandslidePosition()" button>
         <ion-label color="medium" position="stacked" class="ion-text-uppercase">{{
           "REGISTRATION.DIRT.LAND_SLIDE_OBS.POSITION" | translate
         }}</ion-label>

--- a/src/app/modules/registration/pages/overview/overview.page.html
+++ b/src/app/modules/registration/pages/overview/overview.page.html
@@ -3,7 +3,7 @@
     <ion-buttons slot="start">
       <ion-back-button text="" defaultHref="/"></ion-back-button>
     </ion-buttons>
-    <ion-title class="header-title">
+    <ion-title>
       {{ title() }}
     </ion-title>
   </ion-toolbar>

--- a/src/app/modules/registration/pages/overview/overview.page.html
+++ b/src/app/modules/registration/pages/overview/overview.page.html
@@ -3,22 +3,15 @@
     <ion-buttons slot="start">
       <ion-back-button text="" defaultHref="/"></ion-back-button>
     </ion-buttons>
-    <ng-container *ngIf="geoHazardName$ | async as geoHazardName">
-      <ion-title class="header-title">
-        {{ isDesktop ? "Varsom" : ("ADD_MENU.NEW_" + geoHazardName + "_OBSERVATION" | uppercase | translate) }}
-      </ion-title>
-    </ng-container>
+    <ion-title class="header-title">
+      {{ title() }}
+    </ion-title>
   </ion-toolbar>
 </ion-header>
 <ng-container *ngIf="draft$ | async as draft">
   <ion-content>
     <!-- Simple snow obs header-->
     <div class="content-wrapper">
-      <ng-container *ngIf="isDesktop">
-        <h2 *ngIf="geoHazardName$ | async as geoHazardName">
-          {{ "ADD_MENU.NEW_" + geoHazardName + "_OBSERVATION" | uppercase | translate }}
-        </h2>
-      </ng-container>
       <ng-container *ngIf="showSnowObsModeSelector$ | async">
         <ion-grid class="header">
           <ion-row>

--- a/src/app/modules/registration/pages/overview/overview.page.scss
+++ b/src/app/modules/registration/pages/overview/overview.page.scss
@@ -2,10 +2,6 @@ ion-list {
   padding-bottom: 10px;
 }
 
-.header-title {
-  padding-inline: 30px;
-}
-
 .content-wrapper {
   max-width: var(--form-max-width);
   margin: auto;

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -35,7 +35,6 @@ import {
   ConfirmationModalService,
   PopupResponse,
 } from '../../../../core/services/confirmation-modal/confirmation-modal.service';
-import { Capacitor } from '@capacitor/core';
 import { HeaderColorDirective } from '../../../shared/directives/header-color/header-color.directive';
 import { NgIf, NgFor, AsyncPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -119,10 +118,8 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
     map((draft) => draft.registration.GeoHazardTID === GeoHazard.Snow && !this.syncFailed(draft))
   );
   geoHazardName$ = this.draft$.pipe(map((draft) => GeoHazard[draft.registration.GeoHazardTID]));
-  isDesktop = !Capacitor.isNativePlatform();
 
   draft = toSignal(this.draft$);
-  regId = computed(() => this.draft()?.regId);
   geoHazardName = toSignal(this.geoHazardName$);
 
   title = computed(() => {

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, NgZone, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, NgZone, OnInit, computed, inject } from '@angular/core';
 import { firstValueFrom, map, Observable, of, switchMap, takeUntil } from 'rxjs';
 import { RegistrationTid, SyncStatus } from 'src/app/modules/common-registration/registration.models';
 import { UserGroupService } from '../../../../core/services/user-group/user-group.service';
@@ -15,7 +15,7 @@ import { getRegistrationName } from 'src/app/modules/common-registration/registr
 import { DangerObsEditModel, SnowSurfaceEditModel } from 'src/app/modules/common-regobs-api';
 import { isEmpty } from 'src/app/modules/common-core/helpers';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import {
   IonBackButton,
   IonButtons,
@@ -45,6 +45,7 @@ import { SimpleWaterObsComponent } from '../../components/water/simple-water-obs
 import { SummaryItemComponent } from '../../components/summary-item/summary-item.component';
 import { SendButtonComponent } from '../../components/send-button/send-button.component';
 import { CoachMarksSimpleObsComponent } from '../../../../components/coach-marks/coach-marks-simple-obs/coach-marks-simple-obs.component';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 const DEBUG_TAG = 'OverviewPage';
 
@@ -100,6 +101,7 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
   private logger = inject(LoggingService);
   private draftRepository = inject(DraftRepositoryService);
   private confirmationModalService = inject(ConfirmationModalService);
+  private translateService = inject(TranslateService);
 
   private uuid = this.activatedRoute.snapshot.params['id'];
 
@@ -119,6 +121,22 @@ export class OverviewPage extends NgDestoryBase implements OnInit {
   );
   geoHazardName$ = this.draft$.pipe(map((draft) => GeoHazard[draft.registration.GeoHazardTID]));
   isDesktop = !Capacitor.isNativePlatform();
+
+  draft = toSignal(this.draft$);
+  regId = computed(() => this.draft()?.regId);
+  geoHazardName = toSignal(this.geoHazardName$);
+
+  title = computed(() => {
+    if (this.draft()?.regId) {
+      // dette er en observasjon som er sendt inn tidligere
+      const regId = this.draft()?.regId;
+      return this.translateService.instant('REGISTRATION.OVERVIEW.TITLE_EDIT', { regId });
+    } else {
+      // dette er en ny observasjon som ikke er sendt inn enda
+      const geoHazard = this.geoHazardName()?.toUpperCase();
+      return this.translateService.instant(`ADD_MENU.NEW_${geoHazard}_OBSERVATION`);
+    }
+  });
 
   ngOnInit() {
     this.userGroupService.updateUserGroups();

--- a/src/app/modules/registration/pages/overview/overview.page.ts
+++ b/src/app/modules/registration/pages/overview/overview.page.ts
@@ -37,7 +37,7 @@ import {
 } from '../../../../core/services/confirmation-modal/confirmation-modal.service';
 import { Capacitor } from '@capacitor/core';
 import { HeaderColorDirective } from '../../../shared/directives/header-color/header-color.directive';
-import { NgIf, NgFor, AsyncPipe, UpperCasePipe } from '@angular/common';
+import { NgIf, NgFor, AsyncPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { FailedRegistrationComponent } from '../../components/failed-registration/failed-registration.component';
 import { SimpleSnowObsComponent } from '../../components/snow/simple-snow-obs/simple-snow-obs.component';
@@ -88,7 +88,6 @@ const DEBUG_TAG = 'OverviewPage';
     SimpleWaterObsComponent,
     SummaryItemComponent,
     TranslatePipe,
-    UpperCasePipe,
   ],
 })
 export class OverviewPage extends NgDestoryBase implements OnInit {

--- a/src/app/modules/registration/pages/snow/avalanche-activity/avalanche-activity.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-activity/avalanche-activity.page.html
@@ -20,7 +20,7 @@
       <ion-item
         detail="true"
         (click)="addOrEditAvalancheActivity(i)"
-        *ngFor="let avalancheActivity of avalancheActivities; let i = index"
+        *ngFor="let avalancheActivity of avalancheActivities; let i = index" button
       >
         <ion-label
           >{{ getEstimatedNumber(avalancheActivity) | translate
@@ -29,7 +29,7 @@
           ></ion-label
         >
       </ion-item>
-      <ion-item (click)="addOrEditAvalancheActivity()">
+      <ion-item (click)="addOrEditAvalancheActivity()" button>
         <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
         <ion-label>{{ "REGISTRATION.SNOW.AVALANCHE_ACTIVITY.ADD_NEW" | translate }}</ion-label>
       </ion-item>

--- a/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-obs/avalanche-obs.page.html
@@ -56,7 +56,7 @@
           {{ "ALERT.WARNING" | translate }}! {{ "REGISTRATION.SNOW.AVALANCHE_ACTIVITY.DATE_WARNING" | translate }}
         </ion-label>
       </ion-item>
-      <ion-item (click)="setAvalanchePosition()">
+      <ion-item (click)="setAvalanchePosition()" button>
         <ion-label color="medium" position="stacked" class="ion-text-uppercase">
           {{ "REGISTRATION.SNOW.AVALANCHE_OBS.POSITION" | translate }}</ion-label
         >

--- a/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem.page.html
+++ b/src/app/modules/registration/pages/snow/avalanche-problem/avalanche-problem.page.html
@@ -19,13 +19,13 @@
       </ion-list-header>
       <ion-reorder-group disabled="false" (ionItemReorder)="onProblemReorder($event)">
         @for (ap of draft.registration.AvalancheEvalProblem2; track $index) {
-          <ion-item detail="true" (click)="addOrEditAvalancheProblem($index)">
+          <ion-item detail="true" (click)="addOrEditAvalancheProblem($index)" button>
             <ion-label>{{ getDescription(ap) | translate }}</ion-label>
             <ion-reorder slot="end"></ion-reorder>
           </ion-item>
         }
       </ion-reorder-group>
-      <ion-item (click)="addOrEditAvalancheProblem()">
+      <ion-item (click)="addOrEditAvalancheProblem()" button>
         <ion-icon color="primary" name="add-circle-outline" slot="start"></ion-icon>
         <ion-label>{{ "REGISTRATION.SNOW.AVALANCHE_PROBLEM.ADD_NEW" | translate }}</ion-label>
       </ion-item>

--- a/src/app/pages/user-settings/user-settings.page.html
+++ b/src/app/pages/user-settings/user-settings.page.html
@@ -10,7 +10,7 @@
   <main>
     <ion-list lines="full">
       <!-- App version -->
-      <ion-item (click)="versionClick()">
+      <ion-item (click)="versionClick()" button>
         <ion-label position="stacked" color="medium" class="ion-text-uppercase"
           >{{ "SETTINGS.APP_VERSION" | translate }}
         </ion-label>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -595,7 +595,7 @@
         "TOGGLE": "Simple observation"
       },
       "TITLE": "Observation",
-      "TITLE_EDIT": "Edit observation with ID={{regId}}"
+      "TITLE_EDIT": "Observation with ID={{regId}}"
     },
     "REQUIRED_FIELDS_MISSING": "Some fields are invalid. Do you want to reset form and go back?",
     "RESEND": "Try to send again",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -595,7 +595,7 @@
         "TOGGLE": "Simple observation"
       },
       "TITLE": "Observation",
-      "TITLE_EDIT": "Edit observation #{{regId}}"
+      "TITLE_EDIT": "Edit observation with ID={{regId}}"
     },
     "REQUIRED_FIELDS_MISSING": "Some fields are invalid. Do you want to reset form and go back?",
     "RESEND": "Try to send again",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -594,7 +594,8 @@
         "IMAGES_MODAL_TITLE": "Images of {{registrationType}}",
         "TOGGLE": "Simple observation"
       },
-      "TITLE": "Observation"
+      "TITLE": "Observation",
+      "TITLE_EDIT": "Edit observation #{{regId}}"
     },
     "REQUIRED_FIELDS_MISSING": "Some fields are invalid. Do you want to reset form and go back?",
     "RESEND": "Try to send again",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -593,7 +593,8 @@
         "IMAGES_MODAL_TITLE": "Bilder av {{registrationType}}",
         "TOGGLE": "Enkel observasjon"
       },
-      "TITLE": "Observasjon"
+      "TITLE": "Observasjon",
+      "TITLE_EDIT": "Rediger observasjon #{{regId}}"
     },
     "REQUIRED_FIELDS_MISSING": "Ugyldig skjema. Vil du nullstille skjemaet og gå tilbake?",
     "RESEND": "Prøv å sende på nytt",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -594,7 +594,7 @@
         "TOGGLE": "Enkel observasjon"
       },
       "TITLE": "Observasjon",
-      "TITLE_EDIT": "Rediger observasjon med ID={{regId}}"
+      "TITLE_EDIT": "Observasjon med ID={{regId}}"
     },
     "REQUIRED_FIELDS_MISSING": "Ugyldig skjema. Vil du nullstille skjemaet og gå tilbake?",
     "RESEND": "Prøv å sende på nytt",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -594,7 +594,7 @@
         "TOGGLE": "Enkel observasjon"
       },
       "TITLE": "Observasjon",
-      "TITLE_EDIT": "Rediger observasjon #{{regId}}"
+      "TITLE_EDIT": "Rediger observasjon med ID={{regId}}"
     },
     "REQUIRED_FIELDS_MISSING": "Ugyldig skjema. Vil du nullstille skjemaet og gå tilbake?",
     "RESEND": "Prøv å sende på nytt",


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/RO-3107

Denne endringen er altså trigget av at en observatør ikke skjønte hva han skulle gjøre når han fikk en versjonskonflikt på regobs.no. Og det forstår jeg, fordi "knappene" oppfører seg ikke som knapper.

Har søkt gjennom alle `ion-item` med click-event i applikasjonen og lagt til [`button`-attributtet](https://ionicframework.com/docs/api/item#button). Her har det vært en endring i Ionic 7, det er nok derfor vi har mistet "hover-effekten" på disse.

Noen steder har jeg ryddet litt mer, men innså ganske fort at jeg ikke har lyst til å prioritere å bytte ut alle *ngIf o.l. nå.
Den komponenten som er endret mest er nok den som viser weblenker. Den var kodet litt rart, så jeg brukte knapper i stedet.

- [x] Har igjen å bytte eller fjerne overskriften "Ny snøobservasjon" når innsending feiler, dette var veldig misvisende, i hvert fall hvis du får versjonskonflikt, for det er ikke mulig å få på en ny observasjon. Jeg bare fjernet overskriften, og viser heller "Rediger observasjon #<reg-ID>" i tittelfeltet. Litt teknisk, men i hvert fall bedre enn det var, synes jeg. Denne vises også når du redigerer en observasjon som allerede er sendt inn (ny visning til høyre):
<img width="689" height="257" alt="image" src="https://github.com/user-attachments/assets/58dfb6f4-ad40-469c-9f70-63aeb51eaa7c" />


Disse skjemaene er endret:
- søk på stedsnavn
- oversikt over observasjon når man redigerer (OverviewPage)
- alle skjema som har weblinker
- faretegn
- visning av observasjon når den feiler under innsending:
-- versjonskonflikt
-- registrering er slettet
-- andre feil (f.eks. nettverksfeil)
- Snø:
-- skredproblem
-- snøprofil
--- lagdeling
--- tester
--- tetthet
- Vann:
-- enkel vannobservasjon
- Jord:
-- jordskred

- [x] Jeg har ikke testet i app ennå. pga. problemer med utviklingsmiljø her

