### PR TITLE
RO-3171: Fiks race-condition feil

### DIFF
--- a/src/app/app.providers.ts
+++ b/src/app/app.providers.ts
@@ -42,6 +42,7 @@ import { Observable } from 'rxjs';
 import { AppMode } from './modules/common-core/models';
 import { provideWarningService } from './core/services/warning/provide-warning-service';
 import { ObserverTripsService } from './core/services/observer-trips/observer-trips.service';
+import { GeoJSONService } from './core/services/geojson/geojson.service';
 
 export class DynamicLocaleId extends String {
   constructor(protected service: TranslateService) {
@@ -109,6 +110,11 @@ export const APP_PROVIDERS: (Provider | EnvironmentProviders)[] = [
       return new TranslateHttpLoader(http, '../assets/i18n/', '.json?v5cache-bust');
     },
   },
+
+  provideAppInitializer(() => {
+    const geojson = inject(GeoJSONService);
+    return geojson.init();
+  }),
 
   // Initialiser ngx-translate og usersettings etter hverandre
   provideAppInitializer(() => {

--- a/src/app/core/services/geojson/geojson.service.spec.ts
+++ b/src/app/core/services/geojson/geojson.service.spec.ts
@@ -59,21 +59,23 @@ describe('GeoJSONService', () => {
   });
 
   describe('init', () => {
-    it('should load metadata from database on initialization', fakeAsync(() => {
+    it('should load metadata from database on initialization', fakeAsync(async () => {
       const existingMetadata: GeoJSONItem[] = [mockMetadataItem];
       databaseService.get.and.returnValue(Promise.resolve(existingMetadata));
 
       service = TestBed.inject(GeoJSONService);
+      await service.init();
       tick();
 
       expect(databaseService.get).toHaveBeenCalledWith('geojson-metadata');
       expect(service.metadata()).toEqual(existingMetadata);
     }));
 
-    it('should initialize with empty metadata if none exists', fakeAsync(() => {
+    it('should initialize with empty metadata if none exists', fakeAsync(async () => {
       databaseService.get.and.returnValue(Promise.resolve(null));
 
       service = TestBed.inject(GeoJSONService);
+      await service.init();
       tick();
 
       expect(service.metadata()).toEqual([]);
@@ -81,8 +83,9 @@ describe('GeoJSONService', () => {
   });
 
   describe('save', () => {
-    beforeEach(fakeAsync(() => {
+    beforeEach(fakeAsync(async () => {
       service = TestBed.inject(GeoJSONService);
+      await service.init();
       tick(); // Complete initialization
       tick(); // Allow effect to run
       databaseService.set.calls.reset();
@@ -126,8 +129,9 @@ describe('GeoJSONService', () => {
   });
 
   describe('get', () => {
-    beforeEach(fakeAsync(() => {
+    beforeEach(fakeAsync(async () => {
       service = TestBed.inject(GeoJSONService);
+      await service.init();
       tick();
     }));
 
@@ -144,8 +148,9 @@ describe('GeoJSONService', () => {
   });
 
   describe('remove', () => {
-    beforeEach(fakeAsync(() => {
+    beforeEach(fakeAsync(async () => {
       service = TestBed.inject(GeoJSONService);
+      await service.init();
       tick();
       // Add an item first
       service.save(mockMetadataItem, mockGeoJSON);
@@ -181,8 +186,9 @@ describe('GeoJSONService', () => {
   });
 
   describe('changedMetadataItem$', () => {
-    beforeEach(fakeAsync(() => {
+    beforeEach(fakeAsync(async () => {
       service = TestBed.inject(GeoJSONService);
+      await service.init();
       tick();
     }));
 

--- a/src/app/core/services/geojson/geojson.service.ts
+++ b/src/app/core/services/geojson/geojson.service.ts
@@ -29,8 +29,6 @@ export class GeoJSONService {
   removedMetadataItemId$ = this.removedMetadataItemId.asObservable();
 
   constructor() {
-    this.init();
-
     effect(() => {
       const metadata = this.metadata();
       if (!this.initialized) return;
@@ -38,13 +36,23 @@ export class GeoJSONService {
     });
   }
 
-  private async init() {
-    this.logger.debug('Init', DEBUG_TAG);
-    const items = await this.getMetadata();
-    if (items && items.length > 0) {
-      this.metadata_.set(items);
+  async init() {
+    if (this.initialized) {
+      return;
     }
-    setTimeout(() => (this.initialized = true)); // For å unngå en første unødvendig lagring i effecten
+
+    this.logger.debug('Init', DEBUG_TAG);
+
+    // Try/catch her sikrer at appen starter selv om init feiler
+    try {
+      const items = await this.getMetadata();
+      if (items && items.length > 0) {
+        this.metadata_.set(items);
+      }
+      setTimeout(() => (this.initialized = true)); // For å unngå en første unødvendig lagring i effecten
+    } catch (error) {
+      this.logger.error(error, DEBUG_TAG, 'Init error');
+    }
   }
 
   private async saveMetadata(items: GeoJSONItem[]) {


### PR DESCRIPTION
Jeg tror feilen skyldtes at map.component hentet turer via metadata-egenskapen på GeoJSONService under oppstarten, uten at det ble sjekket om servicen var ferdig med initialisering / lesing fra databasen. I de tilfellene hvor MapComponent leste metadata før GeoJSON var klar, vil i alle fall toggling av og på være eneste fix, og stenge/starte appen igjen ikke nødvendigvis hjelpe, så det stemmer bra med det @gruble opplevde.

Denne fiksen sørger for at appen venter med oppstarten til GeoJSONService.init er ferdig.
Merk at jeg ikke har fått feilen selv, så jeg er ikke sikker på om feilen løses av dette.