### PR TITLE
Fiks bildekarusell-høyde på iOS

### DIFF
--- a/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
+++ b/src/app/components/observation/observation-image-carousel/observation-image-carousel.component.scss
@@ -1,3 +1,10 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding-top: env(safe-area-inset-top);
+}
+
 swiper-container {
   flex: 1;
   width: 100%;
@@ -41,7 +48,7 @@ ion-fab-button {
   --background: #fff;
   --color: var(--ion-color-primary);
   position: fixed;
-  top: 1rem;
+  top: calc(1rem + env(safe-area-inset-top));
   right: 1rem;
   z-index: 1000;
   will-change: transform;


### PR DESCRIPTION
Feil funnet under testing av v5.0.15 på iOS: Enkelte ganger legger toppen av karusellen seg bak "safe-area" i toppen av skjermen, der hvor "notchen" ligger, klokke, batteri osv. Denne fiksen prøver å sørge for at det ikke skjer.