### PR TITLE
RO-3167: Ikke lagre kladd på nytt om sletting av kladd feiler etter innsending

### DIFF
--- a/src/app/core/services/draft/draft-repository.service.spec.ts
+++ b/src/app/core/services/draft/draft-repository.service.spec.ts
@@ -290,6 +290,29 @@ describe('DraftRepositoryService', () => {
     expect(newAttachmentService.removeAttachments).toHaveBeenCalledWith(draft.uuid);
   }));
 
+  it('delete removes the draft from database even if attachment cleanup fails', fakeAsync(async () => {
+    // Regression test: previously removeAttachments() throwing would prevent
+    // databaseService.remove() from running, leaving the draft in the DB with
+    // syncStatus: Sync — causing it to be re-submitted on next app start.
+    const service = TestBed.inject(DraftRepositoryService);
+    const draft = await service.create(GeoHazard.Ice);
+    await service.save(draft as RegistrationDraft);
+
+    expect(database.store.size).toBe(1);
+
+    // Simulate a filesystem error (e.g. Filesystem.rmdir failed)
+    newAttachmentService.removeAttachments.and.rejectWith(new Error('Filesystem.rmdir failed'));
+
+    // delete() should not throw
+    await expectAsync(service.delete(draft.uuid)).toBeResolved();
+    tick();
+
+    // The draft must be gone from the database despite the attachment error
+    expect(database.store.has(`drafts.TEST.${draft.uuid}`)).toBeFalse();
+    const draftChanges = await firstValueFrom(service.drafts$);
+    expect(draftChanges.length).toBe(0);
+  }));
+
   it('we do not mix data from different environments', fakeAsync(async () => {
     const service = TestBed.inject(DraftRepositoryService);
     //save 2 drafts in test environment

--- a/src/app/core/services/draft/draft-repository.service.ts
+++ b/src/app/core/services/draft/draft-repository.service.ts
@@ -370,7 +370,11 @@ export class DraftRepositoryService {
   async delete(uuid: string): Promise<void> {
     this.logger.debug(`Deleting draft`, DEBUG_TAG, { uuid });
     this.throwIfMissingUuid(uuid);
-    await this.newAttachmentSerivice.removeAttachments(uuid);
+    try {
+      await this.newAttachmentSerivice.removeAttachments(uuid);
+    } catch (error) {
+      this.logger.error(error, DEBUG_TAG, 'Failed to remove attachments during draft delete, continuing', { uuid });
+    }
     const appMode = await firstValueFrom(this.userSettingService.appMode$);
     const key = this.createKey(uuid, appMode);
     await this.databaseService.remove(key);

--- a/src/app/core/services/draft/draft-to-registration.service.spec.ts
+++ b/src/app/core/services/draft/draft-to-registration.service.spec.ts
@@ -295,4 +295,74 @@ describe('DraftToRegistrationService', () => {
       discardPeriodicTasks();
     })
   );
+
+  it('Does not save draft with error when upload succeeds but draft delete fails', fakeAsync(() => {
+    // Regression test for RO-3167: Previously the catch block wrapped both the upload AND the delete,
+    // so a failed delete (e.g. Filesystem.rmdir error) would re-save the draft with an error
+    // even though the observation was already submitted to the server.
+    spyOn(loggerService, 'error').and.callThrough();
+
+    const registration = { RegId: 123456, GeoHazardTID: 10, DtObsTime: 'Test' } as RegistrationViewModel;
+    addUpdateDeleteRegService.add.and.resolveTo(registration);
+
+    // Simulate a filesystem error when trying to delete the local draft
+    draftService.delete.and.rejectWith(new Error('Filesystem.rmdir failed'));
+
+    connected.next(true);
+    drafts.next([draft]);
+
+    service.createSubscriptions();
+    flush();
+
+    // The observation is on the server, so the draft must NOT be saved with an error code
+    expect(draftService.save).not.toHaveBeenCalled();
+
+    // The error should be logged so we can diagnose it
+    expect(loggerService.error).toHaveBeenCalledTimes(1);
+
+    discardPeriodicTasks();
+  }));
+
+  it('saves the draft with SyncStatus.Sync', async () => {
+    draftService.save.and.resolveTo();
+
+    await service.markDraftAsReadyToSubmit(draft);
+
+    expect(draftService.save).toHaveBeenCalledWith(jasmine.objectContaining({ syncStatus: SyncStatus.Sync }));
+  });
+
+  it('removes existing error from draft so it can be retried', async () => {
+    draftService.save.and.resolveTo();
+
+    const draftWithError: RegistrationDraft = {
+      ...draft,
+      syncStatus: SyncStatus.Sync,
+      error: { code: RegistrationDraftErrorCode.NoNetworkOrTimedOut, timestamp: 12345 },
+    };
+
+    await service.markDraftAsReadyToSubmit(draftWithError);
+
+    const savedDraft = draftService.save.calls.first().args[0];
+    expect(savedDraft.error).toBeUndefined();
+    expect(savedDraft.syncStatus).toBe(SyncStatus.Sync);
+  });
+
+  it('resolves only after the save is complete', async () => {
+    // Regression test for RO-3167: previously save() was called without await, so the method
+    // returned before the save completed, creating a race condition.
+    let saveResolved = false;
+    draftService.save.and.callFake(
+      () =>
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            saveResolved = true;
+            resolve();
+          }, 50)
+        )
+    );
+
+    await service.markDraftAsReadyToSubmit(draft);
+
+    expect(saveResolved).toBeTrue();
+  });
 });

