### PR TITLE
Mer musevennlig visning av navn og beskrivelse

### DIFF
--- a/src/app/modules/map/components/map/map.component.ts
+++ b/src/app/modules/map/components/map/map.component.ts
@@ -271,19 +271,18 @@ export class MapComponent implements OnInit, OnDestroy, AfterViewInit {
       shadowSize: [41, 41],
     });
     const geojsonLayer = L.geoJSON(geojson, {
-      style: { dashArray: '4', color: 'red', stroke: true },
+      style: { dashArray: '4', color: 'red', stroke: true, weight: 3 },
       pointToLayer: (_, latlng) => {
         return L.marker(latlng, { icon: pointIcon });
       },
     });
 
-    let extraTapRadiusLayer: L.Layer | undefined;
-    if (isAndroidOrIos(this.platform)) {
-      // To get a bigger tap hit radius on devices, add the geojson twice with much wider stroke
-      extraTapRadiusLayer = L.geoJSON(geojson, { style: { color: 'rgba(0,0,0,0)', weight: 30, stroke: true } });
-    }
+    // Add an invisible layer with wider stroke for easier interaction
+    const extraTapRadiusLayer = L.geoJSON(geojson, {
+      style: { color: 'rgba(0,0,0,0)', weight: 30, stroke: true },
+    });
 
-    const layer: L.Layer = extraTapRadiusLayer ? L.featureGroup([geojsonLayer, extraTapRadiusLayer]) : geojsonLayer;
+    const layer: L.Layer = L.featureGroup([geojsonLayer, extraTapRadiusLayer]);
 
     // Add layer to map if zoom is sufficient
     if (map.getZoom() >= observerTripsMinZoom) {


### PR DESCRIPTION
Det er vanskelig å "treffe" sporet når man ønsker å få opp navn og beskrivelse på sporet i kartet. Flere testere[ nevner også dette](https://teams.microsoft.com/l/message/19:289eb1b228a24a3bbfa1471ebddb8940@thread.tacv2/1765899006904?tenantId=bc8d840d-60c9-410b-b4fb-11b86806780c&groupId=575584d5-a204-47b6-b667-aa431253b285&parentMessageId=1765899006904&teamName=PROSJ-Regobs&channelName=Testing&createdTime=1765899006904).
Jeg har tatt i bruk det ekstra tappe-laget også for web, slik at det blir lettere å treffe sporet for å kunne få opp navn og beskrivelse i kartet.