### PR TITLE
RO-3157: Vis alltid ledetekst for knappen "Vis observasjoner"

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -1,14 +1,12 @@
 <ion-split-pane contentId="main-content-home-page">
   <ion-menu side="start" menuId="filter" contentId="main-content-home-page" max-edge-start="0">
-    @defer {
-      <app-filter-menu>
-        <ion-item lines="full" color="light" button detail="false">
-          <ion-toggle [checked]="showObservations$ | async" (ionChange)="saveShowObservation($event)">
-            {{ "MENU.SHOW_OBSERVATIONS" | translate }}
-          </ion-toggle>
-        </ion-item>
-      </app-filter-menu>
-    }
+    <app-filter-menu>
+      <ion-item lines="full" color="light" button detail="false">
+        <ion-toggle [checked]="showObservations$ | async" (ionChange)="saveShowObservation($event)">
+          {{ "MENU.SHOW_OBSERVATIONS" | translate }}
+        </ion-toggle>
+      </ion-item>
+    </app-filter-menu>
   </ion-menu>
 
   <div id="main-content-home-page" class="ion-page">


### PR DESCRIPTION
Det var @defer som var synderen virket det som.
Tenker at det kanskje ikke er så viktig å ha @defer her siden den uansett ikke laster noe særlig før man skrur på observasjoner.
Men det var ikke jeg som la inn @defer, så jeg har kanskje ikke forstått hensikten.

Testes vha. stegene i saken: https://nveprojects.atlassian.net/browse/RO-3157
