### PR TITLE
RO-3047: Mer effektiv tegning av spor, forsøk 2

### DIFF
--- a/src/app/core/services/geojson/geojson-item.model.ts
+++ b/src/app/core/services/geojson/geojson-item.model.ts
@@ -1,7 +1,7 @@
 export interface GeoJSONItem {
   id: string;
   name: string;
-  date?: number;
+  date: number;
   visibleOnMap?: boolean;
   comment?: string;
   lengthKm?: number;

--- a/src/app/core/services/geojson/geojson.service.spec.ts
+++ b/src/app/core/services/geojson/geojson.service.spec.ts
@@ -148,7 +148,7 @@ describe('GeoJSONService', () => {
       service = TestBed.inject(GeoJSONService);
       tick();
       // Add an item first
-      service.metadata.set([mockMetadataItem]);
+      service.save(mockMetadataItem, mockGeoJSON);
       tick();
       databaseService.set.calls.reset();
     }));

--- a/src/app/core/services/geojson/geojson.service.spec.ts
+++ b/src/app/core/services/geojson/geojson.service.spec.ts
@@ -1,0 +1,189 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { GeoJSONService } from './geojson.service';
+import { DatabaseService } from '../database/database.service';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { FeatureCollection } from 'geojson';
+import { GeoJSONItem } from './geojson-item.model';
+
+describe('GeoJSONService', () => {
+  let service: GeoJSONService;
+  let databaseService: jasmine.SpyObj<DatabaseService>;
+  let loggingService: jasmine.SpyObj<LoggingService>;
+
+  const mockGeoJSON: FeatureCollection = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [10.0, 60.0],
+        },
+        properties: {
+          name: 'Test Point',
+        },
+      },
+    ],
+  };
+
+  const mockMetadataItem: GeoJSONItem = {
+    id: 'test-id-1',
+    name: 'Test GeoJSON',
+    date: new Date().getTime(),
+  };
+
+  beforeEach(() => {
+    const databaseServiceSpy = jasmine.createSpyObj('DatabaseService', ['get', 'set', 'remove']);
+    const loggingServiceSpy = jasmine.createSpyObj('LoggingService', ['debug', 'error']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        GeoJSONService,
+        { provide: DatabaseService, useValue: databaseServiceSpy },
+        { provide: LoggingService, useValue: loggingServiceSpy },
+      ],
+    });
+
+    databaseService = TestBed.inject(DatabaseService) as jasmine.SpyObj<DatabaseService>;
+    loggingService = TestBed.inject(LoggingService) as jasmine.SpyObj<LoggingService>;
+
+    // Default spy returns
+    databaseService.get.and.returnValue(Promise.resolve([]));
+    databaseService.set.and.returnValue(Promise.resolve());
+    databaseService.remove.and.returnValue(Promise.resolve());
+  });
+
+  it('should be created', () => {
+    service = TestBed.inject(GeoJSONService);
+    expect(service).toBeTruthy();
+  });
+
+  describe('init', () => {
+    it('should load metadata from database on initialization', fakeAsync(() => {
+      const existingMetadata: GeoJSONItem[] = [mockMetadataItem];
+      databaseService.get.and.returnValue(Promise.resolve(existingMetadata));
+
+      service = TestBed.inject(GeoJSONService);
+      tick();
+
+      expect(databaseService.get).toHaveBeenCalledWith('geojson-metadata');
+      expect(service.metadata()).toEqual(existingMetadata);
+    }));
+
+    it('should initialize with empty metadata if none exists', fakeAsync(() => {
+      databaseService.get.and.returnValue(Promise.resolve(null));
+
+      service = TestBed.inject(GeoJSONService);
+      tick();
+
+      expect(service.metadata()).toEqual([]);
+    }));
+  });
+
+  describe('save', () => {
+    beforeEach(fakeAsync(() => {
+      service = TestBed.inject(GeoJSONService);
+      tick(); // Complete initialization
+      tick(); // Allow effect to run
+      databaseService.set.calls.reset();
+    }));
+
+    it('should save geojson and update metadata', fakeAsync(() => {
+      service.save(mockMetadataItem, mockGeoJSON);
+      tick();
+
+      expect(databaseService.set).toHaveBeenCalledWith(`geojson:${mockMetadataItem.id}`, mockGeoJSON);
+      expect(service.metadata()).toContain(mockMetadataItem);
+    }));
+
+    it('should save metadata after adding item', fakeAsync(() => {
+      service.save(mockMetadataItem, mockGeoJSON);
+      tick();
+      tick(); // Allow effect to trigger
+
+      expect(databaseService.set).toHaveBeenCalledWith('geojson-metadata', [mockMetadataItem]);
+    }));
+
+    it('should throw error if save fails', fakeAsync(() => {
+      const error = new Error('Save failed');
+      databaseService.set.and.returnValue(Promise.reject(error));
+
+      expectAsync(service.save(mockMetadataItem, mockGeoJSON)).toBeRejectedWith(error);
+      tick();
+
+      expect(loggingService.error).toHaveBeenCalled();
+    }));
+  });
+
+  describe('get', () => {
+    beforeEach(fakeAsync(() => {
+      service = TestBed.inject(GeoJSONService);
+      tick();
+    }));
+
+    it('should retrieve geojson by id', fakeAsync(() => {
+      databaseService.get.and.returnValue(Promise.resolve(mockGeoJSON));
+
+      service.get(mockMetadataItem.id).then((result) => {
+        expect(result).toEqual(mockGeoJSON);
+      });
+      tick();
+
+      expect(databaseService.get).toHaveBeenCalledWith(`geojson:${mockMetadataItem.id}`);
+    }));
+  });
+
+  describe('remove', () => {
+    beforeEach(fakeAsync(() => {
+      service = TestBed.inject(GeoJSONService);
+      tick();
+      // Add an item first
+      service.metadata.set([mockMetadataItem]);
+      tick();
+      databaseService.set.calls.reset();
+    }));
+
+    it('should remove geojson and update metadata', fakeAsync(() => {
+      service.remove(mockMetadataItem.id);
+      tick();
+
+      expect(databaseService.remove).toHaveBeenCalledWith(`geojson:${mockMetadataItem.id}`);
+      expect(service.metadata()).not.toContain(mockMetadataItem);
+    }));
+
+    it('should emit removed id', fakeAsync(() => {
+      let emittedId: string | undefined;
+      service.removedMetadataItemId$.subscribe((id) => (emittedId = id));
+
+      service.remove(mockMetadataItem.id);
+      tick();
+
+      expect(emittedId).toBe(mockMetadataItem.id);
+    }));
+
+    it('should save updated metadata after removal', fakeAsync(() => {
+      service.remove(mockMetadataItem.id);
+      tick();
+      tick(); // Allow effect to trigger
+
+      expect(databaseService.set).toHaveBeenCalledWith('geojson-metadata', []);
+    }));
+  });
+
+  describe('metadata$', () => {
+    beforeEach(fakeAsync(() => {
+      service = TestBed.inject(GeoJSONService);
+      tick();
+    }));
+
+    it('should emit metadata changes', fakeAsync(() => {
+      const emittedValues: GeoJSONItem[] = [];
+      service.changedMetadataItem$.subscribe((metadata) => emittedValues.push(metadata));
+
+      service.updateMetadata(mockMetadataItem);
+      tick();
+
+      expect(emittedValues[emittedValues.length - 1]).toEqual(mockMetadataItem);
+    }));
+  });
+});

