### PR TITLE
Ekskludere generert kode fra testdekning

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -138,6 +138,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.spec.json",
             "karmaConfig": "src/karma.conf.js",
+            "codeCoverageExclude": ["src/app/modules/common-regobs-api/**"],
             "scripts": [],
             "assets": [
               {

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -54,6 +54,7 @@ module.exports = function (config) {
         require('karma-jasmine'),
         require('karma-chrome-launcher'),
         require('karma-jasmine-html-reporter'),
+        require('karma-coverage'),
         require('@angular-devkit/build-angular/plugins/karma'),
       ],
       client: {
@@ -64,6 +65,11 @@ module.exports = function (config) {
       },
       jasmineHtmlReporter: {
         suppressAll: true, // removes the duplicated traces
+      },
+      coverageReporter: {
+        dir: '../coverage',
+        subdir: '.',
+        reporters: [{ type: 'html' }],
       },
       reporters: ['progress', 'kjhtml'],
       colors: true,

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -30,6 +30,7 @@ module.exports = function (config) {
         reporters: [{ type: 'html' }, { type: 'lcovonly' }, { type: 'cobertura' }],
         includeAllSources: true,
         fixWebpackSourcePaths: true,
+        exclude: ['**/app/modules/common-regobs-api/**'],
         // check: {
         //   global: {
         //     statements: 50,


### PR DESCRIPTION
Jeg har endret litt på konfigurasjonen slik at generert kode fra API blir tatt med når vi lager rapporter over testdekning.

Her er testdekning for denne PR'en:
https://dev.azure.com/NVE-devops/Varsom%20Regobs/_build/results?buildId=78986&view=codecoverage-tab

Her er forrige commit hvor generert kode er med:
https://dev.azure.com/NVE-devops/Varsom%20Regobs/_build/results?buildId=78307&view=codecoverage-tab