### PR TITLE
Vis alltid enten registrert eller endret tid

### DIFF
--- a/src/app/components/observation/observation/observation.component.html
+++ b/src/app/components/observation/observation/observation.component.html
@@ -50,16 +50,22 @@
       </ion-label>
     </ion-chip>
 
-    @if (savedTime() != registration().DtRegTime) {
-      <ion-chip color="primary" disabled>
-        <ion-icon name="create-outline"></ion-icon>
+    <ion-chip color="primary" disabled>
+      <ion-icon name="create-outline"></ion-icon>
+      @if (showChangedTime()) {
         <ion-label
           ><b> {{ "REGISTRATION.CARD.TIME.UPDATED" | translate }}</b
           >:</ion-label
         >
-        <ion-label> {{ savedTime() | date: "short" }}</ion-label>
-      </ion-chip>
-    }
+        <ion-label> {{ registration().DtChangeTime | date: "short" }}</ion-label>
+      } @else {
+        <ion-label
+          ><b> {{ "REGISTRATION.CARD.TIME.REGISTERED" | translate }}</b
+          >:</ion-label
+        >
+        <ion-label> {{ registration().DtRegTime | date: "short" }}</ion-label>
+      }
+    </ion-chip>
 
     <app-geohazard-chip [registration]="registration()"></app-geohazard-chip>
 

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -15,6 +15,7 @@ import { addIcons } from 'ionicons';
 import {
   calendarNumberOutline,
   chatbubbleEllipses,
+  createOutline,
   locationOutline,
   peopleCircleOutline,
   personCircleOutline,
@@ -81,11 +82,11 @@ export class ObservationComponent implements AfterViewInit, OnDestroy {
 
   readonly registration = input.required<RegistrationViewModel>();
   showChangedTime = computed(() => {
-    const changed = this.registration().DtChangeTime;
-    if (changed == null) {
+    const { DtChangeTime, DtRegTime } = this.registration();
+    if (DtChangeTime == null) {
       return false;
     }
-    if (changed === this.registration().DtRegTime) {
+    if (DtChangeTime === DtRegTime) {
       return false;
     }
     return true;
@@ -99,6 +100,7 @@ export class ObservationComponent implements AfterViewInit, OnDestroy {
       personCircleOutline,
       peopleCircleOutline,
       chatbubbleEllipses,
+      createOutline,
     });
   }
 

--- a/src/app/components/observation/observation/observation.component.ts
+++ b/src/app/components/observation/observation/observation.component.ts
@@ -80,7 +80,16 @@ export class ObservationComponent implements AfterViewInit, OnDestroy {
   modalController = inject(ModalController);
 
   readonly registration = input.required<RegistrationViewModel>();
-  savedTime = computed(() => this.registration().DtChangeTime || this.registration().DtRegTime);
+  showChangedTime = computed(() => {
+    const changed = this.registration().DtChangeTime;
+    if (changed == null) {
+      return false;
+    }
+    if (changed === this.registration().DtRegTime) {
+      return false;
+    }
+    return true;
+  });
   attachments = computed(() => getAllAttachmentsFromViewModel(this.registration()));
 
   constructor() {


### PR DESCRIPTION
Fikser en liten feil i listevisninga: At kun endret tid dukker opp, og først etter at en registrering har blitt endret minst én gang. Det vil si at registrert tidspunkt aldri dukker opp om ikke en obs er endra.