### PR TITLE
Bruk appversjon for å invalidere kdv cache

### DIFF
--- a/src/app/modules/common-registration/models/offline-sync-meta.interface.ts
+++ b/src/app/modules/common-registration/models/offline-sync-meta.interface.ts
@@ -1,5 +1,6 @@
 export interface OfflineSyncMeta<T> {
   id: string;
   lastUpdated: number;
+  appVersion?: string;
   data: T;
 }

--- a/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
+++ b/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
-import { Observable, combineLatest, from, of, BehaviorSubject } from 'rxjs';
+import { Observable, combineLatest, from, of, BehaviorSubject, Subject } from 'rxjs';
 import { AppMode, LangKey } from 'src/app/modules/common-core/models';
-import { map, switchMap, shareReplay, catchError, concatMap, take, timeout, finalize } from 'rxjs/operators';
+import { map, switchMap, shareReplay, catchError, concatMap, take, timeout, finalize, startWith } from 'rxjs/operators';
 import { OfflineSyncMeta } from '../../models/offline-sync-meta.interface';
 import moment from 'moment';
 import { LoggingService } from 'src/app/modules/shared/services/logging/logging.service';
@@ -24,6 +24,7 @@ export abstract class ApiSyncOfflineBaseService<T> {
 
   public readonly data$: Observable<T>;
   private isUpdatingSubject = new BehaviorSubject<boolean>(false);
+  private refreshSubject = new Subject<void>();
 
   get isUpdating$(): Observable<boolean> {
     return this.isUpdatingSubject.asObservable();
@@ -51,9 +52,12 @@ export abstract class ApiSyncOfflineBaseService<T> {
   public update(): Observable<boolean> {
     this.isUpdatingSubject.next(true);
     return combineLatest([this.userSettingService.language$, this.userSettingService.appMode$]).pipe(
-      switchMap(([langKey, appMode]) => this.getUpdatedDataAndSaveResultIfSuccess(appMode, langKey)),
+      switchMap(([langKey, appMode]) => this.getUpdatedDataWithoutTimeout(appMode, langKey)),
       take(1),
-      map(() => true),
+      map(() => {
+        this.refreshSubject.next();
+        return true;
+      }),
       catchError((err) => {
         this.logger.log('Update failed', err, LogLevel.Warning, this.getDebugTag());
         return of(false);
@@ -87,7 +91,11 @@ export abstract class ApiSyncOfflineBaseService<T> {
    * Get data observable
    */
   private getDataObservable(): Observable<T> {
-    return combineLatest([this.userSettingService.language$, this.userSettingService.appMode$]).pipe(
+    return combineLatest([
+      this.userSettingService.language$,
+      this.userSettingService.appMode$,
+      this.refreshSubject.pipe(startWith(undefined)),
+    ]).pipe(
       switchMap(([langKey, appMode]) => {
         try {
           return from(this.getOfflineDataAndReturnIfDataIsUpToDate(appMode, langKey)).pipe(
@@ -151,11 +159,28 @@ export abstract class ApiSyncOfflineBaseService<T> {
   }
 
   /**
-   * Get updated data and save result to offline storage if successful
+   * Get updated data and save result to offline storage if successful (with timeout for automatic fetches)
    */
   private getUpdatedDataAndSaveResultIfSuccess(appMode: AppMode, langKey: LangKey) {
     return this.getUpdatedData(appMode, langKey).pipe(
       timeout(this.FETCH_NEW_DATA_TIMEOUT),
+      switchMap((data) =>
+        from(this.saveDataToOfflineDb(appMode, langKey, data)).pipe(
+          catchError((err) => {
+            this.logger.error(err, this.getDebugTag(), 'Could not save data to offline storage');
+            return of(data);
+          }),
+          map(() => data)
+        )
+      )
+    );
+  }
+
+  /**
+   * Get updated data and save result to offline storage if successful (no timeout, for manual updates)
+   */
+  private getUpdatedDataWithoutTimeout(appMode: AppMode, langKey: LangKey) {
+    return this.getUpdatedData(appMode, langKey).pipe(
       switchMap((data) =>
         from(this.saveDataToOfflineDb(appMode, langKey, data)).pipe(
           catchError((err) => {

--- a/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
+++ b/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
@@ -9,7 +9,7 @@ import { LogLevel } from 'src/app/modules/shared/services/logging/log-level.mode
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { getCacheAge } from '../cache-age';
 import { DatabaseService } from 'src/app/core/services/database/database.service';
-import * as version from 'src/environments/version.json';
+import version from 'src/environments/version.json';
 
 export interface ApiSyncOfflineBaseServiceOptions {
   useLangKeyAsDbKey: boolean;

--- a/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
+++ b/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
@@ -68,7 +68,7 @@ export abstract class ApiSyncOfflineBaseService<T> {
   }
 
   /**
-   * Check if data is to old to use (cache time has expired)
+   * Check if data is to old to use
    * @param metaData cached offline data
    */
   protected isValid(metaData: OfflineSyncMeta<T>): boolean {

--- a/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
+++ b/src/app/modules/common-registration/services/api-sync-offline-base/api-sync-offline-base.service.ts
@@ -9,6 +9,7 @@ import { LogLevel } from 'src/app/modules/shared/services/logging/log-level.mode
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { getCacheAge } from '../cache-age';
 import { DatabaseService } from 'src/app/core/services/database/database.service';
+import * as version from 'src/environments/version.json';
 
 export interface ApiSyncOfflineBaseServiceOptions {
   useLangKeyAsDbKey: boolean;
@@ -71,7 +72,8 @@ export abstract class ApiSyncOfflineBaseService<T> {
    * @param metaData cached offline data
    */
   protected isValid(metaData: OfflineSyncMeta<T>): boolean {
-    const valid = metaData && metaData.lastUpdated > this.getInvalidTime().unix();
+    const valid =
+      metaData && metaData.appVersion === version.version && metaData.lastUpdated > this.getInvalidTime().unix();
     this.logger.debug(
       `Offline data is ${valid ? 'valid -> returning offline data' : 'not valid -> Fetch new data'}`,
       this.getDebugTag(),
@@ -204,6 +206,7 @@ export abstract class ApiSyncOfflineBaseService<T> {
     const meta: OfflineSyncMeta<T> = {
       id: this.getOfflineStorageDbKey(langKey),
       lastUpdated: moment().unix(),
+      appVersion: version.version,
       data,
     };
     const key = this.getOfflineDatabaseKey(appMode, langKey);
@@ -249,9 +252,9 @@ export abstract class ApiSyncOfflineBaseService<T> {
   private getOfflineDataOrFallbackToAssets(appMode: AppMode, langKey: LangKey): Observable<T> {
     return from(this.getOfflineData(appMode, langKey)).pipe(
       concatMap((offlineDataWithMetaData) => {
-        if (!offlineDataWithMetaData) {
+        if (!offlineDataWithMetaData || !this.isValid(offlineDataWithMetaData)) {
           this.logger.log(
-            'No data found in offline storage. Get fallback data',
+            'No valid data found in offline storage. Get fallback data',
             null,
             LogLevel.Warning,
             this.getDebugTag()

--- a/src/app/modules/common-registration/services/kdv/kdv.service.spec.ts
+++ b/src/app/modules/common-registration/services/kdv/kdv.service.spec.ts
@@ -121,6 +121,10 @@ describe('KdvService cache invalidation on app version change', () => {
     httpTesting = TestBed.inject(HttpTestingController);
   });
 
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
   it('henter data fra API når cachet data har gammel appVersion', fakeAsync(() => {
     databaseSpy.get.and.returnValue(Promise.resolve(oldCachedData));
     kdvElementsSpy.KdvElementsGetKdvs.and.returnValue(of(freshApiData));

--- a/src/app/modules/common-registration/services/kdv/kdv.service.spec.ts
+++ b/src/app/modules/common-registration/services/kdv/kdv.service.spec.ts
@@ -1,12 +1,16 @@
 import { TestBed, fakeAsync, flushMicrotasks, tick } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { NEVER, of } from 'rxjs';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { NEVER, Observable, of } from 'rxjs';
 import { KdvService } from './kdv.service';
 import { KdvElementsService } from 'src/app/modules/common-regobs-api/services';
 import { DatabaseService } from 'src/app/core/services/database/database.service';
 import { UserSettingService } from 'src/app/core/services/user-setting/user-setting.service';
 import { AppMode, LangKey } from 'src/app/modules/common-core/models';
 import { provideTestLogger } from 'src/app/modules/shared/services/logging/test-logging.service';
+import { OfflineSyncMeta } from '../../models/offline-sync-meta.interface';
+import { KdvElementsResponseDto } from 'src/app/modules/common-regobs-api/models';
+import version from 'src/environments/version.json';
 
 describe('KdvService.update()', () => {
   let service: KdvService;
@@ -51,17 +55,139 @@ describe('KdvService.update()', () => {
     expect(values).toEqual([false, true, false]);
   }));
 
-  it('setter isUpdating$ tilbake til false når API-kallet timer ut', fakeAsync(() => {
-    kdvElementsSpy.KdvElementsGetKdvs.and.returnValue(NEVER);
+  it('setter isUpdating$ tilbake til false når API-kallet feiler', fakeAsync(() => {
+    kdvElementsSpy.KdvElementsGetKdvs.and.returnValue(
+      new Observable((subscriber) => subscriber.error(new Error('Network error')))
+    );
 
     const values: boolean[] = [];
     service.isUpdating$.subscribe((v) => values.push(v));
 
     let result: boolean | undefined;
     service.update().subscribe((v) => (result = v));
-    tick(2001);
+    flushMicrotasks();
 
     expect(result).toBeFalse();
     expect(values).toEqual([false, true, false]);
+  }));
+});
+
+describe('KdvService cache invalidation on app version change', () => {
+  let service: KdvService;
+  let kdvElementsSpy: jasmine.SpyObj<KdvElementsService>;
+  let databaseSpy: jasmine.SpyObj<DatabaseService>;
+  let httpTesting: HttpTestingController;
+
+  const freshApiData: KdvElementsResponseDto = {
+    KdvRepositories: { Snow_AvalancheKDV: [{ Id: 1, Name: 'Fresh from API', Description: '' }] },
+    ViewRepositories: {},
+  };
+
+  const oldCachedData: OfflineSyncMeta<KdvElementsResponseDto> = {
+    id: `${LangKey.nb}`,
+    lastUpdated: Math.floor(Date.now() / 1000) - 60, // 1 minute ago (still within cache age)
+    appVersion: '4.0.0', // different from current version
+    data: {
+      KdvRepositories: { Snow_AvalancheKDV: [{ Id: 1, Name: 'Old cached', Description: '' }] },
+      ViewRepositories: {},
+    },
+  };
+
+  const fallbackAssetData: KdvElementsResponseDto = {
+    KdvRepositories: { Snow_AvalancheKDV: [{ Id: 1, Name: 'From assets', Description: '' }] },
+    ViewRepositories: {},
+  };
+
+  beforeEach(() => {
+    kdvElementsSpy = jasmine.createSpyObj<KdvElementsService>('KdvElementsService', ['KdvElementsGetKdvs']);
+    databaseSpy = jasmine.createSpyObj<DatabaseService>('DatabaseService', ['get', 'set']);
+    databaseSpy.set.and.returnValue(Promise.resolve());
+
+    TestBed.configureTestingModule({
+      providers: [
+        KdvService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideTestLogger(),
+        { provide: KdvElementsService, useValue: kdvElementsSpy },
+        { provide: DatabaseService, useValue: databaseSpy },
+        {
+          provide: UserSettingService,
+          useValue: { language$: of(LangKey.nb), appMode$: of(AppMode.Prod) },
+        },
+      ],
+    });
+
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  it('henter data fra API når cachet data har gammel appVersion', fakeAsync(() => {
+    databaseSpy.get.and.returnValue(Promise.resolve(oldCachedData));
+    kdvElementsSpy.KdvElementsGetKdvs.and.returnValue(of(freshApiData));
+
+    service = TestBed.inject(KdvService);
+
+    let result: KdvElementsResponseDto | undefined;
+    service.data$.subscribe((v) => (result = v));
+    flushMicrotasks();
+
+    expect(kdvElementsSpy.KdvElementsGetKdvs).toHaveBeenCalled();
+    expect(result).toEqual(freshApiData);
+  }));
+
+  it('bruker fallback assets når cachet data har gammel appVersion og API feiler', fakeAsync(() => {
+    databaseSpy.get.and.returnValue(Promise.resolve(oldCachedData));
+    kdvElementsSpy.KdvElementsGetKdvs.and.returnValue(NEVER); // API will timeout
+
+    service = TestBed.inject(KdvService);
+
+    let result: KdvElementsResponseDto | undefined;
+    service.data$.subscribe((v) => (result = v));
+    flushMicrotasks();
+    tick(2001); // trigger timeout
+
+    // After timeout, falls back to offline → offline is invalid → falls back to assets
+    const req = httpTesting.expectOne('/assets/json/kdvelements.nb.json');
+    req.flush(fallbackAssetData);
+    flushMicrotasks();
+
+    expect(result).toEqual(fallbackAssetData);
+  }));
+
+  it('returnerer cachet data direkte når appVersion matcher', fakeAsync(() => {
+    const validCachedData: OfflineSyncMeta<KdvElementsResponseDto> = {
+      ...oldCachedData,
+      appVersion: version.version, // current version
+    };
+    databaseSpy.get.and.returnValue(Promise.resolve(validCachedData));
+
+    service = TestBed.inject(KdvService);
+
+    let result: KdvElementsResponseDto | undefined;
+    service.data$.subscribe((v) => (result = v));
+    flushMicrotasks();
+
+    expect(kdvElementsSpy.KdvElementsGetKdvs).not.toHaveBeenCalled();
+    expect(result).toEqual(validCachedData.data);
+  }));
+
+  it('henter fra API når cachet data mangler appVersion (eldre cache-format)', fakeAsync(() => {
+    const legacyCachedData: OfflineSyncMeta<KdvElementsResponseDto> = {
+      id: `${LangKey.nb}`,
+      lastUpdated: Math.floor(Date.now() / 1000) - 60,
+      // no appVersion field
+      data: oldCachedData.data,
+    };
+    databaseSpy.get.and.returnValue(Promise.resolve(legacyCachedData));
+    kdvElementsSpy.KdvElementsGetKdvs.and.returnValue(of(freshApiData));
+
+    service = TestBed.inject(KdvService);
+
+    let result: KdvElementsResponseDto | undefined;
+    service.data$.subscribe((v) => (result = v));
+    flushMicrotasks();
+
+    expect(kdvElementsSpy.KdvElementsGetKdvs).toHaveBeenCalled();
+    expect(result).toEqual(freshApiData);
   }));
 });


### PR DESCRIPTION
Forbedre invalideringslogikken i kdv-servicen ved å bruke appversjon for å sjekke om cachen er gyldig eller ikke.
Når appversjon er oppdatert vil appen nå alltid prøve å hente nye kdv-er, fra apiet eller assets.

Legger også til en egen metode for manuell oppdatering av kdv-er, som ikke har timeout på 2000ms.