### PR TITLE
Vise kompassretning i grader til kartsenter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "cordova-plugin-device": "^2.0.3",
         "cordova-sqlite-storage": "^7.0.0",
         "fast-deep-equal": "^3.1.3",
+        "geomagnetism": "^0.2.0",
         "globalthis": "^1.0.2",
         "ionic-appauth": "^2.0.0",
         "json-stringify-safe": "^5.0.1",
@@ -13048,6 +13049,12 @@
       "dependencies": {
         "quickselect": "^1.0.1"
       }
+    },
+    "node_modules/geomagnetism": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/geomagnetism/-/geomagnetism-0.2.0.tgz",
+      "integrity": "sha512-dO8HJrXqah244nMe+pU5m52L90SMoi4lDA0AV3xunRxogloYV+s3aYWCW72VMMfiYis+YSAlhoKktw8aLMiJbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "cordova-plugin-device": "^2.0.3",
     "cordova-sqlite-storage": "^7.0.0",
     "fast-deep-equal": "^3.1.3",
+    "geomagnetism": "^0.2.0",
     "globalthis": "^1.0.2",
     "ionic-appauth": "^2.0.0",
     "json-stringify-safe": "^5.0.1",

--- a/src/app/core/models/user-settings.model.ts
+++ b/src/app/core/models/user-settings.model.ts
@@ -36,4 +36,7 @@ export interface UserSetting extends InfoPopupSettings {
    * Ikke mas om utdaterte kartpakker før dette tidspunktet er passert
    */
   suppressOfflineMapUpdateNotificationUntil?: string; // i ISO8601-format
+
+  /** true = ta med misvisning ved beregning av kompasskurs */
+  useMagneticBearing: boolean;
 }

