### PR TITLE
RO-3205: Fjernet hardkodet høyde og fast posisjon for numerisk tastatur

### DIFF
--- a/src/app/modules/registration/components/numeric-input/numeric-input.component.ts
+++ b/src/app/modules/registration/components/numeric-input/numeric-input.component.ts
@@ -58,7 +58,6 @@ export class NumericInputComponent {
       this.isOpen = true;
       const modal = await this.modalController.create({
         component: NumericInputModalPage,
-        cssClass: 'numeric-input-modal',
         componentProps: {
           value: convert('from', this.convertRatio(), this.value()),
           decimalPlaces: this.decimalPlaces(),

--- a/src/global.scss
+++ b/src/global.scss
@@ -521,13 +521,6 @@ ion-toolbar {
   min-height: 55px;
 }
 
-// /* https://ionicframework.com/docs/intro/upgrading-to-ionic-6#modal */
-ion-modal.numeric-input-modal::part(content) {
-  --height: 470px;
-  position: fixed;
-  bottom: 0;
-}
-
 .leaflet-bottom {
   bottom: var(--leaflet-bottom, 0) !important;
   z-index: 800 !important;


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/RO-3205
Har prøvd mye forskjellig for å flytte talltastaturet over navigasjonsraden nederst, uten å finne en god løsning.
Derfor har jeg fjernet hardkodet høyde og fast posisjon for numerisk tastatur, slik at vi er sikre på at det får plass nok.
Da vil talltastaturet dekke hele skjermen på mobil.
