### PR TITLE
Små forbedringer på pipelines

### DIFF
--- a/pipelines/regobs-ci.yml
+++ b/pipelines/regobs-ci.yml
@@ -1,4 +1,5 @@
 # Regobs ci script. Kjører tester og publiserer test rapport.
+# Trigges kun for PRer mot develop.
 trigger: none
 pr:
   - develop

--- a/pipelines/regobs-ci.yml
+++ b/pipelines/regobs-ci.yml
@@ -1,4 +1,5 @@
 # Regobs ci script. Kjører tester og publiserer test rapport.
+trigger: none
 pr:
   - develop
 

--- a/pipelines/regobs-web-build-release.yml
+++ b/pipelines/regobs-web-build-release.yml
@@ -1,5 +1,7 @@
 # Regobs web bygg og release pipeline.
 trigger:
+  # batch Hindrer at hver eneste commit skal bygges og rulles ut, om vi feks
+  # tar inn 3 dependabot-PRer raskt.
   batch: true
   branches:
     include:

--- a/pipelines/regobs-web-build-release.yml
+++ b/pipelines/regobs-web-build-release.yml
@@ -1,11 +1,11 @@
 # Regobs web bygg og release pipeline.
 trigger:
-  - develop
-
-pr:
+  batch: true
   branches:
-    exclude:
-      - '*'
+    include:
+      - develop
+
+pr: none
 
 name: $(Date:yyyyMMdd)$(Rev:.r)
 


### PR DESCRIPTION
- Det er ikke nødvendig å kjøre CI-pipeline etter at endringer er tatt inn i develop, de samme stegne kjøres i web-release-pipeline (testing osv)
- Legger til batching av release-web-bygget. Det hindrer at hver eneste commit skal bygges og rulles ut, om det feks tas inn 3 dependabot-PRer nesten samtidig 