--- a/src/app/core/services/upload-attachments/set-metadata.spec.ts
+++ b/src/app/core/services/upload-attachments/set-metadata.spec.ts
@@ -20,6 +20,7 @@ const basicUserSettings: UserSetting = {
   featureToggeGpsDebug: false,
   featureToggleDeveloperMode: false,
   topoMap: TopoMap.default,
+  useMagneticBearing: true,
 };
 
 describe('setCopyright', () => {

--- a/src/app/core/services/user-setting/user-settings.default.ts
+++ b/src/app/core/services/user-setting/user-settings.default.ts
@@ -37,5 +37,6 @@ export const DEFAULT_USER_SETTINGS: (langKey?: LangKey) => UserSetting = (langKe
     featureToggeGpsDebug: false,
     featureToggleDeveloperMode: false,
     preferCompleteSnowObservations: false,
+    useMagneticBearing: true,
   };
 };

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.html
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.html
@@ -8,9 +8,9 @@ NB! Root elements in this view has positon: absolute..
 <!-- Map center info box displayed in bottom left corner -->
 <div #infoBoxElement class="map-center-info ion-text-nowrap" (click)="copyToClipboard()">
   <ion-grid class="ion-no-padding">
-    @if (!loading) {
+    @if (!loading()) {
       <!-- Location name -->
-      @if (location) {
+      @if (location(); as location) {
         <ion-row name="map-center-info-row">
           @if (location.name !== location.adminName) {
             <span>{{ location.name }},&nbsp;</span>
@@ -19,19 +19,19 @@ NB! Root elements in this view has positon: absolute..
         </ion-row>
       }
       <!-- Height (masl) and steepness -->
-      @if (elevation != null || steepness != null) {
+      @if (elevation() != null || steepness() != null) {
         <ion-row name="map-center-info-row">
-          @if (elevation != null) {
-            {{ elevation }} {{ "MAP_CENTER_INFO.ABOVE_SEA_LEVEL" | translate }}
+          @if (elevation() != null) {
+            {{ elevation() }} {{ "MAP_CENTER_INFO.ABOVE_SEA_LEVEL" | translate }}
           }
-          @if (steepness != null) {
-            @if (elevation !== null) {
+          @if (steepness() != null && elevation() !== 0) {
+            @if (elevation() != null) {
               <span>,&nbsp;</span>
             }
             <span class="steepness-triangle">
-              <span class="steepness-value" [ngStyle]="{ transform: 'rotate(' + steepness + 'deg)' }"> </span>
+              <span class="steepness-value" [style.transform]="'rotate(' + steepness() + 'deg)'"> </span>
             </span>
-            {{ steepness }}&deg;
+            {{ steepness() }}&deg;
           }
         </ion-row>
       }
@@ -40,7 +40,7 @@ NB! Root elements in this view has positon: absolute..
     }
 
     <!-- Coordinates -->
-    @if (mapCenter) {
+    @if (mapCenter(); as mapCenter) {
       <ion-row name="map-center-info-row">
         {{ mapCenter.lat | number: ".3" : "en-US" }}&deg;{{ "MAP_CENTER_INFO.NORTH_SHORT" | translate }},&nbsp;&nbsp;
         {{ mapCenter.lng | number: ".3" : "en-US" }}&deg;{{ "MAP_CENTER_INFO.EAST_SHORT" | translate }}
@@ -48,28 +48,28 @@ NB! Root elements in this view has positon: absolute..
     }
 
     <!-- Distance and height difference to gps position -->
-    @if (distance != null && distance > 0) {
+    @if (distance() > 0) {
       <ion-row name="map-center-info-row">
         <ion-icon name="arrow-forward" aria-label="{{ 'MAP_CENTER_INFO.DISTANCE_HORIZONTAL' | translate }}"></ion-icon>
-        {{ getHorizontalDifferenceText(distance) }}
-        @if (!loading && heightDifference != null) {
-          @if (heightDifference > 0) {
+        {{ getHorizontalDifferenceText(distance()) }}
+        @if (!loading() && heightDifference() != null) {
+          @if (heightDifference()! > 0) {
             <ion-icon
               name="arrow-up"
               class="height-difference-icon"
               aria-label="{{ 'MAP_CENTER_INFO.DISTANCE_HIGHER' | translate }}"
             ></ion-icon>
           }
-          @if (heightDifference < 0) {
+          @if (heightDifference()! < 0) {
             <ion-icon
               name="arrow-down"
               class="height-difference-icon"
               aria-label="{{ 'MAP_CENTER_INFO.DISTANCE_LOWER' | translate }}"
             ></ion-icon>
           }
-          {{ heightDifference | abs | number: "1.0-0" }} m
+          {{ heightDifference() | abs | number: "1.0-0" }} m
         }
-        @if (bearing !== undefined) {
+        @if (bearing(); as bearing) {
           <span class="bearing">{{ bearing | number: "1.0-0" }} &deg;</span>
         }
       </ion-row>

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.html
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.html
@@ -42,23 +42,35 @@ NB! Root elements in this view has positon: absolute..
     <!-- Coordinates -->
     @if (mapCenter) {
       <ion-row name="map-center-info-row">
-        {{ mapCenter.lat | number: ".3" }}&deg;{{ "MAP_CENTER_INFO.NORTH_SHORT" | translate }},
-        {{ mapCenter.lng | number: ".3" }}&deg;{{ "MAP_CENTER_INFO.EAST_SHORT" | translate }}
+        {{ mapCenter.lat | number: ".3" : "en-US" }}&deg;{{ "MAP_CENTER_INFO.NORTH_SHORT" | translate }},&nbsp;&nbsp;
+        {{ mapCenter.lng | number: ".3" : "en-US" }}&deg;{{ "MAP_CENTER_INFO.EAST_SHORT" | translate }}
       </ion-row>
     }
 
     <!-- Distance and height difference to gps position -->
     @if (distance != null && distance > 0) {
       <ion-row name="map-center-info-row">
-        {{ getHorizontalDifferenceText(distance) }} {{ "MAP_CENTER_INFO.AWAY_FROM" | translate }}
+        <ion-icon name="arrow-forward" aria-label="{{ 'MAP_CENTER_INFO.DISTANCE_HORIZONTAL' | translate }}"></ion-icon>
+        {{ getHorizontalDifferenceText(distance) }}
         @if (!loading && heightDifference != null) {
           @if (heightDifference > 0) {
-            <ion-icon name="arrow-up" class="height-difference-icon"></ion-icon>
+            <ion-icon
+              name="arrow-up"
+              class="height-difference-icon"
+              aria-label="{{ 'MAP_CENTER_INFO.DISTANCE_HIGHER' | translate }}"
+            ></ion-icon>
           }
           @if (heightDifference < 0) {
-            <ion-icon name="arrow-down" class="height-difference-icon"></ion-icon>
+            <ion-icon
+              name="arrow-down"
+              class="height-difference-icon"
+              aria-label="{{ 'MAP_CENTER_INFO.DISTANCE_LOWER' | translate }}"
+            ></ion-icon>
           }
           {{ heightDifference | abs | number: "1.0-0" }} m
+        }
+        @if (bearing !== undefined) {
+          <span class="bearing">{{ bearing | number: "1.0-0" }} &deg;</span>
         }
       </ion-row>
     }

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.html
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.html
@@ -69,8 +69,8 @@ NB! Root elements in this view has positon: absolute..
           }
           {{ heightDifference() | abs | number: "1.0-0" }} m
         }
-        @if (bearing(); as bearing) {
-          <span class="bearing">{{ bearing | number: "1.0-0" }} &deg;</span>
+        @if (bearing() != null) {
+          <span class="bearing">{{ bearing() | number: "1.0-0" }} &deg;</span>
         }
       </ion-row>
     }

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.scss
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.scss
@@ -12,6 +12,8 @@
   display: block;
 
   ion-row {
+    display: flex;
+    align-items: center;
     height: 17px;
   }
 
@@ -51,6 +53,10 @@
   padding-top: 2px;
   padding-left: 5px;
   padding-right: 1px;
+}
+
+.bearing {
+  padding-left: 5px;
 }
 
 .yr-icon {

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.spec.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.spec.ts
@@ -1,25 +1,107 @@
-// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NEVER, of } from 'rxjs';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { MapCenterInfoComponent } from './map-center-info.component';
+import { MapService } from '../../services/map/map.service';
+import { MapSearchService } from '../../services/map-search/map-search.service';
+import { GeoPositionService } from 'src/app/core/services/geo-position/geo-position.service';
+import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
+import { HelperService } from 'src/app/core/services/helpers/helper.service';
+import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
+import { ExternalLinkService } from 'src/app/core/services/external-link/external-link.service';
+import { HttpClient } from '@angular/common/http';
+import { ToastController } from '@ionic/angular/standalone';
 
-// import { MapCenterInfoComponent } from './map-center-info.component';
+describe('MapCenterInfoComponent – visning av høyde og bratthet', () => {
+  let component: MapCenterInfoComponent;
+  let fixture: ComponentFixture<MapCenterInfoComponent>;
 
-// describe('MapCenterInfoComponent', () => {
-//   let component: MapCenterInfoComponent;
-//   let fixture: ComponentFixture<MapCenterInfoComponent>;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        MapCenterInfoComponent,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useFactory: () => ({ getTranslation: () => of({}) }),
+          },
+        }),
+      ],
+      providers: [
+        { provide: MapService, useValue: { followMode$: NEVER, relevantMapChangeWithInitialView$: NEVER } },
+        { provide: GeoPositionService, useValue: { currentPosition$: NEVER } },
+        { provide: UserSettingService, useValue: { userSetting$: of({ useMagneticBearing: true }) } },
+        { provide: MapSearchService, useValue: {} },
+        { provide: HelperService, useValue: { getDistanceText: () => '' } },
+        { provide: LoggingService, useValue: { debug: (_msg: unknown) => undefined } },
+        { provide: ExternalLinkService, useValue: {} },
+        { provide: HttpClient, useValue: {} },
+        { provide: ToastController, useValue: {} },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
 
-//   beforeEach(async(() => {
-//     TestBed.configureTestingModule({
-//       declarations: [ MapCenterInfoComponent ]
-//     })
-//     .compileComponents();
-//   }));
+    fixture = TestBed.createComponent(MapCenterInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
-//   beforeEach(() => {
-//     fixture = TestBed.createComponent(MapCenterInfoComponent);
-//     component = fixture.componentInstance;
-//     fixture.detectChanges();
-//   });
+  function setValues(elevation: number | undefined, steepness: number | undefined): void {
+    component.elevation.set(elevation);
+    component.steepness.set(steepness);
+    fixture.detectChanges();
+  }
 
-//   it('should create', () => {
-//     expect(component).toBeTruthy();
-//   });
-// });
+  function getElevationSteepnessRow(): HTMLElement | null {
+    const rows = fixture.nativeElement.querySelectorAll('[name="map-center-info-row"]');
+    // Første rad kan være stedsnavn, vi vil ha raden med høyde/bratthet
+    for (const row of rows) {
+      if (row.textContent?.includes('ABOVE_SEA_LEVEL') || row.querySelector('.steepness-triangle')) {
+        return row;
+      }
+    }
+    return null;
+  }
+
+  it('viser kun bratthet (ikke høyde eller komma) når høyde er undefined', () => {
+    setValues(undefined, 30);
+    const row = getElevationSteepnessRow();
+    expect(row?.textContent).not.toContain('ABOVE_SEA_LEVEL');
+    expect(row?.textContent).toContain('30');
+    expect(row?.textContent).not.toContain(',');
+  });
+
+  it('viser kun høyde (ikke bratthet eller komma) når høyde er 0 moh', () => {
+    setValues(0, 30);
+    const row = getElevationSteepnessRow();
+    expect(row?.textContent).toContain('0');
+    expect(row?.textContent).toContain('ABOVE_SEA_LEVEL');
+    expect(row?.querySelector('.steepness-triangle')).toBeNull();
+    expect(row?.textContent).not.toContain(',');
+  });
+
+  it('viser kun høyde (ikke bratthet eller komma) når bratthet er undefined', () => {
+    setValues(500, undefined);
+    const row = getElevationSteepnessRow();
+    expect(row?.textContent).toContain('500');
+    expect(row?.textContent).toContain('ABOVE_SEA_LEVEL');
+    expect(row?.querySelector('.steepness-triangle')).toBeNull();
+    expect(row?.textContent).not.toContain(',');
+  });
+
+  it('viser høyde, komma og bratthet-symbol når begge er satt og høyde er over 0', () => {
+    setValues(500, 30);
+    const row = getElevationSteepnessRow();
+    expect(row?.textContent).toContain('500');
+    expect(row?.textContent).toContain('ABOVE_SEA_LEVEL');
+    expect(row?.textContent).toContain(',');
+    expect(row?.textContent).toContain('30');
+    expect(row?.querySelector('.steepness-triangle')).not.toBeNull();
+  });
+
+  it('viser ingenting når verken høyde eller bratthet er satt', () => {
+    setValues(undefined, undefined);
+    expect(getElevationSteepnessRow()).toBeNull();
+  });
+});

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.ts
@@ -30,7 +30,8 @@ import { NORWAY_BOUNDS } from 'src/app/core/helpers/leaflet/norway-bounds';
 import { NgStyle, DecimalPipe } from '@angular/common';
 import { AbsPipe } from '../../../shared/pipes/abs.pipe';
 import { addIcons } from 'ionicons';
-import { arrowUp, arrowDown } from 'ionicons/icons';
+import { arrowUp, arrowDown, arrowForward } from 'ionicons/icons';
+import { calculateMagneticBearing } from './map-center-utils';
 
 const DEBUG_TAG = 'MapCenterInfoComponent';
 const LOCATION_INFO_REQUEST_TIMEOUT = 10_000;
@@ -99,13 +100,31 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
     return;
   }
 
+  /**
+   * Beregner kompasskurs i grader fra brukerens posisjon til kartets sentrum, der 0° er nord, 90° er øst, osv.
+   * Returnerer undefined hvis vi ikke har nok info til å beregne (f.eks. ingen gps-posisjon eller kart-senter).
+   * Funksjonen justerer også for misvisning
+   */
+  get bearing(): number | undefined {
+    if (this.userPos?.coords && this.mapCenter != null) {
+      return calculateMagneticBearing(
+        this.userPos.coords.latitude,
+        this.userPos.coords.longitude,
+        this.mapCenter.lat,
+        this.mapCenter.lng,
+        this.userAltitude ?? 0
+      );
+    }
+    return;
+  }
+
   constructor() {
     super();
 
     // We call detectChanges after every new mapView or gps pos has been processed, so
     // no need for this component to be in the regular change detection loop.
     this.cdr.detach();
-    addIcons({ arrowUp, arrowDown });
+    addIcons({ arrowUp, arrowDown, arrowForward });
   }
 
   ngOnInit(): void {

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.ts
@@ -11,7 +11,7 @@ import { IonGrid, IonIcon, IonRow, IonSpinner, ToastController } from '@ionic/an
 import { Clipboard } from '@capacitor/clipboard';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 import { combineLatest, firstValueFrom, iif, Observable, of } from 'rxjs';
-import { catchError, debounceTime, switchMap, takeUntil, tap, timeout } from 'rxjs/operators';
+import { catchError, debounceTime, map, switchMap, takeUntil, tap, timeout } from 'rxjs/operators';
 import { MapSearchService } from '../../services/map-search/map-search.service';
 import { MapService } from '../../services/map/map.service';
 import { GeoPositionService } from 'src/app/core/services/geo-position/geo-position.service';
@@ -31,7 +31,9 @@ import { NgStyle, DecimalPipe } from '@angular/common';
 import { AbsPipe } from '../../../shared/pipes/abs.pipe';
 import { addIcons } from 'ionicons';
 import { arrowUp, arrowDown, arrowForward } from 'ionicons/icons';
-import { calculateMagneticBearing } from './map-center-utils';
+import { calculateBearing, calculateMagneticBearing } from './map-center-utils';
+import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 const DEBUG_TAG = 'MapCenterInfoComponent';
 const LOCATION_INFO_REQUEST_TIMEOUT = 10_000;
@@ -54,6 +56,7 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
   private loggingService = inject(LoggingService);
   private externalLinkService = inject(ExternalLinkService);
   private http = inject(HttpClient);
+  private userSettingService = inject(UserSettingService);
 
   private userPos?: Position; // Caches the gps position for distance and height diff computation
   private lastUserPos?: L.LatLng; //Remember last gps position to avoid adjusting altitude when device dont' move
@@ -103,20 +106,32 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
   /**
    * Beregner kompasskurs i grader fra brukerens posisjon til kartets sentrum, der 0° er nord, 90° er øst, osv.
    * Returnerer undefined hvis vi ikke har nok info til å beregne (f.eks. ingen gps-posisjon eller kart-senter).
-   * Funksjonen justerer også for misvisning
+   * Funksjonen justerer også for misvisning hvis bruker ikke har deaktivert dette
    */
   get bearing(): number | undefined {
     if (this.userPos?.coords && this.mapCenter != null) {
-      return calculateMagneticBearing(
+      if (this.useMagneticBearing()) {
+        return calculateMagneticBearing(
+          this.userPos.coords.latitude,
+          this.userPos.coords.longitude,
+          this.mapCenter.lat,
+          this.mapCenter.lng,
+          this.userAltitude ?? 0
+        );
+      }
+      return calculateBearing(
         this.userPos.coords.latitude,
         this.userPos.coords.longitude,
         this.mapCenter.lat,
-        this.mapCenter.lng,
-        this.userAltitude ?? 0
+        this.mapCenter.lng
       );
     }
     return;
   }
+
+  readonly useMagneticBearing = toSignal(this.userSettingService.userSetting$.pipe(map((s) => s.useMagneticBearing)), {
+    initialValue: true,
+  });
 
   constructor() {
     super();

--- a/src/app/modules/map/components/map-center-info/map-center-info.component.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-info.component.ts
@@ -1,11 +1,12 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   ElementRef,
   OnInit,
   inject,
   viewChild,
+  signal,
+  computed,
 } from '@angular/core';
 import { IonGrid, IonIcon, IonRow, IonSpinner, ToastController } from '@ionic/angular/standalone';
 import { Clipboard } from '@capacitor/clipboard';
@@ -27,7 +28,7 @@ import { ExternalLinkService } from 'src/app/core/services/external-link/externa
 import { HttpClient } from '@angular/common/http';
 import { booleanPointInPolygon } from '@turf/turf';
 import { NORWAY_BOUNDS } from 'src/app/core/helpers/leaflet/norway-bounds';
-import { NgStyle, DecimalPipe } from '@angular/common';
+import { DecimalPipe } from '@angular/common';
 import { AbsPipe } from '../../../shared/pipes/abs.pipe';
 import { addIcons } from 'ionicons';
 import { arrowUp, arrowDown, arrowForward } from 'ionicons/icons';
@@ -43,7 +44,7 @@ const LOCATION_INFO_REQUEST_TIMEOUT = 10_000;
   templateUrl: './map-center-info.component.html',
   styleUrls: ['./map-center-info.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [AbsPipe, DecimalPipe, IonGrid, IonIcon, IonRow, IonSpinner, NgStyle, TranslatePipe],
+  imports: [AbsPipe, DecimalPipe, IonGrid, IonIcon, IonRow, IonSpinner, TranslatePipe],
 })
 export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
   private mapService = inject(MapService);
@@ -52,15 +53,12 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
   private translateService = inject(TranslateService);
   private geoPositionService = inject(GeoPositionService);
   private helperService = inject(HelperService);
-  private cdr = inject(ChangeDetectorRef);
   private loggingService = inject(LoggingService);
   private externalLinkService = inject(ExternalLinkService);
   private http = inject(HttpClient);
   private userSettingService = inject(UserSettingService);
 
-  private userPos?: Position; // Caches the gps position for distance and height diff computation
   private lastUserPos?: L.LatLng; //Remember last gps position to avoid adjusting altitude when device dont' move
-  private _userAltitude?: number; // Cached user altitude from server fetched when we can't trust the GPS altitude
 
   // For accessing the info box element from parent views
   readonly infoBoxElement = viewChild.required<ElementRef<HTMLDivElement>>('infoBoxElement');
@@ -70,64 +68,44 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
   }
 
   // Public props we can see in the map center info box
-  mapCenter?: L.LatLng;
-  elevation?: number;
-  location?: LocationName;
-  steepness?: number;
-  loading = false;
+  readonly mapCenter = signal<L.LatLng | undefined>(undefined);
+  readonly elevation = signal<number | undefined>(undefined);
+  readonly location = signal<LocationName | undefined>(undefined);
+  readonly steepness = signal<number | undefined>(undefined);
+  readonly loading = signal(false);
+  private readonly userPos = signal<Position | undefined>(undefined);
+  private readonly serverAltitude = signal<number | undefined>(undefined); // korrigert høyde fra API
 
-  get distance(): number {
-    if (this.userPos?.coords && this.mapCenter != null) {
-      return this.mapCenter.distanceTo({
-        lat: this.userPos.coords.latitude,
-        lng: this.userPos.coords.longitude,
-      });
-    }
-    return 0;
-  }
+  readonly userAltitude = computed(() => this.serverAltitude() ?? this.userPos()?.coords?.altitude ?? undefined);
 
-  get userAltitude(): number | undefined {
-    if (this._userAltitude != null) {
-      return this._userAltitude;
-    }
-    if (this.userPos?.coords?.altitude != null) {
-      return this.userPos.coords.altitude;
-    }
-    return;
-  }
+  readonly distance = computed(() => {
+    const pos = this.userPos();
+    const center = this.mapCenter();
+    if (!pos?.coords || center == null) return 0;
+    return center.distanceTo({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+  });
 
-  get heightDifference(): number | undefined {
-    if (this.userAltitude != null && this.elevation != null) {
-      return this.elevation - this.userAltitude;
-    }
-    return;
-  }
+  readonly heightDifference = computed(() => {
+    const alt = this.userAltitude();
+    const elev = this.elevation();
+    return alt != null && elev != null ? elev - alt : undefined;
+  });
 
   /**
    * Beregner kompasskurs i grader fra brukerens posisjon til kartets sentrum, der 0° er nord, 90° er øst, osv.
    * Returnerer undefined hvis vi ikke har nok info til å beregne (f.eks. ingen gps-posisjon eller kart-senter).
    * Funksjonen justerer også for misvisning hvis bruker ikke har deaktivert dette
    */
-  get bearing(): number | undefined {
-    if (this.userPos?.coords && this.mapCenter != null) {
-      if (this.useMagneticBearing()) {
-        return calculateMagneticBearing(
-          this.userPos.coords.latitude,
-          this.userPos.coords.longitude,
-          this.mapCenter.lat,
-          this.mapCenter.lng,
-          this.userAltitude ?? 0
-        );
-      }
-      return calculateBearing(
-        this.userPos.coords.latitude,
-        this.userPos.coords.longitude,
-        this.mapCenter.lat,
-        this.mapCenter.lng
-      );
+  readonly bearing = computed(() => {
+    const pos = this.userPos();
+    const center = this.mapCenter();
+    if (!pos?.coords || center == null) return undefined;
+    const { latitude, longitude } = pos.coords;
+    if (this.useMagneticBearing()) {
+      return calculateMagneticBearing(latitude, longitude, center.lat, center.lng, this.userAltitude() ?? 0);
     }
-    return;
-  }
+    return calculateBearing(latitude, longitude, center.lat, center.lng);
+  });
 
   readonly useMagneticBearing = toSignal(this.userSettingService.userSetting$.pipe(map((s) => s.useMagneticBearing)), {
     initialValue: true,
@@ -135,10 +113,6 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
 
   constructor() {
     super();
-
-    // We call detectChanges after every new mapView or gps pos has been processed, so
-    // no need for this component to be in the regular change detection loop.
-    this.cdr.detach();
     addIcons({ arrowUp, arrowDown, arrowForward });
   }
 
@@ -148,12 +122,10 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
     combineLatest([this.geoPositionService.currentPosition$, this.mapService.followMode$])
       .pipe(
         takeUntil(this.ngDestroy$),
-        tap(([newPos, followMode]) => (this.userPos = followMode ? undefined : newPos)),
+        tap(([newPos, followMode]) => this.userPos.set(followMode ? undefined : newPos)),
         switchMap(() => this.fixGpsPosHeight())
       )
-      .subscribe(() => {
-        this.cdr.detectChanges();
-      });
+      .subscribe();
 
     //fetch location info from Regobs API on map pan or zoom
     //update location, elevation and steepness when/if we get results from the API
@@ -161,12 +133,11 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
       .pipe(
         takeUntil(this.ngDestroy$),
         tap((newMapView) => {
-          this.loading = true;
-          this.mapCenter = newMapView.center;
-          this.location = undefined;
-          this.elevation = undefined;
-          this.steepness = undefined;
-          this.cdr.detectChanges();
+          this.loading.set(true);
+          this.mapCenter.set(newMapView.center);
+          this.location.set(undefined);
+          this.elevation.set(undefined);
+          this.steepness.set(undefined);
         }),
         debounceTime(1500),
         switchMap((newMapView) =>
@@ -179,34 +150,35 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
       )
       .subscribe((locationInfo) => {
         if (locationInfo != null) {
-          this.location = locationInfo.location;
-          this.elevation = locationInfo.elevation;
-          this.steepness = locationInfo.steepness;
+          this.location.set(locationInfo?.location);
+          this.elevation.set(locationInfo?.elevation);
+          this.steepness.set(locationInfo?.steepness);
         }
-        this.loading = false;
-        this.cdr.detectChanges();
+        this.loading.set(false);
       });
   }
 
+  /** Hent høyde for Android fra server fordi GPS-høyde ofte er unøyaktig */
   private async fixGpsPosHeight(): Promise<void> {
-    if (Capacitor.getPlatform() !== 'ios' && this.userPos?.coords) {
+    const pos = this.userPos();
+    if (Capacitor.getPlatform() !== 'ios' && pos?.coords) {
       const start = Date.now();
-      const latLng = new L.LatLng(this.userPos.coords.latitude, this.userPos.coords.longitude);
+      const latLng = new L.LatLng(pos.coords.latitude, pos.coords.longitude);
       if (!this.lastUserPos || this.lastUserPos.distanceTo(latLng) > 5) {
         this.lastUserPos = latLng;
         const locationInfo = await firstValueFrom(this.getLocationInfo$(latLng));
         if (locationInfo?.elevation) {
-          this._userAltitude = locationInfo.elevation;
+          this.serverAltitude.set(locationInfo.elevation);
           this.loggingService.debug(
-            `Device altitude ${this.userPos.coords.altitude} adjusted to ${locationInfo.elevation} ` +
+            `Device altitude ${pos.coords.altitude} adjusted to ${locationInfo.elevation} ` +
               `in ${Date.now() - start}ms`,
             DEBUG_TAG
           );
         } else {
-          this._userAltitude = undefined;
+          this.serverAltitude.set(undefined);
           this.loggingService.debug(
             'Tried to adjust user position altitude, but got no response from server, ' +
-              `keeping altitude from device: ${this.userPos.coords.altitude}, took ${Date.now() - start}ms`,
+              `keeping altitude from device: ${pos.coords.altitude}, took ${Date.now() - start}ms`,
             DEBUG_TAG
           );
         }
@@ -232,7 +204,7 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
   }
 
   async copyToClipboard(): Promise<void> {
-    const textToCopy = `${this.mapCenter?.lat}, ${this.mapCenter?.lng}`;
+    const textToCopy = `${this.mapCenter()?.lat.toFixed(5)}, ${this.mapCenter()?.lng.toFixed(5)}`;
     await Clipboard.write({ string: textToCopy });
 
     const toastText = await firstValueFrom(this.translateService.get('MAP_CENTER_INFO.COPIED_TO_CLIPBOARD'));
@@ -245,12 +217,13 @@ export class MapCenterInfoComponent extends NgDestoryBase implements OnInit {
   }
 
   async loadYrClick(event: MouseEvent) {
-    // siden vi bruker nå aux for å støtte midtklikk på mus, må vi sikkre at auxclick ikke blir kalt for høyreklikk
+    // siden vi bruker aux for å støtte midtklikk på mus, må vi sikre at auxclick ikke blir kalt for høyreklikk
     if (event.button == 2) return;
     event.stopPropagation();
     event.preventDefault();
-    if (this.mapCenter) {
-      await this.loadYr(this.mapCenter.lat, this.mapCenter.lng);
+    const center = this.mapCenter();
+    if (center != null) {
+      await this.loadYr(center.lat, center.lng);
     }
   }
 

--- a/src/app/modules/map/components/map-center-info/map-center-utils.spec.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-utils.spec.ts
@@ -1,0 +1,210 @@
+import { calculateBearing, calculateMagneticBearing, getMagneticDeclination } from './map-center-utils';
+
+describe('map-center-utils', () => {
+  describe('calculateBearing', () => {
+    it('should calculate bearing due north as 0 degrees', () => {
+      const bearing = calculateBearing(0, 10, 1, 10);
+      expect(bearing).toBeCloseTo(0, 1);
+    });
+
+    it('should calculate bearing due east as 90 degrees', () => {
+      const bearing = calculateBearing(0, 10, 0, 11); // Ved ekvator
+      expect(bearing).toBeCloseTo(90, 1);
+    });
+
+    it('should calculate bearing due south as 180 degrees', () => {
+      const bearing = calculateBearing(0, 10, -1, 10);
+      expect(bearing).toBeCloseTo(180, 1);
+    });
+
+    it('should calculate bearing due west as 270 degrees', () => {
+      const bearing = calculateBearing(0, 10, 0, 9); // Ved ekvator
+      expect(bearing).toBeCloseTo(270, 1);
+    });
+
+    it('should calculate bearing from Oslo to Bergen (approximately west-northwest)', () => {
+      // Oslo: 59.9139°N, 10.7522°E
+      // Bergen: 60.3913°N, 5.3221°E
+      const bearing = calculateBearing(59.9139, 10.7522, 60.3913, 5.3221);
+      expect(bearing).toBeCloseTo(282, 0); // Approximately WNW
+    });
+
+    it('should calculate bearing from Bergen to Oslo (approximately east-southeast)', () => {
+      // Bergen: 60.3913°N, 5.3221°E
+      // Oslo: 59.9139°N, 10.7522°E
+      const bearing = calculateBearing(60.3913, 5.3221, 59.9139, 10.7522);
+      expect(bearing).toBeCloseTo(98, 0); // Approximately ESE
+    });
+
+    it('should calculate bearing from Oslo to Trondheim (approximately north)', () => {
+      // Oslo: 59.9139°N, 10.7522°E
+      // Trondheim: 63.4305°N, 10.3951°E
+      const bearing = calculateBearing(59.9139, 10.7522, 63.4305, 10.3951);
+      expect(bearing).toBeCloseTo(357, 0); // Nearly due north
+    });
+
+    it('should handle same position (return some value 0-360)', () => {
+      const bearing = calculateBearing(60, 10, 60, 10);
+      expect(bearing).toBeGreaterThanOrEqual(0);
+      expect(bearing).toBeLessThan(360);
+    });
+
+    it('should always return a value between 0 and 360', () => {
+      const testCases = [
+        [0, 0, 10, 10],
+        [-45, -45, 45, 45],
+        [89, 179, -89, -179],
+      ];
+
+      testCases.forEach(([fromLat, fromLng, toLat, toLng]) => {
+        const bearing = calculateBearing(fromLat, fromLng, toLat, toLng);
+        expect(bearing).toBeGreaterThanOrEqual(0);
+        expect(bearing).toBeLessThan(360);
+      });
+    });
+
+    it('should calculate northeast bearing correctly', () => {
+      const bearing = calculateBearing(60, 10, 61, 11);
+      expect(bearing).toBeGreaterThan(0);
+      expect(bearing).toBeLessThan(90);
+    });
+
+    it('should calculate southwest bearing correctly', () => {
+      const bearing = calculateBearing(60, 10, 59, 9);
+      expect(bearing).toBeGreaterThan(180);
+      expect(bearing).toBeLessThan(270);
+    });
+  });
+
+  describe('getMagneticDeclination', () => {
+    it('should return positive declination for Oslo (magnetic north is east of true north)', () => {
+      // Oslo: 59.9139°N, 10.7522°E
+      const declination = getMagneticDeclination(59.9139, 10.7522);
+      expect(declination).toBeGreaterThan(0);
+      expect(declination).toBeLessThan(10); // Norge har ca. 5-7° østlig misvisning
+    });
+
+    it('should return positive declination for Bergen', () => {
+      // Bergen: 60.3913°N, 5.3221°E
+      const declination = getMagneticDeclination(60.3913, 5.3221);
+      expect(declination).toBeGreaterThan(0);
+      expect(declination).toBeLessThan(10);
+    });
+
+    it('should return positive declination for Trondheim', () => {
+      // Trondheim: 63.4305°N, 10.3951°E
+      const declination = getMagneticDeclination(63.4305, 10.3951);
+      expect(declination).toBeGreaterThan(0);
+      expect(declination).toBeLessThan(10);
+    });
+
+    it('should handle altitude parameter at sea level', () => {
+      const declinationDefault = getMagneticDeclination(59.9139, 10.7522);
+      const declinationSeaLevel = getMagneticDeclination(59.9139, 10.7522, 0);
+
+      // Verdiene skal være identiske siden default er 0
+      expect(declinationDefault).toBe(declinationSeaLevel);
+    });
+
+    it('should have minimal difference with altitude changes', () => {
+      const declinationSea = getMagneticDeclination(59.9139, 10.7522, 0);
+      const declinationMountain = getMagneticDeclination(59.9139, 10.7522, 2000);
+
+      // Høyde påvirker misvisning svært lite (< 0.1° for 2000m)
+      expect(Math.abs(declinationSea - declinationMountain)).toBeLessThan(1);
+    });
+
+    it('should return declination for Svalbard (high latitude)', () => {
+      // Longyearbyen: 78.2186°N, 15.6488°E
+      const declination = getMagneticDeclination(78.2186, 15.6488);
+
+      // Svalbard har høyere misvisning enn fastlands-Norge
+      expect(declination).toBeGreaterThan(0);
+      expect(declination).toBeLessThan(20);
+    });
+
+    it('should handle negative latitudes (southern hemisphere)', () => {
+      // Sydney: -33.8688°S, 151.2093°E
+      const declination = getMagneticDeclination(-33.8688, 151.2093);
+
+      // Sydney har østlig misvisning
+      expect(declination).toBeGreaterThan(0);
+      expect(declination).toBeLessThan(20);
+    });
+  });
+
+  describe('calculateMagneticBearing', () => {
+    it('should calculate magnetic bearing from Oslo to Bergen', () => {
+      // Oslo: 59.9139°N, 10.7522°E
+      // Bergen: 60.3913°N, 5.3221°E
+      const magneticBearing = calculateMagneticBearing(59.9139, 10.7522, 60.3913, 5.3221);
+      const trueBearing = calculateBearing(59.9139, 10.7522, 60.3913, 5.3221);
+      const declination = getMagneticDeclination(59.9139, 10.7522);
+
+      // Magnetisk bearing skal være true bearing minus declination
+      expect(magneticBearing).toBeCloseTo((trueBearing - declination + 360) % 360, 0);
+    });
+
+    it('should always return a value between 0 and 360', () => {
+      const testCases = [
+        [59.9139, 10.7522, 60.3913, 5.3221], // Oslo to Bergen
+        [60.3913, 5.3221, 59.9139, 10.7522], // Bergen to Oslo
+        [59.9139, 10.7522, 63.4305, 10.3951], // Oslo to Trondheim
+        [69.6492, 18.9553, 78.2186, 15.6488], // Tromsø to Svalbard
+      ];
+
+      testCases.forEach(([fromLat, fromLng, toLat, toLng]) => {
+        const bearing = calculateMagneticBearing(fromLat, fromLng, toLat, toLng);
+        expect(bearing).toBeGreaterThanOrEqual(0);
+        expect(bearing).toBeLessThan(360);
+      });
+    });
+
+    it('should differ from true bearing by approximately the declination amount', () => {
+      const fromLat = 60;
+      const fromLng = 10;
+      const toLat = 61;
+      const toLng = 10;
+
+      const trueBearing = calculateBearing(fromLat, fromLng, toLat, toLng);
+      const magneticBearing = calculateMagneticBearing(fromLat, fromLng, toLat, toLng);
+      const declination = getMagneticDeclination(fromLat, fromLng);
+
+      // Forskjellen skal være lik misvisningen (med hensyn til wrapping rundt 360)
+      const difference = (trueBearing - magneticBearing + 360) % 360;
+      expect(difference).toBeCloseTo(declination, 0);
+    });
+
+    it('should handle altitude parameter correctly', () => {
+      const bearingSeaLevel = calculateMagneticBearing(59.9139, 10.7522, 60.3913, 5.3221, 0);
+      const bearingMountain = calculateMagneticBearing(59.9139, 10.7522, 60.3913, 5.3221, 2000);
+
+      // Forskjellen skal være minimal siden altitude påvirker lite
+      expect(Math.abs(bearingSeaLevel - bearingMountain)).toBeLessThan(1);
+    });
+
+    it('should give lower magnetic bearing than true bearing for positive declination', () => {
+      // I Norge (positiv misvisning) skal magnetisk bearing være lavere enn true bearing
+      const trueBearing = calculateBearing(59.9139, 10.7522, 60.3913, 5.3221);
+      const magneticBearing = calculateMagneticBearing(59.9139, 10.7522, 60.3913, 5.3221);
+
+      // Med positiv misvisning (magnetisk nord øst for true nord),
+      // må vi kompensere ved å trekke fra, så magnetic < true (for de fleste tilfeller)
+      // Men må ta hensyn til wrapping rundt 0/360
+      const declination = getMagneticDeclination(59.9139, 10.7522);
+      expect(declination).toBeGreaterThan(0); // Bekreft at Norge har positiv misvisning
+
+      // Sjekk at forholdet stemmer
+      const expectedMagnetic = (trueBearing - declination + 360) % 360;
+      expect(magneticBearing).toBeCloseTo(expectedMagnetic, 0);
+    });
+
+    it('should handle bearing near 0/360 boundary correctly', () => {
+      // Test et tilfelle hvor bearing er nær nord (0/360 grenser)
+      const magneticBearing = calculateMagneticBearing(59, 10, 60, 10);
+
+      expect(magneticBearing).toBeGreaterThanOrEqual(0);
+      expect(magneticBearing).toBeLessThan(360);
+    });
+  });
+});

--- a/src/app/modules/map/components/map-center-info/map-center-utils.spec.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-utils.spec.ts
@@ -103,7 +103,7 @@ describe('map-center-utils', () => {
       const declinationSeaLevel = getMagneticDeclination(59.9139, 10.7522, 0);
 
       // Verdiene skal være identiske siden default er 0
-      expect(declinationDefault).toBe(declinationSeaLevel);
+      expect(declinationDefault).toBeCloseTo(declinationSeaLevel);
     });
 
     it('should have minimal difference with altitude changes', () => {

--- a/src/app/modules/map/components/map-center-info/map-center-utils.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-utils.ts
@@ -1,0 +1,68 @@
+import geomagnetism from 'geomagnetism';
+
+/**
+ * Beregner retning fra ett geografisk punkt til et annet.
+ * @param fromLat Breddegrad for startpunkt
+ * @param fromLng Lengdegrad for startpunkt
+ * @param toLat Breddegrad for målpunkt
+ * @param toLng Lengdegrad for målpunkt
+ * @returns Retning i grader [0-360), der 0 er nord, 90 er øst, osv.
+ */
+export function calculateBearing(fromLat: number, fromLng: number, toLat: number, toLng: number): number {
+  const fromLatRad = toRadians(fromLat);
+  const toLatRad = toRadians(toLat);
+  const deltaLon = toRadians(toLng - fromLng);
+
+  const y = Math.sin(deltaLon) * Math.cos(toLatRad);
+  const x = Math.cos(fromLatRad) * Math.sin(toLatRad) - Math.sin(fromLatRad) * Math.cos(toLatRad) * Math.cos(deltaLon);
+  const bearing = Math.atan2(y, x);
+
+  // Konverter fra radianer til grader
+  return (toDegrees(bearing) + 360) % 360;
+}
+
+/**
+ * Henter magnetisk misvisning for en gitt posisjon.
+ * @param lat Breddegrad
+ * @param lng Lengdegrad
+ * @param altitude Høyde over havet i meter (valgfritt, standard 0)
+ * @returns Magnetisk misvisning i grader (positiv = østlig, negativ = vestlig)
+ */
+export function getMagneticDeclination(lat: number, lng: number, altitude = 0): number {
+  const model = geomagnetism.model(new Date(), { allowOutOfBoundsModel: true });
+  const altitudeKm = altitude / 1000; // Konverter høyde til kilometer
+  const info = model.point([lat, lng, altitudeKm]);
+  return info.decl;
+}
+
+/**
+ * Beregner kompasskurs fra ett geografisk punkt til et annet, inkludert misvisning.
+ * @param fromLat Breddegrad for startpunkt
+ * @param fromLng Lengdegrad for startpunkt
+ * @param toLat Breddegrad for målpunkt
+ * @param toLng Lengdegrad for målpunkt
+ * @param altitude Høyde over havet i meter (valgfritt, standard 0)
+ * @returns Magnetisk retning i grader [0-360)
+ */
+export function calculateMagneticBearing(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+  altitude = 0
+): number {
+  const trueBearing = calculateBearing(fromLat, fromLng, toLat, toLng);
+  const declination = getMagneticDeclination(fromLat, fromLng, altitude);
+
+  // Trekk fra misvisning for å få magnetisk kompasskurs
+  // (positiv misvisning betyr at magnetisk nord er øst for sann nord)
+  return (trueBearing - declination + 360) % 360;
+}
+
+function toRadians(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}
+
+function toDegrees(radians: number): number {
+  return radians * (180 / Math.PI);
+}

--- a/src/app/modules/map/components/map-center-info/map-center-utils.ts
+++ b/src/app/modules/map/components/map-center-info/map-center-utils.ts
@@ -29,7 +29,7 @@ export function calculateBearing(fromLat: number, fromLng: number, toLat: number
  * @returns Magnetisk misvisning i grader (positiv = østlig, negativ = vestlig)
  */
 export function getMagneticDeclination(lat: number, lng: number, altitude = 0): number {
-  const model = geomagnetism.model(new Date(), { allowOutOfBoundsModel: true });
+  const model = getGeomagnetismModel();
   const altitudeKm = altitude / 1000; // Konverter høyde til kilometer
   const info = model.point([lat, lng, altitudeKm]);
   return info.decl;
@@ -65,4 +65,17 @@ function toRadians(degrees: number): number {
 
 function toDegrees(radians: number): number {
   return radians * (180 / Math.PI);
+}
+
+// vi gjenbruker modellen så lenge året er det samme, siden modellen oppdateres årlig
+let cachedModel: ReturnType<typeof geomagnetism.model> | undefined;
+let cachedYear: number | undefined;
+
+function getGeomagnetismModel() {
+  const currentYear = new Date().getFullYear();
+  if (cachedModel == null || cachedYear !== currentYear) {
+    cachedModel = geomagnetism.model(new Date(), { allowOutOfBoundsModel: true });
+    cachedYear = currentYear;
+  }
+  return cachedModel;
 }

--- a/src/app/pages/user-settings/user-settings.page.html
+++ b/src/app/pages/user-settings/user-settings.page.html
@@ -37,6 +37,12 @@
         <ion-toggle slot="end" [(ngModel)]="userSettings.useRetinaMap" (ngModelChange)="updateSettings()"> </ion-toggle>
       </ion-item>
 
+      <ion-item>
+        <ion-label>{{ "SETTINGS.USE_MAGNETIC_BEARING" | translate }}</ion-label>
+        <ion-toggle slot="end" [(ngModel)]="userSettings.useMagneticBearing" (ngModelChange)="updateSettings()">
+        </ion-toggle>
+      </ion-item>
+
       <!-- GPS Debug -->
       @if (userSettings.featureToggleDeveloperMode) {
         <ion-item>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -974,6 +974,7 @@
     "TITLE": "Settings",
     "UPDATE_DROPDOWNS": "Update dropdowns",
     "USE_IN_WORLD": "Outside Norway",
+    "USE_MAGNETIC_BEARING": "Use magnetic bearing",
     "USE_RETINA_MAP": "Use high resolution maps"
   },
   "SET_NICK_ALERT": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -172,8 +172,10 @@
   },
   "MAP_CENTER_INFO": {
     "ABOVE_SEA_LEVEL": "masl",
-    "AWAY_FROM": "away",
     "COPIED_TO_CLIPBOARD": "Copied to clipboard",
+    "DISTANCE_HIGHER": "higher",
+    "DISTANCE_HORIZONTAL": "Horizontal distance",
+    "DISTANCE_LOWER": "lower",
     "EAST_SHORT": "E",
     "NORTH_SHORT": "N",
     "WEATHER_ERROR": "Weather forecast not found!",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -171,8 +171,10 @@
   },
   "MAP_CENTER_INFO": {
     "ABOVE_SEA_LEVEL": "moh",
-    "AWAY_FROM": "unna",
     "COPIED_TO_CLIPBOARD": "Kopiert til utklippstavlen",
+    "DISTANCE_HIGHER": "høyere",
+    "DISTANCE_HORIZONTAL": "Horisontal avstand",
+    "DISTANCE_LOWER": "lavere",
     "EAST_SHORT": "Ø",
     "NORTH_SHORT": "N",
     "WEATHER_ERROR": "Fant ikke værvarsel!",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -972,6 +972,7 @@
     "TITLE": "Innstillinger",
     "UPDATE_DROPDOWNS": "Oppdater nedtrekksmenyer",
     "USE_IN_WORLD": "Utenfor Norge",
+    "USE_MAGNETIC_BEARING": "Kompenser for misvisning i kurs",
     "USE_RETINA_MAP": "Bruk høy oppløsning på kart"
   },
   "SET_NICK_ALERT": {

--- a/src/assets/icon/arrow_range.svg
+++ b/src/assets/icon/arrow_range.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000"><path d="M280-280 80-480l200-200 56 56-103 104h494L624-624l56-56 200 200-200 200-56-56 103-104H233l103 104-56 56Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"><path d="M280-280 80-480l200-200 56 56-103 104h494L624-624l56-56 200 200-200 200-56-56 103-104H233l103 104-56 56Z"/></svg>


### PR DESCRIPTION
### Nytt 
- Skrev om all kartsenter-koden til å bruke Signals
- Deling av posisjon runder nå av koordinatene til 5 desimaler
- Har også tatt hensyn til misvisning. Tok inn et nytt bibliotek for dette: https://github.com/naturalatlas/geomagnetism
Kan overstyres med denne innstillinga:
<img width="551" height="866" alt="image" src="https://github.com/user-attachments/assets/9a127b6b-9018-44dc-bb28-8204adf8d0c4" />

Brukte litt tid på å finne en et godt "navn" på innstillinga og som ikke tok for mye plass.
Har foreløpig ikke laget noen hjelpetekst.
---

Har vært på tur i tåka og gått på kompasskurs.
Ønsket meg da en funksjon for å se kompassretning i grader til kartsenter.
Mener andre også har etterspurt det, men fant ingen Jira-sak på det.
Så denne er et forsøk på å løse dette.
<img width="198" height="133" alt="image" src="https://github.com/user-attachments/assets/fd551bad-afa5-4614-a0bf-ceae3a709378" />
For å bedre plass til kursen, byttet jeg ut teksten "unna" etter avstand i luftlinje med et ikon foran avstanden.
Jeg endret også litt på koordinatene til kartsenter for å gjøre dem lettere å lese. Viser dem nå med punktum som desimalskilletegn for ikke å komme i konflikt med kommaet mellom lat og lng, og litt mer avstand mellom lat og lng.
Har testet kjapt på Android:
<img width="517" height="958" alt="Skjermbilde 2026-04-17 185059" src="https://github.com/user-attachments/assets/00f770a2-dbc3-44e1-b377-01907e5e803e" />