### PR TITLE
Fiks for valg av sporfiler på Android

### DIFF
--- a/src/app/pages/plans/plan/plan.page.html
+++ b/src/app/pages/plans/plan/plan.page.html
@@ -35,7 +35,7 @@
           [label]="'PLANS.COMMENT' | translate"
         ></nve-textarea>
         <div class="button-group">
-          <nve-button variant="primary" type="submit" (click)="onSave()">Lagre</nve-button>
+          <nve-button variant="primary" type="submit" (click)="onSave()">{{ "PLANS.SAVE" | translate }}</nve-button>
           <nve-button variant="danger" type="button" (click)="onRemove()">
             <nve-icon slot="prefix" src="assets/icon/delete_white.svg"></nve-icon>
             {{ "PLANS.DELETE" | translate }}

--- a/src/app/pages/plans/plans.page.html
+++ b/src/app/pages/plans/plans.page.html
@@ -53,7 +53,7 @@
     </nve-menu>
 
     <div class="drop-zone-wrapper">
-      <ngx-file-drop dropZoneClassName="drop-zone" [accept]="'.gpx, .geojson, .json'" (onFileDrop)="onFileDrop($event)">
+      <ngx-file-drop dropZoneClassName="drop-zone" [accept]="acceptFileTypes" (onFileDrop)="onFileDrop($event)">
         <ng-template ngx-file-drop-content-tmp let-openFileSelector="openFileSelector">
           <button type="button" (click)="openFileSelector()">
             <h1>{{ "PLANS.IMPORT_BUTTON.CAPTION" | translate }}</h1>

