### PR TITLE
RO-3111: Ikke la tastaturet dekke over tekstfelt i Android 15 og 16

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -19,7 +19,7 @@ const config: CapacitorConfig = {
     },
     Keyboard: {
       resize: KeyboardResize.Ionic,
-      resizeOnFullScreen: false,
+      resizeOnFullScreen: true,
       style: KeyboardStyle.Default,
     },
   },

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -19,7 +19,7 @@ const config: CapacitorConfig = {
     },
     Keyboard: {
       resize: KeyboardResize.Ionic,
-      resizeOnFullScreen: true,
+      resizeOnFullScreen: true, // RO-3111: Hindre at tataturet dekker over tekstfelt i Android 15 og 16
       style: KeyboardStyle.Default,
     },
   },

--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -16,7 +16,7 @@
 		},
 		"Keyboard": {
 			"resize": "ionic",
-			"resizeOnFullScreen": false,
+			"resizeOnFullScreen": true,
 			"style": "DEFAULT"
 		}
 	},
@@ -27,9 +27,9 @@
 		"preferences": {
 			"ScrollEnabled": "false",
 			"android-minSdkVersion": "24",
-			"android-compileSdkVersion": "30",
+			"android-compileSdkVersion": "35",
 			"android-build-tool": "30.0.3",
-			"android-targetSdkVersion": "30",
+			"android-targetSdkVersion": "35",
 			"BackupWebStorage": "none",
 			"SplashMaintainAspectRatio": "true",
 			"AutoHideSplashScreen": "true",

--- a/ios/App/App/config.xml
+++ b/ios/App/App/config.xml
@@ -34,9 +34,9 @@
   
   <preference name="ScrollEnabled" value="false" />
   <preference name="android-minSdkVersion" value="24" />
-  <preference name="android-compileSdkVersion" value="30" />
+  <preference name="android-compileSdkVersion" value="35" />
   <preference name="android-build-tool" value="30.0.3" />
-  <preference name="android-targetSdkVersion" value="30" />
+  <preference name="android-targetSdkVersion" value="35" />
   <preference name="BackupWebStorage" value="none" />
   <preference name="SplashMaintainAspectRatio" value="true" />
   <preference name="AutoHideSplashScreen" value="true" />


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/RO-3111 og https://capacitorjs.com/docs/v7/apis/keyboard.
Har testet på Android 12 og 15.
I Android 15:
- Hvis `resizeOnFullScreen = false` dekker tastaturet over tekstfelt langt ned på sida, og det er ikke mulig å scrolle opp slik at hele sida blir synlig.
- Hvis `resizeOnFullScreen = true` scrolles sida automatisk opp når tastaturet vises, slik at man ser hva man skriver

I Android 12 spiller det ingen rolle hva vi setter i resizeOnFullScreen. Begge deler funker.