--- a/src/app/core/services/geojson/geojson.service.spec.ts
+++ b/src/app/core/services/geojson/geojson.service.spec.ts
@@ -104,6 +104,16 @@ describe('GeoJSONService', () => {
       expect(databaseService.set).toHaveBeenCalledWith('geojson-metadata', [mockMetadataItem]);
     }));
 
+    it('should emit changed metadata item', fakeAsync(() => {
+      let emittedMetadata: GeoJSONItem | undefined;
+      service.changedMetadataItem$.subscribe((metadata) => (emittedMetadata = metadata));
+
+      service.save(mockMetadataItem, mockGeoJSON);
+      tick();
+
+      expect(emittedMetadata).toEqual(mockMetadataItem);
+    }));
+
     it('should throw error if save fails', fakeAsync(() => {
       const error = new Error('Save failed');
       databaseService.set.and.returnValue(Promise.reject(error));
@@ -170,7 +180,7 @@ describe('GeoJSONService', () => {
     }));
   });
 
-  describe('metadata$', () => {
+  describe('changedMetadataItem$', () => {
     beforeEach(fakeAsync(() => {
       service = TestBed.inject(GeoJSONService);
       tick();

--- a/src/app/core/services/geojson/geojson.service.ts
+++ b/src/app/core/services/geojson/geojson.service.ts
@@ -16,11 +16,12 @@ export class GeoJSONService {
   private db = inject(DatabaseService);
   private logger = inject(LoggingService);
   private initialized = false;
+  private metadata_ = signal<GeoJSONItem[]>([]);
   private changedMetadataItem = new Subject<GeoJSONItem>();
   private removedMetadataItemId = new Subject<string>();
 
   /** Metadata for alle lagrede spor */
-  metadata = signal<GeoJSONItem[]>([]);
+  metadata = this.metadata_.asReadonly();
 
   /** Lytt på denne for å få beskjed om nye eller endrede spor */
   changedMetadataItem$ = this.changedMetadataItem.asObservable();
@@ -42,7 +43,7 @@ export class GeoJSONService {
     this.logger.debug('Init', DEBUG_TAG);
     const items = await this.getMetadata();
     if (items && items.length > 0) {
-      this.metadata.set(items);
+      this.metadata_.set(items);
     }
     setTimeout(() => (this.initialized = true)); // For å unngå en første unødvendig lagring i effecten
   }
@@ -71,7 +72,7 @@ export class GeoJSONService {
    * @param item the geojson item to update
    */
   updateMetadata(item: GeoJSONItem) {
-    this.metadata.update((items) => {
+    this.metadata_.update((items) => {
       const other = items.filter((x) => x.id !== item.id);
       return [...other, item];
     });
@@ -100,7 +101,7 @@ export class GeoJSONService {
       }
 
       await this.db.set(`geojson:${metadata.id}`, geojson);
-      this.metadata.update((items) => [...items, metadata]);
+      this.metadata_.update((items) => [...items, metadata]);
       this.changedMetadataItem.next(metadata);
     } catch (error) {
       this.logger.error(error, DEBUG_TAG, 'Could not save', { metadata, geojson });
@@ -124,15 +125,7 @@ export class GeoJSONService {
   async remove(id: GeoJSONItem['id']): Promise<void> {
     this.logger.debug('Remove', DEBUG_TAG, { id });
     await this.db.remove(`geojson:${id}`);
-    this.metadata.update((items) => items.filter((item) => item.id !== id));
+    this.metadata_.update((items) => items.filter((item) => item.id !== id));
     this.removedMetadataItemId.next(id);
   }
-
-  /**
-   * List all geojson ids
-   */
-  // async listIds(): Promise<GeoJSONItem['id'][]> {
-  //   const keys = await this.db.keys();
-  //   return keys.filter((k) => k.startsWith('geojson:')).map((k) => k.replace('geojson:', ''));
-  // }
 }

--- a/src/app/core/services/geojson/geojson.service.ts
+++ b/src/app/core/services/geojson/geojson.service.ts
@@ -3,9 +3,9 @@ import { DatabaseService } from '../database/database.service';
 import { Feature, FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
 import { GeoJSONItem } from './geojson-item.model';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { cleanFeatureCollection } from 'src/app/pages/plans/geojson';
 import { length } from '@turf/turf';
+import { Subject } from 'rxjs';
 
 const DEBUG_TAG = 'GeoJSON';
 
@@ -15,10 +15,18 @@ const DEBUG_TAG = 'GeoJSON';
 export class GeoJSONService {
   private db = inject(DatabaseService);
   private logger = inject(LoggingService);
-
-  metadata = signal<GeoJSONItem[]>([]);
-  readonly metadata$ = toObservable(this.metadata);
   private initialized = false;
+  private changedMetadataItem = new Subject<GeoJSONItem>();
+  private removedMetadataItemId = new Subject<string>();
+
+  /** Metadata for alle lagrede spor */
+  metadata = signal<GeoJSONItem[]>([]);
+
+  /** Lytt på denne for å få beskjed om nye eller endrede spor */
+  changedMetadataItem$ = this.changedMetadataItem.asObservable();
+
+  /** Lytt på denne for å få beskjed om slettede spor */
+  removedMetadataItemId$ = this.removedMetadataItemId.asObservable();
 
   constructor() {
     this.init();
@@ -67,6 +75,7 @@ export class GeoJSONService {
       const other = items.filter((x) => x.id !== item.id);
       return [...other, item];
     });
+    this.changedMetadataItem.next(item);
   }
 
   /**
@@ -92,6 +101,7 @@ export class GeoJSONService {
 
       await this.db.set(`geojson:${metadata.id}`, geojson);
       this.metadata.update((items) => [...items, metadata]);
+      this.changedMetadataItem.next(metadata);
     } catch (error) {
       this.logger.error(error, DEBUG_TAG, 'Could not save', { metadata, geojson });
       throw error;
@@ -115,6 +125,7 @@ export class GeoJSONService {
     this.logger.debug('Remove', DEBUG_TAG, { id });
     await this.db.remove(`geojson:${id}`);
     this.metadata.update((items) => items.filter((item) => item.id !== id));
+    this.removedMetadataItemId.next(id);
   }
 
   /**

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -514,7 +514,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       .subscribe();
 
     // Tegn alle lagrede geoJSON-objekter ved oppstart
-    const allMetadata = await this.geoJSONService.metadata();
+    const allMetadata = this.geoJSONService.metadata();
     for (const metadata of allMetadata) {
       if (metadata.visibleOnMap) {
         const geojson = await this.geoJSONService.get(metadata.id);

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -18,7 +18,7 @@ import { Position } from '@capacitor/geolocation';
 import { Platform } from '@ionic/angular/standalone';
 import L from 'leaflet';
 import { BehaviorSubject, combineLatest, firstValueFrom, from, fromEventPattern, Subject, timer } from 'rxjs';
-import { concatMap, distinctUntilChanged, filter, take, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { concatMap, distinctUntilChanged, filter, take, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 import { isAndroidOrIos } from 'src/app/core/helpers/ionic/platform-helper';
 import { MapLayerZIndex } from 'src/app/core/models/maplayer-zindex.enum';
 import { TopoMapLayer } from 'src/app/core/models/topo-map-layer.enum';
@@ -326,7 +326,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
    * @param map Leaflet map
    * @param id Unique id for the geojson layer
    */
-  private async removeGeojsonLayer(map: L.Map, id: string) {
+  private removeGeojsonLayer(map: L.Map, id: string) {
     const entry = this.geojsonLayers.get(id);
     if (entry) {
       if (map.hasLayer(entry.layer)) map.removeLayer(entry.layer);
@@ -506,12 +506,10 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       .subscribe();
 
     // Fjern geoJSON-lag når metadata slettes
-    this.geoJSONService.removedMetadataItemId$
-      .pipe(
-        takeUntil(this.ngDestroy$),
-        concatMap((id) => from(this.removeGeojsonLayer(map, id)))
-      )
-      .subscribe();
+    this.geoJSONService.removedMetadataItemId$.pipe(takeUntil(this.ngDestroy$)).subscribe((id) => {
+      this.loggingService.debug(`GeoJSON med id = ${id} er slettet, fjerner kartlaget`, DEBUG_TAG, { id });
+      this.removeGeojsonLayer(map, id);
+    });
 
     // Tegn alle lagrede geoJSON-objekter ved oppstart
     const allMetadata = this.geoJSONService.metadata();
@@ -527,7 +525,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
 
   // Oppdaterer et GeoJSON-lag i kartet basert på endrede metadata
   private async updateGeoJsonLayer(map: L.Map, metadata: GeoJSONItem) {
-    await this.removeGeojsonLayer(map, metadata.id);
+    this.removeGeojsonLayer(map, metadata.id);
 
     if (metadata.visibleOnMap) {
       const geojson = await this.geoJSONService.get(metadata.id);

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -17,8 +17,8 @@ import { Capacitor } from '@capacitor/core';
 import { Position } from '@capacitor/geolocation';
 import { Platform } from '@ionic/angular/standalone';
 import L from 'leaflet';
-import { BehaviorSubject, combineLatest, firstValueFrom, fromEventPattern, Subject, timer } from 'rxjs';
-import { distinctUntilChanged, filter, take, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, firstValueFrom, from, fromEventPattern, Subject, timer } from 'rxjs';
+import { distinctUntilChanged, filter, switchMap, take, takeUntil, withLatestFrom } from 'rxjs/operators';
 import { isAndroidOrIos } from 'src/app/core/helpers/ionic/platform-helper';
 import { MapLayerZIndex } from 'src/app/core/models/maplayer-zindex.enum';
 import { TopoMapLayer } from 'src/app/core/models/topo-map-layer.enum';
@@ -291,11 +291,11 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     // Click handler for this geojson
-    const setMetadata = (e: L.LeafletMouseEvent) => {
+    const setMetadata = () => {
       const missingName = this.translateService.instant('PLANS.MISSING_NAME');
       const missingDescription = this.translateService.instant('PLANS.MISSING_COMMENT');
-      const name = metadata?.name || e.layer?.feature?.properties?.navn || missingName;
-      const description = metadata?.comment || e.layer?.feature?.properties?.beskrivelse || missingDescription;
+      const name = metadata?.name || missingName;
+      const description = metadata?.comment || missingDescription;
       this.metadataName.set(name);
       this.metadataDescription.set(description);
     };
@@ -475,23 +475,7 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       }
     });
 
-    // Lytt på endringer i evt. geojson-metadata og tegn geojson-lag (på nytt)
-    this.geoJSONService.metadata$.pipe(takeUntil(this.ngDestroy$)).subscribe(async (metadataForAllTracks) => {
-      if (metadataForAllTracks && map) {
-        metadataForAllTracks.forEach(async (trackMetadata) => {
-          // Fjern eksisterende geojson-lag for id
-          this.removeGeojsonLayer(map, trackMetadata.id);
-          if (!trackMetadata.visibleOnMap) {
-            return;
-          }
-          // Hent oppdatert geojson fra tjenesten
-          const geojson = await this.geoJSONService.get(trackMetadata.id);
-          if (geojson) {
-            this.addGeojsonLayer(map, trackMetadata.id, geojson, trackMetadata);
-          }
-        });
-      }
-    });
+    this.addGeoJsonLayers(map);
 
     if (isAndroidOrIos(this.platform)) {
       this.initOfflineMaps();
@@ -508,6 +492,52 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       .subscribe(() => this.redrawMap());
 
     this.mapReady.emit(map);
+  }
+
+  // Henter alle lagrede geoJSON-objekter og oppretter et kartlag for hver av dem
+  private async addGeoJsonLayers(map: L.Map) {
+    const allMetadata = await this.geoJSONService.metadata();
+    for (const metadata of allMetadata) {
+      if (metadata.visibleOnMap) {
+        const geojson = await this.geoJSONService.get(metadata.id);
+        if (geojson) {
+          this.addGeojsonLayer(map, metadata.id, geojson, metadata);
+        }
+      }
+    }
+    this.geoJSONService.changedMetadataItem$
+      .pipe(
+        takeUntil(this.ngDestroy$),
+        switchMap((metadata) => from(this.updateGeoJsonLayer(map, metadata)))
+      )
+      .subscribe();
+    this.geoJSONService.removedMetadataItemId$
+      .pipe(
+        takeUntil(this.ngDestroy$),
+        switchMap((id) => from(this.removeGeojsonLayer(map, id)))
+      )
+      .subscribe();
+  }
+
+  // Oppdaterer et GeoJSON-lag i kartet basert på endrede metadata
+  private async updateGeoJsonLayer(map: L.Map, metadata: GeoJSONItem) {
+    await this.removeGeojsonLayer(map, metadata.id);
+
+    if (metadata.visibleOnMap) {
+      const geojson = await this.geoJSONService.get(metadata.id);
+      if (geojson) {
+        this.loggingService.debug(
+          `GeoJson med id = ${metadata.id} er ny eller endret. Tegner sporet (på nytt)`,
+          DEBUG_TAG,
+          { metadata }
+        );
+        this.addGeojsonLayer(map, metadata.id, geojson, metadata);
+      }
+    } else {
+      this.loggingService.debug(`GeoJson med id = ${metadata.id} er deaktivert. Fjernet sporet`, DEBUG_TAG, {
+        metadata,
+      });
+    }
   }
 
   private async initOfflineMaps() {

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -291,11 +291,12 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     // Click handler for this geojson
-    const setMetadata = () => {
+    // Obsturer har navn og beskrivelse i properties i geoJSON-objektet, og ikke i metadata-objektet
+    const setMetadata = (e: L.LeafletMouseEvent) => {
       const missingName = this.translateService.instant('PLANS.MISSING_NAME');
       const missingDescription = this.translateService.instant('PLANS.MISSING_COMMENT');
-      const name = metadata?.name || missingName;
-      const description = metadata?.comment || missingDescription;
+      const name = metadata?.name || e.propagatedFrom?.feature?.properties?.navn || missingName;
+      const description = metadata?.comment || e.propagatedFrom?.feature?.properties?.beskrivelse || missingDescription;
       this.metadataName.set(name);
       this.metadataDescription.set(description);
     };

--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -18,7 +18,7 @@ import { Position } from '@capacitor/geolocation';
 import { Platform } from '@ionic/angular/standalone';
 import L from 'leaflet';
 import { BehaviorSubject, combineLatest, firstValueFrom, from, fromEventPattern, Subject, timer } from 'rxjs';
-import { distinctUntilChanged, filter, switchMap, take, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { concatMap, distinctUntilChanged, filter, take, takeUntil, withLatestFrom } from 'rxjs/operators';
 import { isAndroidOrIos } from 'src/app/core/helpers/ionic/platform-helper';
 import { MapLayerZIndex } from 'src/app/core/models/maplayer-zindex.enum';
 import { TopoMapLayer } from 'src/app/core/models/topo-map-layer.enum';
@@ -496,6 +496,23 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
 
   // Henter alle lagrede geoJSON-objekter og oppretter et kartlag for hver av dem
   private async addGeoJsonLayers(map: L.Map) {
+    // Endre eller legg til geoJSON-lag når metadata endres
+    this.geoJSONService.changedMetadataItem$
+      .pipe(
+        takeUntil(this.ngDestroy$),
+        concatMap((metadata) => from(this.updateGeoJsonLayer(map, metadata)))
+      )
+      .subscribe();
+
+    // Fjern geoJSON-lag når metadata slettes
+    this.geoJSONService.removedMetadataItemId$
+      .pipe(
+        takeUntil(this.ngDestroy$),
+        concatMap((id) => from(this.removeGeojsonLayer(map, id)))
+      )
+      .subscribe();
+
+    // Tegn alle lagrede geoJSON-objekter ved oppstart
     const allMetadata = await this.geoJSONService.metadata();
     for (const metadata of allMetadata) {
       if (metadata.visibleOnMap) {
@@ -505,18 +522,6 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
         }
       }
     }
-    this.geoJSONService.changedMetadataItem$
-      .pipe(
-        takeUntil(this.ngDestroy$),
-        switchMap((metadata) => from(this.updateGeoJsonLayer(map, metadata)))
-      )
-      .subscribe();
-    this.geoJSONService.removedMetadataItemId$
-      .pipe(
-        takeUntil(this.ngDestroy$),
-        switchMap((id) => from(this.removeGeojsonLayer(map, id)))
-      )
-      .subscribe();
   }
 
   // Oppdaterer et GeoJSON-lag i kartet basert på endrede metadata

--- a/src/app/pages/plans/plans.page.spec.ts
+++ b/src/app/pages/plans/plans.page.spec.ts
@@ -4,9 +4,9 @@ import { GeoJSONItem } from 'src/app/core/services/geojson/geojson-item.model';
 describe('sortByName', () => {
   it('sorts items alphabetically by name', () => {
     const items: GeoJSONItem[] = [
-      { id: '1', name: 'Charlie' },
-      { id: '2', name: 'Alice' },
-      { id: '3', name: 'Bob' },
+      { id: '1', name: 'Charlie', date: 1 },
+      { id: '2', name: 'Alice', date: 1 },
+      { id: '3', name: 'Bob', date: 1 },
     ];
     const sorted = sortByName(items);
     expect(sorted.map((i) => i.name)).toEqual(['Alice', 'Bob', 'Charlie']);
@@ -14,9 +14,9 @@ describe('sortByName', () => {
 
   it('does not mutate the original array', () => {
     const items: GeoJSONItem[] = [
-      { id: '1', name: 'Charlie' },
-      { id: '2', name: 'Alice' },
-      { id: '3', name: 'Bob' },
+      { id: '1', name: 'Charlie', date: 1 },
+      { id: '2', name: 'Alice', date: 1 },
+      { id: '3', name: 'Bob', date: 1 },
     ];
     const itemsCopy = [...items];
     const sorted = sortByName(items);
@@ -46,17 +46,5 @@ describe('sortByDate', () => {
     const sorted = sortByDate(items);
     expect(sorted).not.toBe(items);
     expect(items).toEqual(itemsCopy);
-  });
-
-  it('handles items with missing dates', () => {
-    const items: GeoJSONItem[] = [
-      { id: '1', name: 'A', date: 100 },
-      { id: '2', name: 'B' },
-      { id: '3', name: 'C', date: 200 },
-    ];
-    const sorted = sortByDate(items);
-    expect(sorted[0].date).toBe(200);
-    expect(sorted[1].date).toBe(100);
-    expect(sorted[2].date).toBeUndefined();
   });
 });


### PR DESCRIPTION
Denne erstatter #887.
Nå tegner vi ikke alle spor på nytt igjen hvis vi får en endring på `GeoJSONService.metadata`.
Kun de sporene som er nye eller endret blir tegnet.

Jeg fulgte [@jorgkv sitt tips](https://github.com/NVE/regObs4/pull/887#discussion_r2588304491), og tegner først alle spor ved oppstart, og deretter oppdaterer jeg kun de sporene som endres eller slettes.
Det er selvfølgelig ikke nødvendig å tegne spor på nytt om ikke selve sporet er endret, men valgte å gjøre dette enkelt nå. Dessuten blir det kanskje mulighet for å endre selve sporet seinere.

Jeg ser at vi tegner nye spor to ganger hvis du trykker "lagre" på detalj-sida: Først idet spor-fila leses og lagres og deretter når du trykker "lagre". Ikke optimalt, men vi trenger dette i tilfelle du ønsker å endre metadata etter import av fila. Vi kunne kanskje latt være lagre sporet med gang, og lagt inn en avbryt-mulighet, men tenker at dette ikke er viktig nå.

Laget også en test av GeoJSONService med god hjelp av annenpiloten.
Jeg har gjort dato-feltet for et spor obligatorisk for å få litt enklere kode. Så ingen grunn til at vi ikke skulle ha dette.

Jeg logger en del ved tegning av spor nå, for å se hva som skjer. Vi kan sikkert slette noe av denne logginga når dette virker stabilt.