### PR TITLE
VAR-695: Fiks av feil som gjør at vi ikke kan filtrere på naturfare vha. URL

### DIFF
--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -19,6 +19,7 @@ import { CRITERIA_SLUSH_FLOW } from './slush-flow';
 import { QueryParamsService } from '../query-params/query-params.service';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { GeoHazard, LangKey } from 'src/app/modules/common-core/models';
+import { isGeoHazardValid } from './url-params';
 
 export type SearchCriteriaOrderBy = keyof Pick<RegistrationViewModel, 'DtObsTime' | 'DtChangeTime'>;
 
@@ -51,10 +52,31 @@ export class SearchCriteriaService {
   private daysBackUserSettings = toSignal(this.userSettingService.daysBackForCurrentGeoHazard$, { initialValue: 2 });
   daysBack = linkedSignal(() => this.daysBackUserSettings());
   private langKey = toSignal(this.userSettingService.language$, { initialValue: LangKey.nb });
-  private geoHazards = toSignal(
-    // Vis alltid vær-observasjoner sammen med andre naturfarer
-    this.userSettingService.currentGeoHazard$.pipe(map((geohazards) => [...geohazards, GeoHazard.Weather]))
-  ); // TODO: Move to usersettings
+
+  // Konverter observable til signal (uten map-logikk)
+  private geoHazardsFromSettings = toSignal(this.userSettingService.currentGeoHazard$);
+
+  // Gjeldende naturfare. Bruker evt. filter satt i URL første gang, deretter leses valgt naturfare fra innstillinger
+  // Viser alltid vær-observasjoner sammen med andre naturfarer
+  // TODO: Move to usersettings
+  private geoHazards = linkedSignal<GeoHazard[] | undefined, GeoHazard[] | undefined>({
+    source: this.geoHazardsFromSettings,
+    computation: (fromSettings, previous) => {
+      // Observable har ikke sendt noe ennå
+      if (fromSettings === undefined) {
+        return previous?.value;
+      }
+      // Første reelle emisjon: URL-parameter vinner om den er gyldig
+      if (previous?.value === undefined) {
+        const fromUrl = this.queryParams.startup.geoHazard();
+        if (fromUrl && isGeoHazardValid(fromUrl)) {
+          return [...fromUrl, GeoHazard.Weather];
+        }
+      }
+      // Etterfølgende emisjoner (bruker bytter naturfare): bruk innstillinger
+      return [...fromSettings, GeoHazard.Weather];
+    },
+  });
 
   /**
    * Om dager tilbake, eller fra og til-dato skal ligge til grunn for

--- a/src/app/core/services/search-criteria/search-criteria.service.ts
+++ b/src/app/core/services/search-criteria/search-criteria.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, computed, effect, inject, linkedSignal, signal, untracked } from '@angular/core';
 import L from 'leaflet';
 import moment from 'moment';
-import { debounceTime, map } from 'rxjs';
+import { debounceTime } from 'rxjs';
 import {
   PositionDto,
   RegistrationTypeCriteriaDto,
@@ -19,7 +19,6 @@ import { CRITERIA_SLUSH_FLOW } from './slush-flow';
 import { QueryParamsService } from '../query-params/query-params.service';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { GeoHazard, LangKey } from 'src/app/modules/common-core/models';
-import { isGeoHazardValid } from './url-params';
 
 export type SearchCriteriaOrderBy = keyof Pick<RegistrationViewModel, 'DtObsTime' | 'DtChangeTime'>;
 
@@ -69,7 +68,7 @@ export class SearchCriteriaService {
       // Første reelle emisjon: URL-parameter vinner om den er gyldig
       if (previous?.value === undefined) {
         const fromUrl = this.queryParams.startup.geoHazard();
-        if (fromUrl && isGeoHazardValid(fromUrl)) {
+        if (fromUrl) {
           return [...fromUrl, GeoHazard.Weather];
         }
       }

--- a/src/app/core/services/search-criteria/url-params.ts
+++ b/src/app/core/services/search-criteria/url-params.ts
@@ -378,6 +378,10 @@ export const readParamsFromDoc = (doc: Document) => {
   };
 
   return {
+    geoHazard: () => {
+      const value = readValue(URL_PARAM_GEOHAZARD);
+      return value ? separatedStringToNumberArray(value) : undefined;
+    },
     nick: () => readValue(URL_PARAM_NICKNAME),
     fromTime: () => readDate(URL_PARAM_FROMDATE),
     toTime: () => readDate(URL_PARAM_TODATE, 'end'),

--- a/src/app/core/services/search-criteria/url-params.ts
+++ b/src/app/core/services/search-criteria/url-params.ts
@@ -5,6 +5,7 @@ import {
   WithinExtentCriteriaDto,
 } from 'src/app/modules/common-regobs-api';
 import { isSlushFlow } from './slush-flow';
+import { GeoHazard } from 'src/app/modules/common-core/models';
 
 export const URL_PARAM_NW_LAT = 'nwLat';
 export const URL_PARAM_NW_LON = 'nwLon';
@@ -300,7 +301,11 @@ function setDateParams(params: UrlParams, criteria: SearchCriteriaRequestDto, da
 
 export function toUrlParams(criteria: SearchCriteriaRequestDto, daysBack?: number): UrlParams {
   const params = new UrlParams();
-  params.set(URL_PARAM_GEOHAZARD, arrayToSeparatedString(criteria.SelectedGeoHazards));
+
+  // På grunn av hacket med at vær automatisk legges til i geoHazards uansett, må vi fjerne vær fra urlen, så det ikke blir dobbelt opp
+  const geoHazardsFilter = criteria.SelectedGeoHazards?.filter((h) => h !== GeoHazard.Weather);
+  params.set(URL_PARAM_GEOHAZARD, arrayToSeparatedString(geoHazardsFilter));
+
   params.set(URL_PARAM_NICKNAME, criteria.ObserverNickName);
   params.set(URL_PARAM_COMPETENCE, competenceFromDtoToUrl(criteria.ObserverCompetence));
   params.set(URL_PARAM_REGISTRATION_TYPE, convertRegTypeDtoToUrl(criteria.SelectedRegistrationTypes));

--- a/src/app/core/services/user-setting/user-setting.service.ts
+++ b/src/app/core/services/user-setting/user-setting.service.ts
@@ -223,9 +223,7 @@ export class UserSettingService extends NgDestoryBase implements OnReset {
         // NB: Hvis vi legger til filter for å skjule observasjoner fra naturfare vær, kanskje vi må revurdere/fjerne
         // dette filteret.
         .filter((x) => x !== GeoHazard.Weather);
-      if (isGeoHazardValid(geoHazards)) {
-        return geoHazards;
-      }
+      return geoHazards;
     }
     return null;
   }


### PR DESCRIPTION
Se saken: https://nveprojects.atlassian.net/browse/VAR-695
Denne feilen gjør at vi ikke får se riktige observasjoner når vi trykker på linken "Vis observasjoner i Regobs siste 3 døgn" i varsom.no. PR på linken i varsom.no er her:
https://dev.azure.com/NVE-devops/NVE-WEB/_git/nve-web-frontend/pullrequest/21345

Nå lar vi url'en bestemme filter på naturfare om dette er angitt i url.
Hvis det ikke er filter på naturfare i url, brukes valgt naturfare fra innstillingene.
NB! Hvis vi ønsker å se alle naturfarer, må vi spesifisere hver enkelt naturfare i URL.

Her er en url som viser både jord-, snø- og værobservasjoner:
https://victorious-water-056410803-1013.westeurope.azurestaticapps.net/search/list?hazard=10~20~60~70~120&competence=100~0~110~115~120~130~150&orderBy=changeTime&fromDate=2026-05-23&toDate=2026-05-24&nwLat=61.6077&nwLon=7.1658&seLat=61.1989&seLon=8.3249

Jeg har latt være å sjekke om vi har "gyldig" filter på naturfare. Denne godtok bare det vi kan angi i naturfare-velgeren, men når vi kommer fra varsom.no, vil vi kanskje se alle naturfarer samtidig.