--- a/src/app/pages/plans/plans.page.ts
+++ b/src/app/pages/plans/plans.page.ts
@@ -48,7 +48,7 @@ export class PlansPage {
   private toastController = inject(ToastController);
   private translateService = inject(TranslateService);
 
-  private allowedFileExtensions = ['gpx', 'geojson', 'json'];
+  private allowedFileExtensions = ['.gpx', '.geojson', '.json'];
 
   // Ikke alle Android-telefoner håndterer spesifikke filtyper, så vi tillater alle på mobile plattformer
   acceptFileTypes = Capacitor.isNativePlatform() ? '*' : this.allowedFileExtensions.join(',');
@@ -92,7 +92,7 @@ export class PlansPage {
   }
 
   private validateFileExtension(filename: string): boolean {
-    const extMatch = filename.toLowerCase().match(/\.([a-z0-9]+)$/);
+    const extMatch = filename.toLowerCase().match(/(\.[a-z0-9]+)$/);
     const ext = extMatch ? extMatch[1] : '';
     return this.allowedFileExtensions.includes(ext);
   }

--- a/src/app/pages/plans/plans.page.ts
+++ b/src/app/pages/plans/plans.page.ts
@@ -1,7 +1,8 @@
 import { Platform } from '@ionic/angular';
+import { ToastController } from '@ionic/angular';
 import { ChangeDetectionStrategy, Component, computed, CUSTOM_ELEMENTS_SCHEMA, inject, signal } from '@angular/core';
 import { IonButtons, IonMenuButton, IonRouterLinkWithHref, IonTitle, IonContent } from '@ionic/angular/standalone';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { HeaderComponent } from 'src/app/modules/shared/components/header/header.component';
 import 'nve-designsystem/components/nve-button/nve-button.component.js';
 import 'nve-designsystem/components/nve-menu/nve-menu.component.js';
@@ -18,6 +19,7 @@ import { GeoJSONItem } from 'src/app/core/services/geojson/geojson-item.model';
 import { generateShortRandomId } from './utils';
 import { DatePipe } from '@angular/common';
 import { Router, RouterLink } from '@angular/router';
+import { Capacitor } from '@capacitor/core';
 
 @Component({
   selector: 'app-plans',
@@ -43,6 +45,13 @@ export class PlansPage {
   private platform = inject(Platform);
   private router = inject(Router);
   private geoJSON = inject(GeoJSONService);
+  private toastController = inject(ToastController);
+  private translateService = inject(TranslateService);
+
+  private allowedFileExtensions = ['gpx', 'geojson', 'json'];
+
+  // Ikke alle Android-telefoner håndterer spesifikke filtyper, så vi tillater alle på mobile plattformer
+  acceptFileTypes = Capacitor.isNativePlatform() ? '*' : this.allowedFileExtensions.join(',');
 
   isMobile = this.platform.is('mobile') || this.platform.is('android') || this.platform.is('ios');
 
@@ -61,16 +70,49 @@ export class PlansPage {
    * Importerer og lagrer sporfiler som GeoJSON-objekter i lokal database
    */
   async onFileDrop(files: NgxFileDropEntry[]) {
+    const ignoredFiles: string[] = [];
+
     for (const { fileEntry, relativePath } of files) {
-      const geojson = await toGeoJSON(fileEntry);
-      const id = generateShortRandomId();
-      const metadata: GeoJSONItem = { id, name: relativePath, date: Date.now(), visibleOnMap: true };
-      await this.geoJSON.save(metadata, geojson);
-      // Åpne detaljsiden kun når en fil er lastet opp.
-      if (files.length === 1) {
-        this.router.navigate(['/plans', id]);
+      if (fileEntry.isFile && this.validateFileExtension(relativePath)) {
+        const geojson = await toGeoJSON(fileEntry);
+        const id = generateShortRandomId();
+        const metadata: GeoJSONItem = { id, name: relativePath, date: Date.now(), visibleOnMap: true };
+        await this.geoJSON.save(metadata, geojson);
+        // Åpne detaljsiden kun når en fil er lastet opp.
+        if (files.length === 1) {
+          this.router.navigate(['/plans', id]);
+        }
+      } else {
+        ignoredFiles.push(relativePath);
       }
     }
+    if (ignoredFiles.length > 0) {
+      this.showFileTypeError(ignoredFiles);
+    }
+  }
+
+  private validateFileExtension(filename: string): boolean {
+    const extMatch = filename.toLowerCase().match(/\.([a-z0-9]+)$/);
+    const ext = extMatch ? extMatch[1] : '';
+    return this.allowedFileExtensions.includes(ext);
+  }
+
+  /**
+   * Viser feilmelding til brukeren når filtype ikke er tillatt
+   */
+  private async showFileTypeError(filenames: string[]): Promise<void> {
+    const message = this.translateService.instant('PLANS.WRONG_FILE_TYPE', {
+      filenames: filenames.join(', '),
+      allowedFileExtensions: this.allowedFileExtensions.join(', '),
+    });
+    const toast = await this.toastController.create({
+      message,
+      duration: 5000,
+      color: 'danger',
+      position: 'bottom',
+      mode: 'md',
+    });
+    toast.present();
   }
 
   /**

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -362,6 +362,7 @@
     "MISSING_COMMENT": "Description/comment missing",
     "MISSING_NAME": "Track without name",
     "NAME": "Name",
+    "SAVE": "Save",
     "SORT_TITLE": " Sort by",
     "SORT_BY_NAME": "Name",
     "SORT_BY_TIME": "Last saved",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -371,7 +371,8 @@
     "SHOW_ALL": "All",
     "FILE_NAME": "File name",
     "COMMENT": "Comment",
-    "VISIBLE_ON_MAP": "Visible on map"
+    "VISIBLE_ON_MAP": "Visible on map",
+    "WRONG_FILE_TYPE": "The file(s) '{{filenames}}' have an incorrect type and were rejected. Allowed file types: {{allowedFileExtensions}}"
   },
   "POPUP_DISCLAMER": {
     "ABOUT_OBSERVATIONS": {

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -370,7 +370,8 @@
     "SHOW_ALL": "Alle",
     "FILE_NAME": "Filnavn",
     "COMMENT": "Kommentar",
-    "VISIBLE_ON_MAP": "Vises i kart"
+    "VISIBLE_ON_MAP": "Vises i kart",
+    "WRONG_FILE_TYPE": "Filen(e) '{{filenames}}' har feil type og ble avvist. Tillatte filtyper: {{allowedFileExtensions}}"
   },
   "POPUP_DISCLAMER": {
     "ABOUT_OBSERVATIONS": {

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -365,6 +365,7 @@
     "SORT_BY_NAME": "Navn",
     "SORT_BY_TIME": "Sist lagret",
     "DATE_EDITED": "Sist lagret",
+    "SAVE": "Lagre",
     "SHOW": "Vis",
     "SHOW_ONLY_VISIBLE_ON_MAP": "Kun synlige i kart",
     "SHOW_ALL": "Alle",


### PR DESCRIPTION
Min telefon aksepterte ikke en liste av filtyper i accept-attributtet til ngx-file-drop.
Da fikk jeg ikke valgt noen filer.
Så løsningen ble å akseptere alle filtyper, men validere filnavn på de filene som brukeren velger.
Siden jeg ikke vet om det er samme problemet på iOS, har jeg valgt samme løsning der. På web funker det å spesifisere filtyper i accept, virker det som.