### PR TITLE
Fjern @ionic/cli som avhengighet

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Kjør appen fra XCode.
 
 [Mer info om ionic utvikling for ios.](https://ionicframework.com/docs/developing/ios)
 
-## Create iOS / android release
+## Opprette iOS / android release
 
 Pipelinen `pipelines/regobs-ci.yml` håndterer bygging og pushing av appen til [App Store Connect](https://appstoreconnect.apple.com/) for iOS og
 [Google Play Console](https://play.google.com/console) for android.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Kjør appen fra XCode.
 
 ## Opprette iOS / android release
 
-Pipelinen `pipelines/regobs-ci.yml` håndterer bygging og pushing av appen til [App Store Connect](https://appstoreconnect.apple.com/) for iOS og
+Pipelinen `pipelines/regobs-mobile-app-build-release.yml` håndterer bygging og pushing av appen til [App Store Connect](https://appstoreconnect.apple.com/) for iOS og
 [Google Play Console](https://play.google.com/console) for android.
 For at pipelinen skal trigges må det pushes en ny release-branch med navn `release/vx.x.x`.
 For eksempel `release/v4.0.0`.

--- a/README.md
+++ b/README.md
@@ -111,61 +111,29 @@ Kjør appen fra XCode.
 
 [Mer info om ionic utvikling for ios.](https://ionicframework.com/docs/developing/ios)
 
-## Build and release
+## Create iOS / android release
 
-### 1. Use npm to make a release build:
-
-```bash
-npm run build --production --device
-```
-
-TIP! if you run into "ERROR maximum call stack size exceeded" it's most probably a circular module dependency.
-If you build without aot, you might get a better error message:
-
-```bash
-ng build --aot=false
-```
-
-### 2. Create release branch
-
-1. For a release to trigger, the branch has to follow the naming convention `release/vx.x.x`. For
-   example `release/v4.0.0`.
-   Switch 4.0.0 with the version number you want to release.
+Pipelinen `pipelines/regobs-ci.yml` håndterer bygging og pushing av appen til [App Store Connect](https://appstoreconnect.apple.com/) for iOS og
+[Google Play Console](https://play.google.com/console) for android.
+For at pipelinen skal trigges må det pushes en ny release-branch med navn `release/vx.x.x`.
+For eksempel `release/v4.0.0`.
 
 ```bash
 git switch develop
 git pull
 git switch -c release/v4.0.0
-```
-
-2. Commit changed files and push relase-branch.
-
-```bash
-git add .
-git commit -m "Release v4.0.0"
 git push release/v4.0.0
 ```
 
-The build will be published to internal testers in Testflight and Google Play automatically.
+Nytt bygg vil publiseres til interne testere via Testflight-appen på iOS og via Google Play automatisk.
 
-You need to add release notes / what to test manually in Appstore connect and Google Play console after the build is
-published.
+**Du må selv legge til release-notes og beskrive hva som skal testes manuelt i App Store Connect / Google Play Console
+etter at ny versjon har blitt opprettet.**
 
-### 3. Update version number
-
-After the release is published, you need to update the version number in `package.json` and `package-lock.json` to the
-next version, and merge the release branch to develop.
-
-```bash
-git switch develop
-git pull
-git merge release/v4.0.0
-git switch -c task/update-version-to-4.0.1
-npm run create-version-file
-git add .
-git commit -m "Update version to 4.0.1"
-git push
-```
+Etter den nye versjonen har blitt rullet ut til produksjon, eller ved behov, må versjonsnummer i develop
+jekkes opp. Du må selv oppdatere versjonsnummer i `package.json`
+og kjøre npm install for å oppdatere versjonsnr i `package-lock.json`.
+Disse endringene pushes deretter til develop (via PR).
 
 ## Fornye sertifikater og provisioning profiles
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ brew link --overwrite cocoapods
 #### Ved vanlig kjøring / debugging
 
 ```
-npm run build   # eller ionic build, eventuelt npm run build:prod for å teste prod-bygg
+npm run build   # eventuelt npm run build:prod for å teste prod-bygg
 npx cap sync ios
 npx cap open ios  # For å åpne prosjektet i xcode
 ```
@@ -302,6 +302,9 @@ NB! Cordova plugins må oppdateres ved å først slette dem og legge dem til på
 ionic cordova plugin rm cordova-plugin-name
 ionic cordova plugin add cordova-plugin-name
 ```
+
+> NB: Vi fjerna @ionic/cli som avhengighet i prosjektet siden det brukes så sjeldent, så du må installere @ionic/cli
+> globalt på din maskin for å kjøre disse kommandoene
 
 ## 4. Oppgrader Angular, hvis det trengs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
         "@angular/language-service": "^20.3.15",
         "@capacitor/cli": "^7.4.0",
         "@ionic/angular-toolkit": "^11.0.1",
-        "@ionic/cli": "^7.2.1",
         "@lokalise/node-api": "^8.5.1",
         "@sentry/cli": "^2.58.4",
         "@sentry/wizard": "^1.2.11",
@@ -5339,70 +5338,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/@ionic/cli": {
-      "version": "7.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/cli-framework": "6.0.1",
-        "@ionic/cli-framework-output": "2.2.8",
-        "@ionic/cli-framework-prompts": "2.1.13",
-        "@ionic/utils-array": "2.1.6",
-        "@ionic/utils-fs": "3.1.7",
-        "@ionic/utils-network": "2.1.7",
-        "@ionic/utils-process": "2.1.12",
-        "@ionic/utils-stream": "3.1.7",
-        "@ionic/utils-subprocess": "3.0.1",
-        "@ionic/utils-terminal": "2.3.5",
-        "chalk": "^4.0.0",
-        "debug": "^4.0.0",
-        "diff": "^4.0.1",
-        "elementtree": "^0.1.7",
-        "leek": "0.0.24",
-        "lodash": "^4.17.5",
-        "open": "^7.0.4",
-        "os-name": "^4.0.0",
-        "proxy-agent": "^6.3.0",
-        "semver": "^7.1.1",
-        "split2": "^3.0.0",
-        "ssh-config": "^1.1.1",
-        "stream-combiner2": "^1.1.1",
-        "superagent": "^9.0.2",
-        "tar": "^6.0.1",
-        "tslib": "^2.0.1"
-      },
-      "bin": {
-        "ionic": "bin/ionic"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/cli-framework": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/cli-framework-output": "2.2.8",
-        "@ionic/utils-array": "2.1.6",
-        "@ionic/utils-fs": "3.1.7",
-        "@ionic/utils-object": "2.1.6",
-        "@ionic/utils-process": "2.1.12",
-        "@ionic/utils-stream": "3.1.7",
-        "@ionic/utils-subprocess": "3.0.1",
-        "@ionic/utils-terminal": "2.3.5",
-        "chalk": "^4.0.0",
-        "debug": "^4.0.0",
-        "lodash": "^4.17.5",
-        "minimist": "^1.2.0",
-        "rimraf": "^3.0.0",
-        "tslib": "^2.0.1",
-        "write-file-atomic": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@ionic/cli-framework-output": {
       "version": "2.2.8",
       "dev": true,
@@ -5414,319 +5349,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/cli-framework-prompts": {
-      "version": "2.1.13",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ionic/utils-terminal": "2.3.5",
-        "debug": "^4.0.0",
-        "inquirer": "^7.0.0",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/inquirer": {
-      "version": "7.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/rxjs": {
-      "version": "6.6.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@ionic/cli-framework-prompts/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@ionic/cli-framework/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/rimraf": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@ionic/cli-framework/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ionic/cli/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@ionic/cli/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@ionic/cli/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@ionic/cli/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@ionic/cli/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@ionic/cli/node_modules/open": {
-      "version": "7.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ionic/cli/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@ionic/core": {
@@ -5787,18 +5409,6 @@
         "@types/fs-extra": "^8.0.0",
         "debug": "^4.0.0",
         "fs-extra": "^9.0.0",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@ionic/utils-network": {
-      "version": "2.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.0.0",
         "tslib": "^2.0.1"
       },
       "engines": {
@@ -6942,17 +6552,6 @@
         "@angular/core": ">=16"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -7268,14 +6867,6 @@
         "follow-redirects": "^1.13.3",
         "form-data": "^4.0.0",
         "opener": "^1.5.2"
-      }
-    },
-    "node_modules/@paralleldrive/cuid2": {
-      "version": "2.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -8839,13 +8430,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -15594,20 +15178,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -15697,30 +15267,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ast-module-types": {
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/astral-regex": {
@@ -15894,16 +15446,6 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/batch": {
@@ -16617,14 +16159,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/cli-width": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/clipboard": {
       "version": "2.0.11",
       "license": "MIT",
@@ -16739,14 +16273,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -16967,11 +16493,6 @@
       "engines": {
         "node": ">=6.6.0"
       }
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.4",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/copy-anything": {
       "version": "2.0.6",
@@ -17934,16 +17455,6 @@
         "lodash-es": "^4.17.21"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "dev": true,
@@ -18097,21 +17608,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/delaunator": {
@@ -18402,15 +17898,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/dezalgo": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/di": {
       "version": "0.0.1",
       "dev": true,
@@ -18551,14 +18038,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/earcut": {
@@ -19681,11 +19160,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-uri": {
       "version": "3.0.3",
       "dev": true,
@@ -19718,20 +19192,6 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -20019,22 +19479,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/formidable": {
-      "version": "3.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@paralleldrive/cuid2": "^2.2.2",
-        "dezalgo": "^1.0.4",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -20264,21 +19708,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -21304,17 +20733,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "dev": true,
@@ -22131,29 +21549,6 @@
         "leaflet": "^1.0.3"
       }
     },
-    "node_modules/leek": {
-      "version": "0.0.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.0",
-        "lodash.assign": "^3.2.0",
-        "rsvp": "^3.0.21"
-      }
-    },
-    "node_modules/leek/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/leek/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/less": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/less/-/less-4.4.0.tgz",
@@ -22511,55 +21906,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/lodash._baseassign": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "node_modules/lodash._basecopy": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash._bindcallback": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash._createassigner": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._bindcallback": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash.restparam": "^3.0.0"
-      }
-    },
-    "node_modules/lodash._getnative": {
-      "version": "3.9.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash._isiterateecall": {
-      "version": "3.0.9",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.assign": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._createassigner": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT",
@@ -22572,33 +21918,8 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarray": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.keys": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.restparam": {
-      "version": "3.6.1",
       "dev": true,
       "license": "MIT"
     },
@@ -22945,17 +22266,6 @@
     "node_modules/lru-fast": {
       "version": "0.2.2",
       "license": "MIT"
-    },
-    "node_modules/macos-release": {
-      "version": "2.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/madge": {
       "version": "5.0.2",
@@ -23830,11 +23140,6 @@
         "npm": ">=1.4.0"
       }
     },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -23948,16 +23253,6 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/ng-swagger-gen": {
       "version": "2.3.1",
@@ -24422,17 +23717,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -24694,21 +23978,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/os-name": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "macos-release": "^2.5.0",
-        "windows-release": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "dev": true,
@@ -24796,64 +24065,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -25692,58 +24903,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "dev": true,
@@ -26462,14 +25621,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/rsvp": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "0.12.* || 4.* || 6.* || >= 7.*"
       }
     },
     "node_modules/run-applescript": {
@@ -27384,27 +26535,6 @@
       "version": "3.1.2",
       "license": "MIT"
     },
-    "node_modules/split2": {
-      "version": "3.2.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
-    "node_modules/split2/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "dev": true,
@@ -27412,11 +26542,6 @@
     },
     "node_modules/sql.js": {
       "version": "1.10.3",
-      "license": "MIT"
-    },
-    "node_modules/ssh-config": {
-      "version": "1.1.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ssri": {
@@ -27469,15 +26594,6 @@
       "license": "Unlicense",
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/stream-combiner2": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/streamroller": {
@@ -27600,14 +26716,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "dev": true,
@@ -27645,25 +26753,6 @@
       "version": "2.20.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/superagent": {
-      "version": "9.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
-        "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^3.5.1",
-        "methods": "^1.1.2",
-        "mime": "2.6.0",
-        "qs": "^6.11.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -28199,17 +27288,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.21.3",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -29303,50 +28381,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/windows-release": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/execa": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/windows-release/node_modules/human-signals": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "0.0.2",
       "license": "MIT/X11",
@@ -29451,17 +28485,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
     },
     "node_modules/ws": {
       "version": "8.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "regobs4",
-  "version": "5.0.14",
+  "version": "5.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "regobs4",
-      "version": "5.0.14",
+      "version": "5.0.15",
       "license": "NLOD-2.0",
       "dependencies": {
         "@angular/animations": "^20.3.15",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "ng": "ng",
     "generate-swagger-api-module": "ng-swagger-gen -c ng-swagger-gen.json",
-    "start": "ionic serve",
-    "build": "ionic build",
+    "start": "ng run app:serve --host=localhost --port=8100",
+    "build": "ng build",
     "build:prod": "ng build --configuration production",
     "cap:sync": "jetify && cap sync",
     "test": "ng test --watch false --reporters progress",
@@ -125,7 +125,6 @@
     "@angular/language-service": "^20.3.15",
     "@capacitor/cli": "^7.4.0",
     "@ionic/angular-toolkit": "^11.0.1",
-    "@ionic/cli": "^7.2.1",
     "@lokalise/node-api": "^8.5.1",
     "@sentry/cli": "^2.58.4",
     "@sentry/wizard": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regobs4",
-  "version": "5.0.14",
+  "version": "5.0.15",
   "author": "NVE",
   "license": "NLOD-2.0",
   "homepage": "http://www.nve.no",


### PR DESCRIPTION
Tror vi kan bruke @angular/cli-kommendoer direkte, og utvikler kan evt installere @ionic/cli globalt om det er spesifikke ting vi trenger å gjøre med ionic-cli.