### PR TITLE
RO-3198: Tatt bort 4 og 12 uker fra mulige tidsfilter-valg for is

### DIFF
--- a/src/app/core/services/user-setting/user-setting-service.spec.ts
+++ b/src/app/core/services/user-setting/user-setting-service.spec.ts
@@ -81,7 +81,7 @@ describe('UserSettingService', () => {
     } as unknown as UserSetting);
   }));
 
-  it('normalizes stored daysBack to first valid option when the saved value is no longer in settings', fakeAsync(async () => {
+  it('normalizes stored daysBack to last valid option when the saved value is no longer in settings', fakeAsync(async () => {
     // Set up a stored value that is no longer a valid option.
     // Valid Ice options in settings.ts are [0, 1, 2, 3, 7, 14] — 28 is not among them anymore.
     db = {
@@ -107,8 +107,8 @@ describe('UserSettingService', () => {
 
     const daysBack = await firstValueFrom(service.daysBackForCurrentGeoHazard$);
 
-    // Should fall back to first valid option (0), not the stored invalid value (28)
-    expect(daysBack).toBe(0);
+    // Should fall back to last valid option (14), not the stored invalid value (28)
+    expect(daysBack).toBe(14);
   }));
 
   it('does not change stored daysBack when the value is still a valid option', fakeAsync(async () => {

--- a/src/app/core/services/user-setting/user-setting-service.spec.ts
+++ b/src/app/core/services/user-setting/user-setting-service.spec.ts
@@ -77,4 +77,60 @@ describe('UserSettingService', () => {
       copyright: 'Kantkorn48',
     } as unknown as UserSetting);
   }));
+
+  it('normalizes stored daysBack to first valid option when the saved value is no longer in settings', fakeAsync(async () => {
+    // Set up a stored value that is no longer a valid option.
+    // Valid Ice options in settings.ts are [0, 1, 2, 3, 7, 14] — 28 is not among them anymore.
+    db = {
+      currentGeoHazard: [GeoHazard.Ice],
+      observationDaysBack: [
+        { geoHazard: GeoHazard.Ice, daysBack: 28 }, // no longer valid
+        { geoHazard: GeoHazard.Snow, daysBack: 7 }, // still valid, must not change
+      ],
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideTranslateService(),
+        provideTestLogger(),
+        { provide: UserSettingService, useClass: UserSettingServiceWithoutExternalDeps },
+      ],
+    });
+
+    const service = TestBed.inject(UserSettingService);
+    service.init();
+
+    tick(1500); // wait for simulated 1s DB read + debounce
+
+    const daysBack = await firstValueFrom(service.daysBackForCurrentGeoHazard$);
+
+    // Should fall back to first valid option (0), not the stored invalid value (28)
+    expect(daysBack).toBe(0);
+  }));
+
+  it('does not change stored daysBack when the value is still a valid option', fakeAsync(async () => {
+    db = {
+      currentGeoHazard: [GeoHazard.Snow],
+      observationDaysBack: [
+        { geoHazard: GeoHazard.Snow, daysBack: 7 }, // valid option
+      ],
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideTranslateService(),
+        provideTestLogger(),
+        { provide: UserSettingService, useClass: UserSettingServiceWithoutExternalDeps },
+      ],
+    });
+
+    const service = TestBed.inject(UserSettingService);
+    service.init();
+
+    tick(1500);
+
+    const daysBack = await firstValueFrom(service.daysBackForCurrentGeoHazard$);
+
+    expect(daysBack).toBe(7);
+  }));
 });

--- a/src/app/core/services/user-setting/user-setting-service.spec.ts
+++ b/src/app/core/services/user-setting/user-setting-service.spec.ts
@@ -8,9 +8,12 @@ import { provideTestLogger } from 'src/app/modules/shared/services/logging/test-
 import { Injectable } from '@angular/core';
 
 describe('UserSettingService', () => {
-  let db: Partial<UserSetting> = {
-    photographer: 'Hestejente3000',
-  };
+  let db: Partial<UserSetting>;
+
+  beforeEach(() => {
+    db = { photographer: 'Hestejente3000' };
+    saveSpy.calls.reset();
+  });
 
   const saveSpy = jasmine.createSpy('saveUserSettingsToDb').and.callFake((us) => {
     db = { ...us };

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -471,12 +471,12 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
       if (!validOptions || validOptions.includes(daysBack)) {
         return { geoHazard, daysBack };
       }
-      this.loggingService?.debug('Stored daysBack not in valid options, using first option', DEBUG_TAG, {
+      this.loggingService?.debug('Stored daysBack not in valid options, using last option', DEBUG_TAG, {
         geoHazard,
         stored: daysBack,
         validOptions,
       });
-      return { geoHazard, daysBack: validOptions[0] };
+      return { geoHazard, daysBack: validOptions.at(-1) || 0 };
     });
     return { ...userSettings, observationDaysBack: normalizedDaysBack };
   }

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -457,8 +457,28 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
           };
         }
         return userSettings;
-      })
+      }),
+      map((userSettings) => this.normalizeUserSettings(userSettings))
     );
+  }
+
+  private normalizeUserSettings(userSettings: UserSetting): UserSetting {
+    if (!userSettings.observationDaysBack) {
+      return userSettings;
+    }
+    const normalizedDaysBack = userSettings.observationDaysBack.map(({ geoHazard, daysBack }) => {
+      const validOptions: number[] = settings.observations.daysBack[GeoHazard[geoHazard]];
+      if (!validOptions || validOptions.includes(daysBack)) {
+        return { geoHazard, daysBack };
+      }
+      this.loggingService?.debug('Stored daysBack not in valid options, using first option', DEBUG_TAG, {
+        geoHazard,
+        stored: daysBack,
+        validOptions,
+      });
+      return { geoHazard, daysBack: validOptions[0] };
+    });
+    return { ...userSettings, observationDaysBack: normalizedDaysBack };
   }
 
   protected getUserSettingsFromDb(): Observable<UserSetting> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -52,7 +52,7 @@ export const settings: ISettings = {
     maxObservationsToFetch: 5000,
     daysBack: {
       Snow: [0, 1, 2, 3, 7, 7 * 2],
-      Ice: [0, 1, 2, 7, 7 * 4, 7 * 12],
+      Ice: [0, 1, 2, 3, 7, 7 * 2],
       Water: [0, 1, 2, 3, 7, 7 * 2],
       Soil: [0, 1, 2, 3, 7, 7 * 2],
     },


### PR DESCRIPTION
Link til saken: https://nveprojects.atlassian.net/browse/RO-3198

Tenkte denne var fin å få med i appen.
Det var jo lett å endre innstillingene, men litt mer jobb å håndtere dette smidig, så vi ikke viser 4 eller 12 uker om det var det brukeren brukte sist.

Vi kunne jo fortsatt hatt 4 og 12 uker som hurtigvalg på web, men det hadde blitt mer komplisert. Jeg tror isvarslerne var fornøyd med å ha det likt i app og på web. Jeg la også til 3 dager, slik at hurtigvalgene er helt like for alle naturfarer.

