### PR TITLE
Forhindre flimrende loading-spinner i appen

### DIFF
--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -180,7 +180,10 @@ export class HomePage extends RouterPage implements OnInit, AfterViewChecked, On
     });
 
     this.userSettingService.appMode$.subscribe(() => (this.shouldSearchResultUpdateOnEnter = true));
-    this.isFetchingObservations$ = this.isFetchingObservations.asObservable();
+    // I appen laster observasjoner ekstremt raskt om offlinedatabasen er aktiv,
+    // debounce hindrer loading-spinneren i bare "flimre" på skjermen når lastinga
+    // er veldig rask.
+    this.isFetchingObservations$ = this.isFetchingObservations.asObservable().pipe(debounceTime(100));
     this.showObservations$ = this.userSettingService.showObservations$;
 
     this.refreshRequested$ = this.updateObservationsService.refreshRequested$.pipe(


### PR DESCRIPTION
På iOS laster observasjoner ekstremt raskt om offlinedatabasen er aktiv. Det oppleves bare forstyrrende at loading-spinneren flimrer i brøkdelen av et sekund. En debounce bør forhindre at det skjer.

Dette må testes på web og native. Er ikke sikkert det hjelper med 100ms og kanskje det oppleves flimrende uansett.