--- a/src/app/core/services/draft/draft-to-registration.service.ts
+++ b/src/app/core/services/draft/draft-to-registration.service.ts
@@ -79,7 +79,7 @@ export class DraftToRegistrationService {
       syncStatus: syncStatus,
     };
     this.loggerService.debug('Saving draft with updated sync status', DEBUG_TAG, { updatedDraft, ignoreVersionCheck });
-    this.draftService.save(updatedDraft);
+    await this.draftService.save(updatedDraft);
   }
 
   private startUploadingRegistrations() {
@@ -157,17 +157,27 @@ export class DraftToRegistrationService {
       } else {
         await this.addUpdateDeleteRegistrationService.add(draft);
       }
-
-      this.loggerService.debug(`Add or update complete, deleting draft`, DEBUG_TAG, { uuid: draft.uuid });
-      await this.draftService.delete(draft.uuid);
     } catch (error) {
       const { message, code } = handleError(error);
-      this.loggerService.error(error, DEBUG_TAG, 'Got error during add, update or draft delete', {
+      this.loggerService.error(error, DEBUG_TAG, 'Got error during add or update', {
         message,
         code,
         uuid: draft.uuid,
       });
       await this.draftService.save({ ...draft, error: { code, message, timestamp: Date.now() } });
+      return;
+    }
+
+    this.loggerService.debug(`Add or update complete, deleting draft`, DEBUG_TAG, { uuid: draft.uuid });
+    try {
+      await this.draftService.delete(draft.uuid);
+    } catch (error) {
+      this.loggerService.error(
+        error,
+        DEBUG_TAG,
+        'Got error deleting draft after successful upload. Draft may remain but observation is already submitted.',
+        { uuid: draft.uuid }
+      );
     }
   }
 


### PR DESCRIPTION
Mye arbeid gjort av copiloten her.
Dette er et forsøk på å løse problemet med at kladden noen ganger blir liggende igjen på tlf etter at observasjon er sendt inn.
Kladden skal jo slettes etter at vi har sendt inn observasjonen.
Hypotesen var at om _sletting av kladd_ feilet etter innsending, ville kladden bli lagret på nytt, selv om observasjonen var sendt inn, fordi vi hadde sletting av kladden i samme try...catch-blokk.
Jeg fikk laget et par tester også, og jeg har testet at testene feiler om fiksen ikke er der.
Her er oppsummeringa fra copilot:

### Bug 1 (primary — the draft remaining after successful submit):
The try/catch around the upload also caught errors thrown by draftService.delete. If the delete failed (e.g., Filesystem.rmdir threw in removeAttachments), the catch block re-saved the draft with an error code — even though the observation was already on the server. This is exactly the scenario described: observation submitted, draft stays with an error.

Fix: split into two separate try/catch blocks. Errors during upload → save draft with error code as before. Errors during delete → log only, don't re-save the draft (the observation is already submitted).

### Bug 2 (secondary — potential race condition):
markDraftAsReadyToSubmit called draftService.save() without await. The function returned before the save actually completed, which could cause the SyncStatus.Sync to not be persisted before something else read the draft.

Fix: added await to the draftService.save() call.

### Feil 3 (kanskje viktigst: Kladd ble uansett ikke slettet hvis sletting av vedlegg feilet):
Det var copiloten i PR som fant denne. Feilen skjer hvis sletting av vedlegg feiler når vi prøver å slette en kladd.

Fiks: Try...catch rundt `newAttachmentSerivice.removeAttachments(uuid)` og slette kladden fra databasen uansett.

---

Jeg har testet kjapt på web og i Android. Ser ikke ut som jeg har ødelagt noe, men jeg har ikke fått til å framprovosere feilen heller.
