### PR TITLE
Fiks RO-3175: Hindre evig loop pga 401-feil

### DIFF
--- a/src/app/core/http-interceptor/ApiInterceptor.ts
+++ b/src/app/core/http-interceptor/ApiInterceptor.ts
@@ -105,24 +105,49 @@ export class ApiInterceptor implements HttpInterceptor {
     );
   }
 
+  private lastRefreshTime: number | undefined;
+
+  private hasRefreshedRecently() {
+    if (!this.lastRefreshTime) {
+      return false;
+    }
+    const timeSinceLastRefresh = Date.now() - this.lastRefreshTime;
+    const recentRefreshTime = 30_000; // 30 sekunder
+    return timeSinceLastRefresh < recentRefreshTime;
+  }
+
   private handleResponseError(
     error: unknown,
     request: HttpRequest<unknown>,
     next: HttpHandler
   ): Observable<HttpEvent<unknown>> {
     if (error instanceof HttpErrorResponse && error.status === 401) {
+      // Dette kallet kan returnere 401 uansett om bruker er logget inn.
+      // Kun observatører har tilgang.
+      if (request.url.includes('/Trip/ObserverTrips')) {
+        throw error;
+      }
+
+      if (this.hasRefreshedRecently()) {
+        this.loggerService.debug('Skipping token refresh, already refreshed recently', DEBUG_TAG, {
+          url: request.url,
+        });
+        throw error;
+      }
+
       // Vi er ikke autorisert, trolig fordi tokenet ikke er gyldig
       this.loggerService.debug('Got 401 from API, trying to refresh token and repeat API-call...', DEBUG_TAG, {
         url: request.url,
         method: request.method,
       });
       return from(this.regobsAuthService.refreshToken()).pipe(
-        tap(() =>
+        tap(() => {
+          this.lastRefreshTime = Date.now();
           this.loggerService.debug('Token refreshed', DEBUG_TAG, {
             url: request.url,
             method: request.method,
-          })
-        ),
+          });
+        }),
         catchError((err) => {
           this.loggerService.debug('Token refresh failed', DEBUG_TAG, { err, url: request.url });
           throw error; // Rethrow original 401 error

--- a/src/app/core/services/observer-trips/observer-trips.service.ts
+++ b/src/app/core/services/observer-trips/observer-trips.service.ts
@@ -71,7 +71,12 @@ export class ObserverTripsService {
   }
 
   private async removeData() {
-    await this.geojson.remove(observerTripsGeoJsonId);
+    // Feilhåndtering for å hindre at subscription i init stopper om sletting skulle feile
+    try {
+      await this.geojson.remove(observerTripsGeoJsonId);
+    } catch (error) {
+      this.logger.error(error, DEBUG_TAG, 'Could not remove observer trips data');
+    }
   }
 
   private async fetchData(): Promise<void> {

--- a/src/app/core/services/observer-trips/observer-trips.service.ts
+++ b/src/app/core/services/observer-trips/observer-trips.service.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { combineLatest, debounceTime, firstValueFrom } from 'rxjs';
+import { debounceTime, distinctUntilKeyChanged, firstValueFrom, skipWhile, switchMap, take } from 'rxjs';
 import { RegobsAuthService } from 'src/app/modules/auth/services/regobs-auth.service';
 import { TripService } from 'src/app/modules/common-regobs-api';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
@@ -33,15 +33,27 @@ export class ObserverTripsService {
 
   init() {
     this.logger.debug('Initialize observer trips service', DEBUG_TAG);
-    combineLatest([this.authService.loggedInUser$, this.network.connected$])
-      .pipe(debounceTime(4000))
-      .subscribe(([user, connected]) => {
-        if (user.isLoggedIn && connected) {
-          this.fetchData();
-        } else if (!user.isLoggedIn) {
-          this.removeData();
-        }
-      });
+    this.authService.loggedInUser$
+      .pipe(
+        distinctUntilKeyChanged('isLoggedIn'),
+        debounceTime(5000),
+        switchMap((user) => {
+          // Bruker er ikke logget inn - slett eventuelle data som finnes
+          if (!user.isLoggedIn) {
+            return this.removeData();
+          }
+
+          // Bruker er logget inn, vent på nettverk og hent obsturer
+          return this.network.connected$.pipe(
+            // Vent på at vi har nettverk
+            skipWhile((connected) => !connected),
+            take(1),
+            // Hent obsturer
+            switchMap(() => this.fetchData())
+          );
+        })
+      )
+      .subscribe();
   }
 
   private async persistData(data: FeatureCollection): Promise<void> {


### PR DESCRIPTION
Feilen var at ApiInterceptor snappet opp 401 på /Trip/ObserverTrips og trigget token refresh uendelig mange ganger. Dette gjorde at appen igjen hentet /Account/MyPage i en evig loop, og at appen ikke skjønte at administrator hadde tilgang til redigering.

Dette fikses i ApiInterceptor på to måter. 
  - For det første droppes token refresh om kallet er for /Trips/ObserverTrips. Det gjøres uansett token refresh under oppstarten, og observatører kan evt logge ut og inn igjen om de har problemer med dette. 
  - For det andre legges det til en variabel `lastRefreshTime` som brukes for å stoppe en evt lignende evig loop i framtiden.

I tillegg endres logikken litt i ObserverTripsService. Nå hentes bare turene når egenskapen `isLoggedIn` endrer seg. En debouce bør sørge for at token refresh under oppstarten fås med.
Eventuelle token refresh senere trigger ikke henting av obsturer på nytt.