### PR TITLE
RO-3002: Vis antall skred under skredaktivitet

### DIFF
--- a/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.html
+++ b/src/app/components/observation/registrations/avalanche-activity-view/avalanche-activity-view.component.html
@@ -25,7 +25,7 @@
     [value]="formatTime().toLowerCase()"
   />
 }
-@if (!noActivity && estimatedNum()) {
+@if (!noActivity() && estimatedNum()) {
   <app-key-value
     [key]="'REGISTRATION.SNOW.AVALANCHE_ACTIVITY.HOW_MANY_AVALANCHES' | translate"
     [value]="estimatedNum()"


### PR DESCRIPTION
Aron hadde helt rett, det manglet en parentes.
Nå skal feltet for antall skred vises.
Se f.eks. https://test.regobs.no/Registration/273382
Denne har to skredaktivitet-registreringer, bare for å sjekke at ting blir vist riktig også om man velger "Ingen skredaktivitet". Da skal feltet "antall skred" skjules:
<img width="197" height="260" alt="image" src="https://github.com/user-attachments/assets/e99ed7f4-6dc8-4942-a47b-b72d70f02f39" />
